### PR TITLE
FeatureToggled to accept node or function for togged/untoggled

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postinstall": "check-node-version --package && npm run build",
     "lint": "eslint --format 'node_modules/eslint-formatter-pretty' packages",
-    "format": "format:md format:js",
+    "format": "npm run format:md && npm run format:js",
     "format:md": "pmd *.md",
     "format:js": "prettier --write '**/modules/**/*.js' '**/demo/**/*.js'",
     "test": "cross-env NODE_ENV=test jest",

--- a/packages/react/modules/components/__snapshots__/feature-toggled.spec.js.snap
+++ b/packages/react/modules/components/__snapshots__/feature-toggled.spec.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`with feature disabled with untoggled component should match snapshot 1`] = `
-<div>
-  UntoggledComponent
-</div>
-`;
+exports[`when feature disabled with untoggled component should match snapshot 1`] = `<UntoggledComponent />`;
 
-exports[`with feature disabled without untoggled component should match snapshot 1`] = `<FeatureComponent />`;
+exports[`when feature disabled without untoggled component should match snapshot 1`] = `""`;
+
+exports[`when feature enabled with \`children\` should match snapshot 1`] = `<FeatureComponent />`;
+
+exports[`when feature enabled with \`toggledComponent\` should match snapshot 1`] = `<FeatureComponent />`;

--- a/packages/react/modules/components/__snapshots__/feature-toggled.spec.js.snap
+++ b/packages/react/modules/components/__snapshots__/feature-toggled.spec.js.snap
@@ -6,4 +6,10 @@ exports[`when feature disabled without untoggled component should match snapshot
 
 exports[`when feature enabled with \`children\` should match snapshot 1`] = `<FeatureComponent />`;
 
+exports[`when feature enabled with \`render\` should match snapshot 1`] = `
+<div>
+  FeatureComponent
+</div>
+`;
+
 exports[`when feature enabled with \`toggledComponent\` should match snapshot 1`] = `<FeatureComponent />`;

--- a/packages/react/modules/components/feature-toggled.js
+++ b/packages/react/modules/components/feature-toggled.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+const isEmptyChildren = children => React.Children.count(children) === 0;
+
 export default class FeatureToggled extends React.PureComponent {
   static propTypes = {
-    untoggledComponent: PropTypes.element,
-    children: PropTypes.element.isRequired,
+    untoggledComponent: PropTypes.node,
+    toggledComponent: PropTypes.node,
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 
     // HoC
     isFeatureEnabled: PropTypes.bool.isRequired,
@@ -12,13 +15,24 @@ export default class FeatureToggled extends React.PureComponent {
 
   static defaultProps = {
     untoggledComponent: null,
+    toggledComponent: null,
+    children: null,
   };
 
   render() {
     if (this.props.isFeatureEnabled) {
-      return this.props.children;
+      if (!isEmptyChildren(this.props.toggledComponent))
+        return React.cloneElement(this.props.toggledComponent);
+
+      if (typeof this.props.children === 'function')
+        return this.props.children();
+
+      if (this.props.children && !isEmptyChildren(this.props.children))
+        return React.Children.only(this.props.children);
+    } else if (!isEmptyChildren(this.props.untoggledComponent)) {
+      return React.cloneElement(this.props.untoggledComponent);
     }
 
-    return this.props.untoggledComponent;
+    return null;
   }
 }

--- a/packages/react/modules/components/feature-toggled.js
+++ b/packages/react/modules/components/feature-toggled.js
@@ -5,8 +5,10 @@ const isEmptyChildren = children => React.Children.count(children) === 0;
 
 export default class FeatureToggled extends React.PureComponent {
   static propTypes = {
-    untoggledComponent: PropTypes.node,
-    toggledComponent: PropTypes.node,
+    untoggledComponent: PropTypes.func,
+    toggledComponent: PropTypes.func,
+
+    render: PropTypes.func,
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 
     // HoC
@@ -16,21 +18,29 @@ export default class FeatureToggled extends React.PureComponent {
   static defaultProps = {
     untoggledComponent: null,
     toggledComponent: null,
+    render: null,
     children: null,
   };
 
   render() {
     if (this.props.isFeatureEnabled) {
-      if (!isEmptyChildren(this.props.toggledComponent))
-        return React.cloneElement(this.props.toggledComponent);
-
       if (typeof this.props.children === 'function')
         return this.props.children();
 
+      if (this.props.toggledComponent)
+        return React.createElement(this.props.toggledComponent);
+
       if (this.props.children && !isEmptyChildren(this.props.children))
         return React.Children.only(this.props.children);
-    } else if (!isEmptyChildren(this.props.untoggledComponent)) {
-      return React.cloneElement(this.props.untoggledComponent);
+    }
+
+    if (typeof this.props.render === 'function')
+      return this.props.render({
+        isFeatureEnabled: this.props.isFeatureEnabled,
+      });
+
+    if (this.props.untoggledComponent) {
+      return React.createElement(this.props.untoggledComponent);
     }
 
     return null;

--- a/packages/react/modules/components/feature-toggled.spec.js
+++ b/packages/react/modules/components/feature-toggled.spec.js
@@ -2,10 +2,12 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import FeatureToggled from './feature-toggled';
 
-const UntoggledComponent = <div>{'UntoggledComponent'}</div>;
-const FeatureComponent = () => <div>{'FeatureComponent'}</div>;
+const UntoggledComponent = () => <div />;
+UntoggledComponent.displayName = 'UntoggledComponent';
+const FeatureComponent = () => <div />;
+FeatureComponent.displayName = 'FeatureComponent';
 
-describe('with feature disabled', () => {
+describe('when feature disabled', () => {
   describe('with untoggled component', () => {
     let wrapper;
 
@@ -13,7 +15,7 @@ describe('with feature disabled', () => {
       wrapper = shallow(
         <FeatureToggled
           isFeatureEnabled={false}
-          untoggledComponent={UntoggledComponent}
+          untoggledComponent={<UntoggledComponent />}
         >
           <FeatureComponent />
         </FeatureToggled>
@@ -25,11 +27,11 @@ describe('with feature disabled', () => {
     });
 
     it('should render the `UntoggledComponent`', () => {
-      expect(wrapper).toHaveText('UntoggledComponent');
+      expect(wrapper).toRender(UntoggledComponent);
     });
 
     it('should not render the `FeatureComponent`', () => {
-      expect(wrapper).not.toRender('FeatureComponent');
+      expect(wrapper).not.toRender(FeatureComponent);
     });
   });
 
@@ -38,9 +40,31 @@ describe('with feature disabled', () => {
 
     beforeEach(() => {
       wrapper = shallow(
+        <FeatureToggled isFeatureEnabled={false}>
+          <FeatureComponent />
+        </FeatureToggled>
+      );
+    });
+
+    it('should match snapshot', () => {
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should not render the `FeatureComponent`', () => {
+      expect(wrapper).not.toRender(FeatureComponent);
+    });
+  });
+});
+
+describe('when feature enabled', () => {
+  let wrapper;
+
+  describe('with `children`', () => {
+    beforeEach(() => {
+      wrapper = shallow(
         <FeatureToggled
           isFeatureEnabled
-          untoggledComponent={UntoggledComponent}
+          untoggledComponent={<UntoggledComponent />}
         >
           <FeatureComponent />
         </FeatureToggled>
@@ -51,12 +75,36 @@ describe('with feature disabled', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render the `UntoggledComponent`', () => {
-      expect(wrapper).not.toRender('UntoggledComponent');
+    it('should not render the `UntoggledComponent`', () => {
+      expect(wrapper).not.toRender(UntoggledComponent);
     });
 
     it('should render the `FeatureComponent`', () => {
-      expect(wrapper).toRender('FeatureComponent');
+      expect(wrapper).toRender(FeatureComponent);
+    });
+  });
+
+  describe('with `toggledComponent`', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <FeatureToggled
+          isFeatureEnabled
+          untoggledComponent={<UntoggledComponent />}
+          toggledComponent={<FeatureComponent />}
+        />
+      );
+    });
+
+    it('should match snapshot', () => {
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should not render the `UntoggledComponent`', () => {
+      expect(wrapper).not.toRender(UntoggledComponent);
+    });
+
+    it('should render the `FeatureComponent`', () => {
+      expect(wrapper).toRender(FeatureComponent);
     });
   });
 });

--- a/packages/react/modules/components/feature-toggled.spec.js
+++ b/packages/react/modules/components/feature-toggled.spec.js
@@ -2,9 +2,11 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import FeatureToggled from './feature-toggled';
 
-const UntoggledComponent = () => <div />;
+const UntoggledComponent = () => <div>{'UntoggledComponent'}</div>;
 UntoggledComponent.displayName = 'UntoggledComponent';
-const FeatureComponent = () => <div />;
+const ToggledComponent = () => <div>{'ToggledComponent'}</div>;
+ToggledComponent.displayName = 'ToggledComponent';
+const FeatureComponent = () => <div>{'FeatureComponent'}</div>;
 FeatureComponent.displayName = 'FeatureComponent';
 
 describe('when feature disabled', () => {
@@ -15,7 +17,7 @@ describe('when feature disabled', () => {
       wrapper = shallow(
         <FeatureToggled
           isFeatureEnabled={false}
-          untoggledComponent={<UntoggledComponent />}
+          untoggledComponent={UntoggledComponent}
         >
           <FeatureComponent />
         </FeatureToggled>
@@ -64,7 +66,7 @@ describe('when feature enabled', () => {
       wrapper = shallow(
         <FeatureToggled
           isFeatureEnabled
-          untoggledComponent={<UntoggledComponent />}
+          untoggledComponent={UntoggledComponent}
         >
           <FeatureComponent />
         </FeatureToggled>
@@ -89,8 +91,8 @@ describe('when feature enabled', () => {
       wrapper = shallow(
         <FeatureToggled
           isFeatureEnabled
-          untoggledComponent={<UntoggledComponent />}
-          toggledComponent={<FeatureComponent />}
+          untoggledComponent={UntoggledComponent}
+          toggledComponent={FeatureComponent}
         />
       );
     });
@@ -105,6 +107,33 @@ describe('when feature enabled', () => {
 
     it('should render the `FeatureComponent`', () => {
       expect(wrapper).toRender(FeatureComponent);
+    });
+  });
+
+  describe('with `render`', () => {
+    let props;
+    beforeEach(() => {
+      props = {
+        isFeatureEnabled: true,
+        untoggledComponent: UntoggledComponent,
+        render: jest.fn(() => <div>{'FeatureComponent'}</div>),
+      };
+
+      wrapper = shallow(<FeatureToggled {...props} />);
+    });
+
+    it('should match snapshot', () => {
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should invoke `render`', () => {
+      expect(props.render).toHaveBeenCalled();
+    });
+
+    it('should invoke `render` with `isFeatureEnabled`', () => {
+      expect(props.render).toHaveBeenCalledWith({
+        isFeatureEnabled: props.isFeatureEnabled,
+      });
     });
   });
 });

--- a/readme.md
+++ b/readme.md
@@ -176,10 +176,11 @@ import { FeatureToggled } from '@flopflip/react-redux';
 // or import { FeatureToggled } from '@flopflip/react-broadcast';
 import flagsNames from './feature-flags';
 
+const UntoggledComponent = () => <h3>{'At least there is a fallback!'}</h3>;
 export default (
   <FeatureToggled
     flag={flagsNames.THE_FEATURE_TOGGLE}
-    untoggledComponent={<h3>At least there is a fallback!</h3>}
+    untoggledComponent={UntoggledComponent}
   >
     <h3>I might be gone or there!</h3>
   </FeatureToggled>
@@ -189,11 +190,13 @@ export default (
 or with for multivariate feature toggles
 
 ```js
+const UntoggledComponent = () => <h3>{'At least there is a fallback!'}</h3>;
+
 export default (
   <FeatureToggled
     flag={flagsNames.THE_FEATURE_TOGGLE.NAME}
     variate={flagsNames.THE_FEATURE_TOGGLE.VARIATES.A}
-    untoggledComponent={<h3>At least there is a fallback!</h3>}
+    untoggledComponent={UntoggledComponent}
   >
     <h3>I might be gone or there!</h3>
   </FeatureToggled>
@@ -203,12 +206,15 @@ export default (
 or with `toggledComponent` prop
 
 ```js
+const UntoggledComponent = () => <h3>{'At least there is a fallback!'}</h3>;
+const ToggledComponent = () => <h3>{'I might be gone or there!'}</h3>;
+
 export default (
   <FeatureToggled
     flag={flagsNames.THE_FEATURE_TOGGLE.NAME}
     variate={flagsNames.THE_FEATURE_TOGGLE.VARIATES.A}
-    untoggledComponent={<h3>At least there is a fallback!</h3>}
-    toggledComponent={<h3>I might be gone or there!</h3>}
+    untoggledComponent={UntoggledComponent}
+    toggledComponent={ToggledComponent}
   />
 );
 ```
@@ -216,14 +222,31 @@ export default (
 or with Function as a Child
 
 ```js
+const UntoggledComponent = () => <h3>{'At least there is a fallback!'}</h3>;
+
 export default (
   <FeatureToggled
     flag={flagsNames.THE_FEATURE_TOGGLE.NAME}
     variate={flagsNames.THE_FEATURE_TOGGLE.VARIATES.A}
-    untoggledComponent={<h3>At least there is a fallback!</h3>}
+    untoggledComponent={UntoggledComponent}
   >
     {() => <h3>I might be gone or there!</h3>}
   </FeatureToggled>
+);
+```
+
+or with a `render` prop. Note that the `render` prop will always be invoked not matter if the feature is on or off. It therefore also receives an `isFeatureEnabled` boolean argument.
+
+```js
+const UntoggledComponent = () => <h3>{'At least there is a fallback!'}</h3>;
+
+export default (
+  <FeatureToggled
+    flag={flagsNames.THE_FEATURE_TOGGLE.NAME}
+    variate={flagsNames.THE_FEATURE_TOGGLE.VARIATES.A}
+    untoggledComponent={UntoggledComponent}
+    render={({ isFeatureEnabled }) => <h3>I might be gone or there!</h3>}
+  />
 );
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -200,6 +200,33 @@ export default (
 );
 ```
 
+or with `toggledComponent` prop
+
+```js
+export default (
+  <FeatureToggled
+    flag={flagsNames.THE_FEATURE_TOGGLE.NAME}
+    variate={flagsNames.THE_FEATURE_TOGGLE.VARIATES.A}
+    untoggledComponent={<h3>At least there is a fallback!</h3>}
+    toggledComponent={<h3>I might be gone or there!</h3>}
+  />
+);
+```
+
+or with Function as a Child
+
+```js
+export default (
+  <FeatureToggled
+    flag={flagsNames.THE_FEATURE_TOGGLE.NAME}
+    variate={flagsNames.THE_FEATURE_TOGGLE.VARIATES.A}
+    untoggledComponent={<h3>At least there is a fallback!</h3>}
+  >
+    {() => <h3>I might be gone or there!</h3>}
+  </FeatureToggled>
+);
+```
+
 this last example will always turn the feature on if the variate or toggle does not exist. For this also look at `defaultFlags` for `ConfigureFlopFlip`.
 
 We actually recommend maintaining a list of constants with feature flag names somewhere within your application. This avoids typos and unexpected behavior. After all, the correct workings of your feature flags is crutial to your application.


### PR DESCRIPTION
> Refactors `FeatureToggeld` to be more relaxed on what it accepts as arguments.

Before

```jsx
<Featuretoggled flag="foo" untoggledComponent={UntoggledComponent}>
   <Yay />
</Featuretoggled>
```

After

```jsx
<Featuretoggled flag="foo" untoggledComponent={UntoggledComponent}>
   <Yay />
</Featuretoggled>
```

```jsx
<Featuretoggled flag="foo" untoggledComponent={UntoggledComponent}>
   {() => <Yay />}
</Featuretoggled>
```

```jsx
<Featuretoggled flag="foo" untoggledComponent={UntoggledComponent} toggledComponent={ToggledComponent} />
```

```jsx
<Featuretoggled flag="foo" untoggledComponent={UntoggledComponent} render={({ isFeatureEnabled }) => <div />} />
```