### PR TITLE
Remove clientSideId being a required prop

### DIFF
--- a/packages/react-broadcast/modules/components/configure.js
+++ b/packages/react-broadcast/modules/components/configure.js
@@ -10,7 +10,7 @@ export default class Configure extends React.Component {
 
   static propTypes = {
     children: PropTypes.node,
-    clientSideId: PropTypes.string.isRequired,
+    clientSideId: PropTypes.string,
     shouldInitialize: PropTypes.bool,
     shouldChangeUserContext: PropTypes.bool,
     defaultFlags: PropTypes.object,
@@ -21,6 +21,7 @@ export default class Configure extends React.Component {
 
   static defaultProps = {
     children: null,
+    clientSideId: null,
     user: {},
     defaultFlags: {},
     shouldInitialize: true,

--- a/packages/react-redux/modules/components/configure.js
+++ b/packages/react-redux/modules/components/configure.js
@@ -8,7 +8,7 @@ export class Configure extends React.Component {
   static displayName = 'ConfigureFlopflip';
   static propTypes = {
     children: PropTypes.node,
-    clientSideId: PropTypes.string.isRequired,
+    clientSideId: PropTypes.string,
     user: PropTypes.shape({
       key: PropTypes.string,
     }),
@@ -24,6 +24,7 @@ export class Configure extends React.Component {
   static defaultProps = {
     children: null,
     user: {},
+    clientSideId: null,
     defaultFlags: {},
     shouldInitialize: true,
     shouldChangeUserContext: false,

--- a/packages/react/modules/components/flags-subscription.js
+++ b/packages/react/modules/components/flags-subscription.js
@@ -11,7 +11,7 @@ export default class FlagsSubscription extends React.Component {
   static propTypes = {
     shouldInitialize: PropTypes.bool.isRequired,
     shouldChangeUserContext: PropTypes.bool.isRequired,
-    clientSideId: PropTypes.string.isRequired,
+    clientSideId: PropTypes.string,
     user: PropTypes.shape({
       key: PropTypes.string,
     }),
@@ -25,6 +25,7 @@ export default class FlagsSubscription extends React.Component {
 
   static defaultProps = {
     children: null,
+    clientSideId: null,
     user: {},
     defaultFlags: {},
   };


### PR DESCRIPTION
> This removes the `clientSideId` being a required prop.

This `clientSideId` generally has to be defined when setting up the `ld-wrapper`. However, the library allows deferring this. In cases where an application does not yet know the users `key` for instance - due to loading - we wait until `shouldInitialize` is `true` to then set up things. The same might hold for the `clientSideId`. 