### PR TITLE
Add splitio adapter

### DIFF
--- a/packages/splitio-adapter/modules/adapter/adapter.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.js
@@ -56,7 +56,7 @@ const ensureUser = user => ({
 const initializeClient = (authorizationKey, user) => {
   const factory = splitio({
     core: {
-      authorizationKey: authorizationKey,
+      authorizationKey,
       key: user.key,
     },
   });

--- a/packages/splitio-adapter/modules/adapter/adapter.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.js
@@ -53,7 +53,7 @@ const ensureUser = user => ({
   ...user,
 });
 
-const initializeUserContext = (clientSideId, user) => {
+const initializeClient = (clientSideId, user) => {
   const factory = splitio({
     core: {
       authorizationKey: clientSideId,
@@ -96,10 +96,7 @@ const configure = ({
   onStatusStateChange,
 }) => {
   adapterState.user = ensureUser(user);
-  const { client, manager } = initializeUserContext(
-    clientSideId,
-    adapterState.user
-  );
+  const { client, manager } = initializeClient(clientSideId, adapterState.user);
   adapterState.client = client;
   adapterState.manager = manager;
 

--- a/packages/splitio-adapter/modules/adapter/adapter.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.js
@@ -57,6 +57,7 @@ const initializeUserContext = (clientSideId, user) => {
       key: user.key,
     },
   });
+
   return {
     client: factory.client(),
     manager: factory.manager(),
@@ -121,7 +122,6 @@ const reconfigure = ({ user, onFlagsStateChange }) =>
           '@flopflip/splitio-adapter: please configure adapter before reconfiguring.'
         )
       );
-
     if (adapterState.user.key !== user.key) {
       adapterState.user = ensureUser(user);
       const names = adapterState.manager.names();

--- a/packages/splitio-adapter/modules/adapter/adapter.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.js
@@ -53,10 +53,10 @@ const ensureUser = user => ({
   ...user,
 });
 
-const initializeClient = (clientSideId, user) => {
+const initializeClient = (authorizationKey, user) => {
   const factory = splitio({
     core: {
-      authorizationKey: clientSideId,
+      authorizationKey: authorizationKey,
       key: user.key,
     },
   });
@@ -90,13 +90,16 @@ const subscribe = ({ onFlagsStateChange, onStatusStateChange }) =>
   });
 
 const configure = ({
-  clientSideId,
+  authorizationKey,
   user,
   onFlagsStateChange,
   onStatusStateChange,
 }) => {
   adapterState.user = ensureUser(user);
-  const { client, manager } = initializeClient(clientSideId, adapterState.user);
+  const { client, manager } = initializeClient(
+    authorizationKey,
+    adapterState.user
+  );
   adapterState.client = client;
   adapterState.manager = manager;
 

--- a/packages/splitio-adapter/modules/adapter/adapter.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.js
@@ -9,27 +9,30 @@ const adapterState = {
   manager: null,
 };
 
-const normalizeFlag = (flagName, flagValue) => {
-  let value;
+export const normalizeFlag = (flagName, flagValue) => {
+  let normalizeFlagValue;
   if (flagValue === null) {
-    value = false;
+    normalizeFlagValue = false;
   } else if (flagValue === 'on') {
-    value = true;
+    normalizeFlagValue = true;
   } else if (flagValue === 'off') {
-    value = false;
+    normalizeFlagValue = false;
   } else {
-    value = flagValue;
+    normalizeFlagValue = flagValue;
   }
   return {
-    name: camelCase(flagName),
-    value,
+    flagName: camelCase(flagName),
+    flagValue: normalizeFlagValue,
   };
 };
 
 export const camelCaseFlags = flags =>
   Object.entries(flags).reduce((acc, [flagName, flaValue]) => {
-    const { name, value } = normalizeFlag(flagName, flaValue);
-    acc[name] = value;
+    const {
+      flagName: normalizeFlagName,
+      flagValue: normalizeFlagValue,
+    } = normalizeFlag(flagName, flaValue);
+    acc[normalizeFlagName] = normalizeFlagValue;
     return acc;
   }, {});
 

--- a/packages/splitio-adapter/modules/adapter/adapter.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.js
@@ -1,0 +1,138 @@
+import splitio from '@splitsoftware/splitio';
+import camelCase from 'camelcase';
+
+const adapterState = {
+  isReady: false,
+  isConfigured: false,
+  user: null,
+  client: null,
+  manager: null,
+};
+
+const normalizeFlag = (flagName, flagValue) => {
+  let value;
+  if (flagValue === null) {
+    value = false;
+  } else if (flagValue === 'on') {
+    value = true;
+  } else if (flagValue === 'off') {
+    value = false;
+  } else {
+    value = flagValue;
+  }
+  return {
+    name: camelCase(flagName),
+    value,
+  };
+};
+
+export const camelCaseFlags = flags =>
+  Object.entries(flags).reduce((acc, [flagName, flaValue]) => {
+    const { name, value } = normalizeFlag(flagName, flaValue);
+    acc[name] = value;
+    return acc;
+  }, {});
+
+const subscribeToFlagsChanges = ({ names, onFlagsStateChange }) => {
+  adapterState.client.on(adapterState.client.Event.SDK_UPDATE, () => {
+    const flags = adapterState.client.getTreatments(names, adapterState.user);
+    onFlagsStateChange(camelCaseFlags(flags));
+  });
+};
+
+export const createAnonymousUserKey = () =>
+  Math.random()
+    .toString(36)
+    .substring(2);
+
+const ensureUser = user => ({
+  key: user && user.key ? user.key : createAnonymousUserKey(),
+  ...user,
+});
+
+const initializeUserContext = (clientSideId, user) => {
+  const factory = splitio({
+    core: {
+      authorizationKey: clientSideId,
+      key: user.key,
+    },
+  });
+  return {
+    client: factory.client(),
+    manager: factory.manager(),
+  };
+};
+
+const subscribe = ({ onFlagsStateChange, onStatusStateChange }) =>
+  new Promise(resolve => {
+    adapterState.client.on(adapterState.client.Event.SDK_READY, () => {
+      const names = adapterState.manager.names();
+      const flags = adapterState.client.getTreatments(names, adapterState.user);
+
+      // First update internal state
+      adapterState.isReady = true;
+      // ...to then signal that the adapter is ready
+      onStatusStateChange({ isReady: true });
+      // ...and flush initial state of flags
+      onFlagsStateChange(camelCaseFlags(flags));
+      // ...to finally subscribe to later changes.
+      subscribeToFlagsChanges({
+        names,
+        onFlagsStateChange,
+      });
+
+      return resolve();
+    });
+  });
+
+const configure = ({
+  clientSideId,
+  user,
+  onFlagsStateChange,
+  onStatusStateChange,
+}) => {
+  adapterState.user = ensureUser(user);
+  const { client, manager } = initializeUserContext(
+    clientSideId,
+    adapterState.user
+  );
+  adapterState.client = client;
+  adapterState.manager = manager;
+
+  return subscribe({
+    onFlagsStateChange,
+    onStatusStateChange,
+  }).then(() => {
+    adapterState.isConfigured = true;
+
+    return adapterState.client;
+  });
+};
+
+const reconfigure = ({ user, onFlagsStateChange }) =>
+  new Promise((resolve, reject) => {
+    if (
+      !adapterState.isReady ||
+      !adapterState.isConfigured ||
+      !adapterState.user
+    )
+      return reject(
+        new Error(
+          '@flopflip/splitio-adapter: please configure adapter before reconfiguring.'
+        )
+      );
+
+    if (adapterState.user.key !== user.key) {
+      adapterState.user = ensureUser(user);
+      const names = adapterState.manager.names();
+      const flags = adapterState.client.getTreatments(names, adapterState.user);
+      onFlagsStateChange(camelCaseFlags(flags));
+    }
+
+    return resolve();
+  });
+
+export default {
+  configure,
+  reconfigure,
+};

--- a/packages/splitio-adapter/modules/adapter/adapter.spec.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.spec.js
@@ -1,5 +1,9 @@
 import splitio from '@splitsoftware/splitio';
-import adapter, { camelCaseFlags, createAnonymousUserKey } from './adapter';
+import adapter, {
+  camelCaseFlags,
+  createAnonymousUserKey,
+  normalizeFlag,
+} from './adapter';
 
 jest.mock('@splitsoftware/splitio', () =>
   jest.fn(() => ({
@@ -233,5 +237,56 @@ describe('create anonymous user', () => {
 
   it('should create uuid of length `foo-random-id`', () => {
     expect(createAnonymousUserKey().length).toBeGreaterThan(0);
+  });
+});
+
+describe('normalizeFlag', () => {
+  const flagName = 'fooFlag';
+
+  describe('with `flagValue` being `null`', () => {
+    it('should return `false`', () => {
+      expect(normalizeFlag(flagName, null)).toEqual({
+        flagName,
+        flagValue: false,
+      });
+    });
+  });
+
+  describe('with `flagValue` being `on`', () => {
+    it('should return `true`', () => {
+      expect(normalizeFlag(flagName, 'on')).toEqual({
+        flagName,
+        flagValue: true,
+      });
+    });
+  });
+
+  describe('with `flagValue` being `off`', () => {
+    it('should return `false`', () => {
+      expect(normalizeFlag(flagName, 'off')).toEqual({
+        flagName,
+        flagValue: false,
+      });
+    });
+  });
+
+  describe('with anoy other `flagValue`', () => {
+    describe('with a `String`', () => {
+      it('should the `String`', () => {
+        expect(normalizeFlag(flagName, 'Yeehaaw')).toEqual({
+          flagName,
+          flagValue: 'Yeehaaw',
+        });
+      });
+    });
+
+    describe('with a `Number`', () => {
+      it('should the `Number`', () => {
+        expect(normalizeFlag(flagName, 42)).toEqual({
+          flagName,
+          flagValue: 42,
+        });
+      });
+    });
   });
 });

--- a/packages/splitio-adapter/modules/adapter/adapter.spec.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.spec.js
@@ -1,0 +1,237 @@
+import splitio from '@splitsoftware/splitio';
+import adapter, { camelCaseFlags, createAnonymousUserKey } from './adapter';
+
+const clientSideId = '123-abc';
+const userWithKey = { key: 'foo-user' };
+const userWithoutKey = {
+  group: 'foo-group',
+};
+const names = ['some-flag-1', 'some-flag-2'];
+const flags = { 'some-flag-1': true, 'some-flag-2': false };
+
+jest.mock('@splitsoftware/splitio', () => {
+  /*const mockSplitio = {
+    client: jest.fn(),
+    manager: jest.fn(),
+  }
+  mockSplitio.client.mockImplementation(() => ({
+    on: jest.fn((_, cb) => cb()),
+    getTreatments: jest.fn(() => ({})),
+    Event: {
+      SDK_READY: 'SDK_READY',
+      SDK_UPDATE: 'SDK_UPDATE',
+    },
+  }))
+  mockSplitio.manager.mockImplementation(() => ({
+    names: jest.fn(() => []),
+  }))
+  return jest.fn(() => mockSplitio)*/
+  return jest.fn(() => ({
+    client: jest.fn(() => ({
+      on: jest.fn((_, cb) => cb()),
+      getTreatments: jest.fn(() => ({})),
+      Event: {
+        SDK_READY: 'SDK_READY',
+        SDK_UPDATE: 'SDK_UPDATE',
+      },
+    })),
+    manager: jest.fn(() => ({
+      names: jest.fn(() => []),
+    })),
+  }));
+});
+
+describe('when configuring', () => {
+  let onStatusStateChange;
+  let onFlagsStateChange;
+
+  beforeEach(() => {
+    onStatusStateChange = jest.fn();
+    onFlagsStateChange = jest.fn();
+  });
+
+  describe('with user key', () => {
+    beforeEach(() => {
+      return adapter.configure({
+        clientSideId,
+        user: userWithKey,
+        onStatusStateChange,
+        onFlagsStateChange,
+      });
+    });
+
+    it('should initialize the `splitio` client with `clientSideId` and given `user`', () => {
+      expect(splitio).toHaveBeenCalledWith({
+        core: {
+          authorizationKey: clientSideId,
+          key: userWithKey.key,
+        },
+      });
+    });
+  });
+
+  describe('without key', () => {
+    beforeEach(() =>
+      adapter.configure({
+        clientSideId,
+        user: userWithoutKey,
+        onStatusStateChange,
+        onFlagsStateChange,
+      })
+    );
+
+    it('should initialize the `splitio` with `clientSideId` and random `user` `key`', () => {
+      expect(splitio).toHaveBeenCalledWith({
+        core: {
+          authorizationKey: clientSideId,
+          key: expect.any(String),
+        },
+      });
+    });
+  });
+
+  describe('when reconfiguring before configured', () => {
+    it('should reject reconfiguration', () => {
+      return expect(adapter.reconfigure({ user: userWithKey })).rejects.toEqual(
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('when ready', () => {
+    let factory;
+    let onStatusStateChange;
+    let onFlagsStateChange;
+
+    beforeEach(() => {
+      onStatusStateChange = jest.fn();
+      onFlagsStateChange = jest.fn();
+      factory = {
+        client: jest.fn(() => ({
+          on: jest.fn((_, cb) => cb()),
+          getTreatments: jest.fn(() => flags),
+          Event: {
+            SDK_READY: 'SDK_READY',
+            SDK_UPDATE: 'SDK_UPDATE',
+          },
+        })),
+        manager: jest.fn(() => ({
+          names: jest.fn(() => names),
+        })),
+      };
+
+      splitio.mockReturnValue(factory);
+
+      return adapter.configure({
+        clientSideId,
+        user: userWithKey,
+        onStatusStateChange,
+        onFlagsStateChange,
+      });
+    });
+
+    describe('when `splitio` is ready', () => {
+      it('should `dispatch` `onUpdateStatus` action with `isReady`', () => {
+        expect(onStatusStateChange).toHaveBeenCalledWith({
+          isReady: true,
+        });
+      });
+
+      it('should `dispatch` `onStatusStateChange`', () => {
+        expect(onFlagsStateChange).toHaveBeenCalledWith({
+          someFlag1: true,
+          someFlag2: false,
+        });
+      });
+
+      it('should register callbacks to receive flag updates', () => {
+        expect(factory.client().on).toHaveBeenCalledWith(
+          factory.client().Event.SDK_UPDATE,
+          expect.any(Function)
+        );
+      });
+    });
+
+    describe('when reconfiguring', () => {
+      const nextUser = { key: 'bar-user' };
+      let factory;
+
+      beforeEach(() => {
+        onStatusStateChange = jest.fn();
+        onFlagsStateChange = jest.fn();
+        factory = {
+          client: jest.fn(() => ({
+            on: jest.fn((_, cb) => cb()),
+            getTreatments: jest.fn(() => flags),
+            Event: {
+              SDK_READY: 'SDK_READY',
+              SDK_UPDATE: 'SDK_UPDATE',
+            },
+          })),
+          manager: jest.fn(() => ({
+            names: jest.fn(() => names),
+          })),
+        };
+
+        splitio.mockReturnValue(factory);
+
+        return adapter
+          .configure({
+            clientSideId,
+            user: userWithKey,
+            onStatusStateChange,
+            onFlagsStateChange,
+          })
+          .then(() =>
+            adapter.reconfigure({
+              user: nextUser,
+              onStatusStateChange,
+              onFlagsStateChange,
+            })
+          );
+      });
+
+      it('should invoke `getTreatments` on the `client` with the new `user`', () => {
+        expect(factory.manager().names).toHaveBeenCalled();
+        expect(factory.client().getTreatments).toHaveBeenCalledWith(
+          names,
+          nextUser
+        );
+      });
+    });
+  });
+});
+
+describe('camelCasedFlags', () => {
+  describe('with dashes', () => {
+    const rawFlags = {
+      'a-flag': true,
+      'flag-b-c': false,
+    };
+
+    it('should camel case to uppercased flag names', () => {
+      expect(camelCaseFlags(rawFlags)).toEqual({ aFlag: true, flagBC: false });
+    });
+  });
+
+  describe('with spaces', () => {
+    const rawFlags = {
+      'a flag': true,
+      'flag b-c': false,
+    };
+
+    it('should camel case to uppercased flag names', () => {
+      expect(camelCaseFlags(rawFlags)).toEqual({ aFlag: true, flagBC: false });
+    });
+  });
+});
+
+describe('create anonymous user', () => {
+  it('should create user with uuid in key property', () => {
+    expect(createAnonymousUserKey()).toBeDefined();
+  });
+
+  it('should create uuid of length `foo-random-id`', () => {
+    expect(createAnonymousUserKey().length).toBeGreaterThan(0);
+  });
+});

--- a/packages/splitio-adapter/modules/adapter/adapter.spec.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.spec.js
@@ -21,7 +21,7 @@ jest.mock('@splitsoftware/splitio', () =>
   }))
 );
 
-const clientSideId = '123-abc';
+const authorizationKey = '123-abc';
 const userWithKey = { key: 'foo-user' };
 const userWithoutKey = {
   group: 'foo-group',
@@ -41,17 +41,17 @@ describe('when configuring', () => {
   describe('with user key', () => {
     beforeEach(() => {
       return adapter.configure({
-        clientSideId,
+        authorizationKey,
         user: userWithKey,
         onStatusStateChange,
         onFlagsStateChange,
       });
     });
 
-    it('should initialize the `splitio` client with `clientSideId` and given `user`', () => {
+    it('should initialize the `splitio` client with `authorizationKey` and given `user`', () => {
       expect(splitio).toHaveBeenCalledWith({
         core: {
-          authorizationKey: clientSideId,
+          authorizationKey: authorizationKey,
           key: userWithKey.key,
         },
       });
@@ -61,17 +61,17 @@ describe('when configuring', () => {
   describe('without key', () => {
     beforeEach(() =>
       adapter.configure({
-        clientSideId,
+        authorizationKey,
         user: userWithoutKey,
         onStatusStateChange,
         onFlagsStateChange,
       })
     );
 
-    it('should initialize the `splitio` with `clientSideId` and random `user` `key`', () => {
+    it('should initialize the `splitio` with `authorizationKey` and random `user` `key`', () => {
       expect(splitio).toHaveBeenCalledWith({
         core: {
-          authorizationKey: clientSideId,
+          authorizationKey: authorizationKey,
           key: expect.any(String),
         },
       });
@@ -114,7 +114,7 @@ describe('when configuring', () => {
       splitio.mockReturnValue(factory);
 
       return adapter.configure({
-        clientSideId,
+        authorizationKey,
         user: userWithKey,
         onStatusStateChange,
         onFlagsStateChange,
@@ -173,7 +173,7 @@ describe('when configuring', () => {
 
         return adapter
           .configure({
-            clientSideId,
+            authorizationKey,
             user: userWithKey,
             onStatusStateChange,
             onFlagsStateChange,

--- a/packages/splitio-adapter/modules/adapter/adapter.spec.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.spec.js
@@ -51,7 +51,7 @@ describe('when configuring', () => {
     it('should initialize the `splitio` client with `authorizationKey` and given `user`', () => {
       expect(splitio).toHaveBeenCalledWith({
         core: {
-          authorizationKey: authorizationKey,
+          authorizationKey,
           key: userWithKey.key,
         },
       });
@@ -71,7 +71,7 @@ describe('when configuring', () => {
     it('should initialize the `splitio` with `authorizationKey` and random `user` `key`', () => {
       expect(splitio).toHaveBeenCalledWith({
         core: {
-          authorizationKey: authorizationKey,
+          authorizationKey,
           key: expect.any(String),
         },
       });

--- a/packages/splitio-adapter/modules/adapter/index.js
+++ b/packages/splitio-adapter/modules/adapter/index.js
@@ -1,0 +1,1 @@
+export default from './adapter';

--- a/packages/splitio-adapter/modules/index.js
+++ b/packages/splitio-adapter/modules/index.js
@@ -1,0 +1,4 @@
+const version = VERSION;
+
+export default from './adapter';
+export { version };

--- a/packages/splitio-adapter/package.json
+++ b/packages/splitio-adapter/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@flopflip/splitio-adapter",
+  "version": "1.0.0",
+  "description": "A adapter around the split.io client for flipflop",
+  "main": "dist/@flopflip-splitio-adapter.cjs.js",
+  "module": "dist/@flopflip-splitio-adapter.es.js",
+  "scripts": {
+    "preversion": "npm run build",
+    "prebuild": "rimraf dist/**",
+    "build": "cross-env npm run build:es && npm run build:cjs",
+    "build:watch": "cross-env npm run build:es -- -w",
+    "build:es": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js -f es -i modules/index.js -o dist/@flopflip-splitio-adapter.es.js",
+    "build:cjs": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js -f cjs -i modules/index.js -o dist/@flopflip-splitio-adapter.cjs.js"
+  },
+  "files": [
+    "readme.md",
+    "dist/**"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tdeekens/flopflip.git"
+  },
+  "author": "Tobias Deekens <nerd@tdeekens.name>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/tdeekens/flopflip/issues"
+  },
+  "homepage": "https://github.com/tdeekens/flopflip#readme",
+  "devDependencies": {
+    "enzyme": "^3.2.0",
+    "enzyme-to-json": "^3.2.2"
+  },
+  "dependencies": {
+    "@splitsoftware/splitio": "^9.3.6",
+    "camelcase": "^4.1.0"
+  },
+  "keywords": [
+    "feature-flags",
+    "feature-toggles",
+    "split.io",
+    "client"
+  ]
+}

--- a/packages/splitio-adapter/readme.md
+++ b/packages/splitio-adapter/readme.md
@@ -1,0 +1,13 @@
+<p align="center">
+  <b style="font-size: 25px">🎛 flopflip - Feature Toggling 🎚</b><br />
+  <i>flip or flop a feature via adapters (e.g. memory or LaunchDarkly) with real-time updates through a Redux store or React's context.</i>
+</p>
+
+<p align="center">
+  <img alt="Logo" src="https://raw.githubusercontent.com/tdeekens/flopflip/master/logo.png" /><br /><br />
+  <i>Toggle features with their state being maintained in a Redux state slice or a broadcasting system (through the context) being accessible through a set of Higher-Order Components in React.</i><br />
+</p>
+
+### `@flopflip/splitio-adapter`
+
+This repository is part of the `flopflip` mono repository. Please head [here](https://github.com/tdeekens/flopflip) for more information.

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@
 
 | Package                                                  | Version                                                                                    | Dependencies                                                                                                             |
 | -------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| [`splitio-adapter`](/packages/splitio-adapter)           | [![splitio-adapter Version][splitio-adapter-icon]][splitio-adapter-version]                | [![splitio-adapter Dependencies Status][splitio-adapter-dependencies-icon]][splitio-adapter-dependencies]                |
 | [`launchdarkly-adapter`](/packages/launchdarkly-adapter) | [![launchdarkly-adapter Version][launchdarkly-adapter-icon]][launchdarkly-adapter-version] | [![launchdarkly-adapter Dependencies Status][launchdarkly-adapter-dependencies-icon]][launchdarkly-adapter-dependencies] |
 | [`memory-adapter`](/packages/memory-adapter)             | [![memory-adapter Version][memory-adapter-icon]][memory-adapter-version]                   | [![memory-adapter Dependencies Status][memory-adapter-dependencies-icon]][memory-adapter-dependencies]                   |
 | [`localstorage-adapter`](/packages/localstorage-adapter) | [![localstorage-adapter Version][localstorage-adapter-icon]][localstorage-adapter-version] | [![localstorage-adapter Dependencies Status][localstorage-adapter-dependencies-icon]][localstorage-adapter-dependencies] |
@@ -42,6 +43,7 @@
 | [`react-broadcast`](/packages/react-broadcast)           | [![react-broadcast Version][react-broadcast-icon]][react-broadcast-version]                | [![react-broadcast Dependencies Status][react-broadcast-dependencies-icon]][react-broadcast-dependencies]                |
 | [`react-redux`](/packages/react-redux)                   | [![react-redux Version][react-redux-icon]][react-redux-version]                            | [![react-redux Dependencies Status][react-redux-dependencies-icon]][react-redux-dependencies]                            |
 
+[splitio-adapter-version]: https://www.npmjs.com/package/@flopflip/splitio-adapter
 [launchdarkly-adapter-version]: https://www.npmjs.com/package/@flopflip/launchdarkly-adapter
 [launchdarkly-adapter-icon]: https://img.shields.io/npm/v/@flopflip/launchdarkly-adapter.svg?style=flat-square
 [launchdarkly-adapter-dependencies]: https://david-dm.org/tdeekens/flopflip?path=packages/launchdarkly-adapter

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,9 +61,28 @@
     common-tags "1.4.0"
     react-display-name "0.2.0"
 
+"@splitsoftware/splitio@^9.3.6":
+  version "9.3.6"
+  resolved "https://registry.yarnpkg.com/@splitsoftware/splitio/-/splitio-9.3.6.tgz#098aa3040ad510f889c62dea9808d323c4faeb17"
+  dependencies:
+    "@types/node" "^8.0.26"
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    ip "^1.1.4"
+    isomorphic-fetch "^2.2.1"
+    lodash "^4.17.3"
+    logplease NicoZelaya/logplease#1.3.0
+    utfx "^1.0.1"
+  optionalDependencies:
+    ioredis "^2.4.3"
+
 "@types/node@*":
   version "6.0.92"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.92.tgz#e7f721ae282772e12ba2579968c00d9cce422c5d"
+
+"@types/node@^8.0.26":
+  version "8.0.53"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
 
 Base64@1.0.0:
   version "1.0.0"
@@ -1081,6 +1100,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@^3.3.4:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -1390,6 +1413,10 @@ clone@^1.0.2:
 clone@~0.1.9:
   version "0.1.19"
   resolved "https://registry.yarnpkg.com/clone/-/clone-0.1.19.tgz#613fb68639b26a494ac53253e15b1a6bd88ada85"
+
+cluster-key-slot@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.0.8.tgz#7654556085a65330932a2e8b5976f8e2d0b3e414"
 
 cmd-shim@^2.0.2:
   version "2.0.2"
@@ -1941,6 +1968,10 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
+double-ended-queue@^2.1.0-0:
+  version "2.1.0-0"
+  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -2389,6 +2420,10 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
+
+flexbuffer@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/flexbuffer/-/flexbuffer-0.0.6.tgz#039fdf23f8823e440c38f3277e6fef1174215b30"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -2879,6 +2914,23 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
+ioredis@^2.4.3:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-2.5.0.tgz#fb6fdf0a1a7e0974614c67b6e5e11308a8cf95b9"
+  dependencies:
+    bluebird "^3.3.4"
+    cluster-key-slot "^1.0.6"
+    debug "^2.2.0"
+    double-ended-queue "^2.1.0-0"
+    flexbuffer "0.0.6"
+    lodash "^4.8.2"
+    redis-commands "^1.2.0"
+    redis-parser "^1.3.0"
+
+ip@^1.1.4:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
+
 irregular-plurals@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.4.0.tgz#2ca9b033651111855412f16be5d77c62a458a766"
@@ -3099,7 +3151,7 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:
@@ -3789,7 +3841,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3798,6 +3850,10 @@ log-symbols@^2.0.0:
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.1.0.tgz#f35fa60e278832b538dc4dddcbb478a45d3e3be6"
   dependencies:
     chalk "^2.0.1"
+
+"logplease@github:nicozelaya/logplease#1.3.0":
+  version "1.3.0"
+  resolved "https://codeload.github.com/nicozelaya/logplease/tar.gz/b4ca204f892080a2011fe3b3f3b2b1c8c72bb29c"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -4652,6 +4708,14 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
+redis-commands@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.3.1.tgz#81d826f45fa9c8b2011f4cd7a0fe597d241d442b"
+
+redis-parser@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-1.3.0.tgz#806ebe7bbfb7d34e4d7c1e9ef282efcfad04126a"
+
 redux@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
@@ -5462,6 +5526,10 @@ url-parse-lax@^1.0.0:
 urlgrey@0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
+
+utfx@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utfx/-/utfx-1.0.1.tgz#d52b2fd632a99eca8d9d4a39eece014a6a2b0048"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This add the adapter for the split.io service (https://www.split.io/).

I adapted it from the LaunchDarkly adapter with few differences:
* There is no boolean flags so I converted `on` and `off` to boolean and let others pass through
* 2 calls have to be made to get first, the flags, then, the values
* There is no concept of `user` because split.io uses segments, but you can pass a map of attributes in the `getTreatment[s]` calls so I adapted this concept with the notion of `user` the flipflop's API has
* The listener doesn't returns changed flags. It only indicates a change. So flags must be refetched.

Finally, the split.io SDK returns a `factory` where you can get either the `.client()` or the `.manager()`. I had trouble to test this because I'm pretty new to Jest so I let 2 tests failed (and one implementation commented out). If you can help me cover this, it would be very appreciated!
Otherwise, removing the tests would work too :D
