### PR TITLE
Fixes `shouldInitialize` receiving user as argument

### DIFF
--- a/packages/react/modules/components/flags-subscription.js
+++ b/packages/react/modules/components/flags-subscription.js
@@ -49,11 +49,13 @@ export default class FlagsSubscription extends React.Component {
 
   componentDidMount() {
     this.handleDefaultFlags(this.props.defaultFlags);
-    if (this.props.shouldInitialize()) this.initializeFlagListening();
+    if (this.props.shouldInitialize(this.props.user))
+      this.initializeFlagListening();
   }
 
-  componentWillReceiveProps() {
-    if (this.props.shouldInitialize()) this.initializeFlagListening();
+  componentWillReceiveProps(nextProps) {
+    if (this.props.shouldInitialize(nextProps.user))
+      this.initializeFlagListening();
   }
 
   render() {

--- a/packages/react/modules/components/flags-subscription.spec.js
+++ b/packages/react/modules/components/flags-subscription.spec.js
@@ -15,7 +15,7 @@ jest.mock('@flopflip/launchdarkly-wrapper', () => ({
 
 const ChildComponet = () => <div />;
 const createTestProps = props => ({
-  shouldInitialize: () => true,
+  shouldInitialize: jest.fn(() => true),
   clientSideId: 'foo-clientSideId',
   user: {
     key: 'foo-user-key',
@@ -220,7 +220,15 @@ describe('lifecycle', () => {
       describe('when not initialized', () => {
         beforeEach(() => {
           wrapper.setState({ isInitialized: false });
-          wrapper.instance().componentWillReceiveProps();
+          wrapper.instance().componentWillReceiveProps(props);
+        });
+
+        it('should invoke `shouldInitialize`', () => {
+          expect(props.shouldInitialize).toHaveBeenCalled();
+        });
+
+        it('should invoke `shouldInitialize` with `user`', () => {
+          expect(props.shouldInitialize).toHaveBeenCalledWith(props.user);
         });
 
         it('should invoke `listen` on `launchdarkly-wrapper`', () => {
@@ -231,7 +239,7 @@ describe('lifecycle', () => {
       describe('when already initialized', () => {
         beforeEach(() => {
           wrapper.setState({ isInitialized: true });
-          wrapper.instance().componentWillReceiveProps();
+          wrapper.instance().componentWillReceiveProps(props);
         });
 
         it('should not invoke `listen` on `launchdarkly-wrapper` again', () => {
@@ -243,7 +251,7 @@ describe('lifecycle', () => {
 
     describe('when `shouldInitialize` returns `false`', () => {
       beforeEach(() => {
-        props = createTestProps({ shouldInitialize: () => false });
+        props = createTestProps({ shouldInitialize: jest.fn(() => false) });
         wrapper = shallow(
           <FlagSubscription {...props}>
             <ChildComponet />
@@ -251,7 +259,15 @@ describe('lifecycle', () => {
         );
 
         wrapper.setState({ isInitialized: false });
-        wrapper.instance().componentWillReceiveProps();
+        wrapper.instance().componentWillReceiveProps(props);
+      });
+
+      it('should invoke `shouldInitialize`', () => {
+        expect(props.shouldInitialize).toHaveBeenCalled();
+      });
+
+      it('should invoke `shouldInitialize` with `user`', () => {
+        expect(props.shouldInitialize).toHaveBeenCalledWith(props.user);
       });
 
       it('should not invoke `listen` on `launchdarkly-wrapper`', () => {

--- a/readme.md
+++ b/readme.md
@@ -137,7 +137,7 @@ It takes the `props`:
 
 - The `clientSideId` is your LaunchDarkly ID.
 - The `user` object needs at least a `key` attribute. An anonymous `key` will be generated using a `uuid` when nothing is specified. The user object can contain additional data.
-- The `shouldInitialize` function can be used to defer the flag subscription setup towards LaunchDarkly (via their SDK). This might be helpful for cases in which you want to wait for the `key` to be present within your root component and you do not want `flopflip` to generate a `uuid` for you automatically. This callback is invoked everytime `ConfigureFlopFlip` receives new props
+- The `shouldInitialize` function can be used to defer the flag subscription setup towards LaunchDarkly (via their SDK). This might be helpful for cases in which you want to wait for the `key` to be present within your root component and you do not want `flopflip` to generate a `uuid` for you automatically. This callback is invoked every time `ConfigureFlopFlip` receives new props with the `user` prop given to `ConfigureFlopFlip`
 - The `defaultFlags` prop object can be used to specify default flag values until LaunchDarkly responds or in case flags were removed from their platform (flag keys will be camel cased as with response from LaunchDarkly's API so e.g. `{ 'a-flag': true }` becomes `{ aFlag: true }`)
 
 ```js


### PR DESCRIPTION
This helps `shouldInitialize` to remain pure and to not get mixed up in the order of lifecycle methods.