### PR TITLE
Add an in memory adapter

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,8 @@
     "redux-thunk": "^2.2.0",
     "@flopflip/react-redux": "^3.0.0",
     "@flopflip/react-broadcast": "^3.0.0",
-    "@flopflip/launchdarkly-adapter": "^1.0.0"
+    "@flopflip/launchdarkly-adapter": "^1.0.0",
+    "@flopflip/memory-adapter": "^1.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -3,6 +3,7 @@ import { compose } from 'recompose';
 import { Provider, connect } from 'react-redux';
 import classNames from 'classnames';
 import adapter from '@flopflip/launchdarkly-adapter';
+//import adapter, { updateFlags } from '@flopflip/memory-adapter';
 import {
   ConfigureFlopFlip,
   withFeatureToggle,
@@ -21,7 +22,7 @@ import store from './store';
 import './App.css';
 import * as flags from './flags';
 
-const UntoggledFeature = <h6>Disabled Feature</h6>;
+const UntoggledFeature = () => <h6>Disabled Feature</h6>;
 
 const IncrementAsyncButton = props => (
   <button onClick={props.incrementAsync} disabled={props.isIncrementing}>
@@ -29,10 +30,7 @@ const IncrementAsyncButton = props => (
   </button>
 );
 const FeatureToggledIncrementAsyncButton = compose(
-  withFeatureToggle(
-    { flag: flags.INCREMENT_ASYNC_BUTTON },
-    () => UntoggledFeature
-  )
+  withFeatureToggle({ flag: flags.INCREMENT_ASYNC_BUTTON }, UntoggledFeature)
 )(IncrementAsyncButton);
 
 const IncrementSyncButton = props => (
@@ -78,7 +76,7 @@ const Counter = props => (
       <br />
       <FeatureToggled
         flag={flags.DECREMENT_ASYNC_BUTTON}
-        untoggledComponent={<h6>Disabled Feature</h6>}
+        untoggledComponent={UntoggledFeature}
       >
         <button onClick={props.decrementAsync} disabled={props.isDecrementing}>
           Decrement Async
@@ -128,5 +126,7 @@ class App extends Component {
     );
   }
 }
+
+//window.updateFlags = updateFlags;
 
 export default App;

--- a/packages/launchdarkly-adapter/modules/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter.spec.js
@@ -1,10 +1,5 @@
 import ldClient from 'ldclient-js';
-import adapter, {
-  camelCaseFlags,
-  createAnonymousUser,
-  subscribe,
-  injectClient,
-} from './adapter';
+import adapter, { camelCaseFlags, createAnonymousUser } from './adapter';
 
 jest.mock('nanoid', () => jest.fn(() => 'foo-random-id'));
 

--- a/packages/launchdarkly-adapter/readme.md
+++ b/packages/launchdarkly-adapter/readme.md
@@ -1,11 +1,11 @@
 <p align="center">
   <b style="font-size: 25px">🎛 flopflip - Feature Toggling 🎚</b><br />
-  <i>flip or flop a feature in LaunchDarkly with real-time updates through a Redux store or React's context.</i>
+  <i>flip or flop a feature via adapters (e.g. memory or LaunchDarkly) with real-time updates through a Redux store or React's context.</i>
 </p>
 
 <p align="center">
   <img alt="Logo" src="https://raw.githubusercontent.com/tdeekens/flopflip/master/logo.png" /><br /><br />
-  <i>Toggle features in LaunchDarkly with their state being maintained in a Redux state slice or a broadcasting system (through the context) being accessible through a set of Higher-Order Components in React.</i><br />
+  <i>Toggle features with their state being maintained in a Redux state slice or a broadcasting system (through the context) being accessible through a set of Higher-Order Components in React.</i><br />
 </p>
 
 ### `@flopflip/launchdarkly-adapter`

--- a/packages/memory-adapter/modules/adapter.js
+++ b/packages/memory-adapter/modules/adapter.js
@@ -1,0 +1,46 @@
+const adapterState = {
+  flags: {},
+  user: {},
+  eventHandlerMap: {},
+};
+
+const configure = ({ user, onFlagsStateChange, onStatusStateChange }) => {
+  adapterState.user = user;
+
+  return Promise.resolve().then(() => {
+    adapterState.isConfigured = true;
+    adapterState.isReady = true;
+
+    adapterState.eventHandlerMap['onFlagsStateChange'] = onFlagsStateChange;
+    adapterState.eventHandlerMap['onStatusStateChange'] = onStatusStateChange;
+
+    onStatusStateChange({ isReady: adapterState.isReady });
+    onFlagsStateChange(adapterState.flags);
+  });
+};
+
+const reconfigure = ({ user }) => {
+  updateUser(user);
+
+  return Promise.resolve();
+};
+
+const updateUser = user => {
+  adapterState.user = user;
+};
+
+export const updateFlags = flags => {
+  adapterState.flags = {
+    ...adapterState.flags,
+    ...flags,
+  };
+
+  adapterState.eventHandlerMap['onFlagsStateChange'](adapterState.flags);
+};
+
+export const getUser = () => adapterState.user;
+
+export default {
+  configure,
+  reconfigure,
+};

--- a/packages/memory-adapter/modules/adapter.spec.js
+++ b/packages/memory-adapter/modules/adapter.spec.js
@@ -1,0 +1,59 @@
+import ldClient from 'ldclient-js';
+import adapter, { getUser, updateFlags } from './adapter';
+
+const createAdapterArgs = (customArgs = {}) => ({
+  user: { id: 'foo' },
+  onFlagsStateChange: jest.fn(),
+  onStatusStateChange: jest.fn(),
+
+  ...customArgs,
+});
+
+describe('when configuring', () => {
+  let adapterArgs = createAdapterArgs();
+
+  beforeEach(() => adapter.configure(adapterArgs));
+
+  it('should invoke `onStatusStateChange`', () => {
+    expect(adapterArgs.onStatusStateChange).toHaveBeenCalled();
+  });
+
+  it('should invoke `onStatusStateChange` with `isReady`', () => {
+    expect(adapterArgs.onStatusStateChange).toHaveBeenCalledWith({
+      isReady: true,
+    });
+  });
+
+  it('should invoke `onFlagsStateChange`', () => {
+    expect(adapterArgs.onFlagsStateChange).toHaveBeenCalled();
+  });
+
+  describe('when reconfiguring', () => {
+    const user = { id: 'bar' };
+
+    beforeEach(() => adapter.reconfigure({ user }));
+
+    it('should update the user', () => {
+      expect(getUser()).toEqual(user);
+    });
+  });
+
+  describe('when updating flags', () => {
+    const updatedFlags = { fooFlag: true, barFlag: false };
+
+    beforeEach(() => {
+      // From `configure`
+      adapterArgs.onFlagsStateChange.mockClear();
+
+      updateFlags(updatedFlags);
+    });
+
+    it('should invoke `onFlagsStateChange`', () => {
+      expect(adapterArgs.onFlagsStateChange).toHaveBeenCalled();
+    });
+
+    it('should invoke `onFlagsStateChange` with `updatedFlags`', () => {
+      expect(adapterArgs.onFlagsStateChange).toHaveBeenCalledWith(updatedFlags);
+    });
+  });
+});

--- a/packages/memory-adapter/modules/index.js
+++ b/packages/memory-adapter/modules/index.js
@@ -1,4 +1,6 @@
 const version = VERSION;
 
 export default from './adapter';
+export { updateFlags } from './adapter';
+
 export { version };

--- a/packages/memory-adapter/modules/index.js
+++ b/packages/memory-adapter/modules/index.js
@@ -1,0 +1,4 @@
+const version = VERSION;
+
+export default from './adapter';
+export { version };

--- a/packages/memory-adapter/package.json
+++ b/packages/memory-adapter/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@flopflip/memory-adapter",
+  "version": "1.0.0",
+  "description": "An in memory adapter for flipflop",
+  "main": "dist/@flopflip-memory-adapter.cjs.js",
+  "module": "dist/@flopflip-memory-adapter.es.js",
+  "browser": "dist/@flopflip-memory-adapter.umd.js",
+  "scripts": {
+    "preversion": "npm run build",
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env npm run build:es && npm run build:cjs",
+    "build:watch": "cross-env npm run build:es -- -w",
+    "build:es": "cross-env NODE_ENV=development rollup -c -f es -o dist/@flopflip-memory-adapter.es.js",
+    "build:cjs": "cross-env NODE_ENV=development rollup -c -f cjs -o dist/@flopflip-memory-adapter.cjs.js"
+  },
+  "files": [
+    "readme.md",
+    "dist/**"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tdeekens/flopflip.git"
+  },
+  "author": "Tobias Deekens <nerd@tdeekens.name>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/tdeekens/flopflip/issues"
+  },
+  "homepage": "https://github.com/tdeekens/flopflip#readme",
+  "devDependencies": {},
+  "dependencies": {
+    "lodash.camelcase": "^4.3.0"
+  },
+  "keywords": [
+    "feature-flags",
+    "feature-toggles",
+    "memory",
+    "client"
+  ]
+}

--- a/packages/memory-adapter/readme.md
+++ b/packages/memory-adapter/readme.md
@@ -8,6 +8,6 @@
   <i>Toggle features with their state being maintained in a Redux state slice or a broadcasting system (through the context) being accessible through a set of Higher-Order Components in React.</i><br />
 </p>
 
-### `@flopflip/launchdarkly-react`
+### `@flopflip/memory-adapter`
 
 This repository is part of the `flopflip` mono repository. Please head [here](https://github.com/tdeekens/flopflip) for more information.

--- a/packages/memory-adapter/rollup.config.js
+++ b/packages/memory-adapter/rollup.config.js
@@ -1,0 +1,45 @@
+const resolve = require('rollup-plugin-node-resolve');
+const commonjs = require('rollup-plugin-commonjs');
+const babel = require('rollup-plugin-babel');
+const replace = require('rollup-plugin-replace');
+const uglify = require('rollup-plugin-uglify');
+const builtins = require('rollup-plugin-node-builtins');
+const filesize = require('rollup-plugin-filesize');
+
+const env = process.env.NODE_ENV;
+const version = process.env.npm_package_version;
+
+const config = {
+  input: 'modules/index.js',
+  name: '@flopflip-memory-adapter',
+  sourcemap: true,
+  plugins: [
+    commonjs(),
+    babel({
+      babelrc: true,
+      exclude: 'node_modules/**',
+      runtimeHelpers: true,
+    }),
+    replace({
+      'process.env.NODE_ENV': JSON.stringify(env),
+      VERSION: `'${version}'`,
+    }),
+    resolve({
+      module: true,
+    }),
+    builtins(),
+    filesize(),
+  ],
+};
+
+if (env === 'production') {
+  config.plugins.push(
+    uglify({
+      compress: {
+        warnings: false,
+      },
+    })
+  );
+}
+
+module.exports = config;

--- a/packages/react-broadcast/readme.md
+++ b/packages/react-broadcast/readme.md
@@ -1,11 +1,11 @@
 <p align="center">
   <b style="font-size: 25px">🎛 flopflip - Feature Toggling 🎚</b><br />
-  <i>flip or flop a feature in LaunchDarkly with real-time updates through a Redux store or React's context.</i>
+  <i>flip or flop a feature via adapters (e.g. memory or LaunchDarkly) with real-time updates through a Redux store or React's context.</i>
 </p>
 
 <p align="center">
   <img alt="Logo" src="https://raw.githubusercontent.com/tdeekens/flopflip/master/logo.png" /><br /><br />
-  <i>Toggle features in LaunchDarkly with their state being maintained in a Redux state slice or a broadcasting system (through the context) being accessible through a set of Higher-Order Components in React.</i><br />
+  <i>Toggle features with their state being maintained in a Redux state slice or a broadcasting system (through the context) being accessible through a set of Higher-Order Components in React.</i><br />
 </p>
 
 ### `@flopflip/react-broadcast`

--- a/packages/react-redux/readme.md
+++ b/packages/react-redux/readme.md
@@ -1,11 +1,11 @@
 <p align="center">
   <b style="font-size: 25px">🎛 flopflip - Feature Toggling 🎚</b><br />
-  <i>flip or flop a feature in LaunchDarkly with real-time updates through a Redux store or React's context.</i>
+  <i>flip or flop a feature via adapters (e.g. memory or LaunchDarkly) with real-time updates through a Redux store or React's context.</i>
 </p>
 
 <p align="center">
   <img alt="Logo" src="https://raw.githubusercontent.com/tdeekens/flopflip/master/logo.png" /><br /><br />
-  <i>Toggle features in LaunchDarkly with their state being maintained in a Redux state slice or a broadcasting system (through the context) being accessible through a set of Higher-Order Components in React.</i><br />
+  <i>Toggle features with their state being maintained in a Redux state slice or a broadcasting system (through the context) being accessible through a set of Higher-Order Components in React.</i><br />
 </p>
 
 ### `@flopflip/react-redux`

--- a/readme.md
+++ b/readme.md
@@ -35,15 +35,20 @@
 
 | Package | Version | Dependencies |
 |--------|-------|------------|
-| [`launchdarkly-wrapper`](/packages/launchdarkly-wrapper) | [![launchdarkly-wrapper Version][launchdarkly-wrapper-icon]][launchdarkly-wrapper-version] | [![launchdarkly-wrapper Dependencies Status][launchdarkly-wrapper-dependencies-icon]][launchdarkly-wrapper-dependencies] |
+| [`launchdarkly-adapter`](/packages/launchdarkly-adapter) | [![launchdarkly-adapter Version][launchdarkly-adapter-icon]][launchdarkly-adapter-version] | [![launchdarkly-adapter Dependencies Status][launchdarkly-adapter-dependencies-icon]][launchdarkly-adapter-dependencies] |
+| [`memory-adapter`](/packages/memory-adapter) | [![memory-adapter Version][memory-adapter-icon]][memory-adapter-version] | [![memory-adapter Dependencies Status][memory-adapter-dependencies-icon]][memory-adapter-dependencies] |
 | [`react`](/packages/react) | [![react Version][react-icon]][react-version] | [![react Dependencies Status][react-dependencies-icon]][react-dependencies] |
 | [`react-broadcast`](/packages/react-broadcast) | [![react-broadcast Version][react-broadcast-icon]][react-broadcast-version] | [![react-broadcast Dependencies Status][react-broadcast-dependencies-icon]][react-broadcast-dependencies] |
 | [`react-redux`](/packages/react-redux) | [![react-redux Version][react-redux-icon]][react-redux-version] | [![react-redux Dependencies Status][react-redux-dependencies-icon]][react-redux-dependencies] |
 
-[launchdarkly-wrapper-version]: https://www.npmjs.com/package/@flopflip/launchdarkly-wrapper
-[launchdarkly-wrapper-icon]: https://img.shields.io/npm/v/@flopflip/launchdarkly-wrapper.svg?style=flat-square
-[launchdarkly-wrapper-dependencies]: https://david-dm.org/tdeekens/flopflip?path=packages/launchdarkly-wrapper
-[launchdarkly-wrapper-dependencies-icon]: https://david-dm.org/tdeekens/flopflip/status.svg?style=flat-square&path=packages/launchdarkly-wrapper
+[launchdarkly-adapter-version]: https://www.npmjs.com/package/@flopflip/launchdarkly-adapter
+[launchdarkly-adapter-icon]: https://img.shields.io/npm/v/@flopflip/launchdarkly-adapter.svg?style=flat-square
+[launchdarkly-adapter-dependencies]: https://david-dm.org/tdeekens/flopflip?path=packages/launchdarkly-adapter
+[launchdarkly-adapter-dependencies-icon]: https://david-dm.org/tdeekens/flopflip/status.svg?style=flat-square&path=packages/launchdarkly-adapter
+[memory-adapter-version]: https://www.npmjs.com/package/@flopflip/memory-adapter
+[memory-adapter-icon]: https://img.shields.io/npm/v/@flopflip/memory-adapter.svg?style=flat-square
+[memory-adapter-dependencies]: https://david-dm.org/tdeekens/flopflip?path=packages/memory-adapter
+[memory-adapter-dependencies-icon]: https://david-dm.org/tdeekens/flopflip/status.svg?style=flat-square&path=packages/memory-adapter
 [react-version]: https://www.npmjs.com/package/@flopflip/react
 [react-icon]: https://img.shields.io/npm/v/@flopflip/react.svg?style=flat-square
 [react-dependencies]: https://david-dm.org/tdeekens/flopflip?path=packages/react
@@ -59,7 +64,7 @@
 
 ## Installation
 
-This is a mono repository maintained using [lerna](https://github.com/lerna/lerna). It currently contains four [packages](/packages) in a `launchdarkly-wrapper`, `react`, `react-redux` and `react-broadcast`. You should not need the `launchdarkly-wrapper` yourself but one of our bindings (react-broadcast or react-redux). Both use the `react` package to share components.
+This is a mono repository maintained using [lerna](https://github.com/lerna/lerna). It currently contains five [packages](/packages) in a `memory-adapter`, `launchdarkly-adapter`, `react`, `react-redux` and `react-broadcast`. You should not need the `launchdarkly-adapter` yourself but one of our bindings (react-broadcast or react-redux). Both use the `react` package to share components.
 
 Depending on the preferred integration (with or without redux) use:
 
@@ -113,6 +118,7 @@ Whenever you do not want to have the state of all flags persisted in redux the m
 ```js
 import { ConfigureFlopFlip } from '@flopflip/react-redux';
 import adapter from '@flopflip/launchdarkly-adapter';
+// or import adapter from '@flopflip/memory-adapter';
 
 <ConfigureFlopFlip adapter={adapter} adapterArgs={{ clientSideId, user }}>
   <App />


### PR DESCRIPTION
> This adds a simple in memory adapter for `flopflip`.

The adapter should be configured like any other adapter

```js
import adapter from '@flopflip/memory-adapter';
import { ConfigureFlopFlip } from '@flopflip/react-redux';

<ConfigureFlopflip adapter={adapter} adapterArgs={{ user }}>
  <App />
</ConfigureFlopflip>
```

Somewhere else in your app you can programmatically toggle things on/off throughout our application.

```js
import { updateFlags } from '@flopflip/memory-adapter';

updateFlags({ fooFeature: true })
```

...which will notify any listening component in `react-broadcast` or `react-redux` like `FeatureToggled` or `withFeatureToggle`.