### PR TITLE
Fix version export in splitio-adapter

### DIFF
--- a/packages/launchdarkly-adapter/modules/index.js
+++ b/packages/launchdarkly-adapter/modules/index.js
@@ -1,5 +1,3 @@
-const version = VERSION;
-
 export default from './adapter';
 
 export { version } from '../package.json';

--- a/packages/localstorage-adapter/modules/index.js
+++ b/packages/localstorage-adapter/modules/index.js
@@ -1,5 +1,3 @@
-const version = VERSION;
-
 export default from './adapter';
 export { updateFlags, STORAGE_SLICE } from './adapter';
 

--- a/packages/memory-adapter/modules/index.js
+++ b/packages/memory-adapter/modules/index.js
@@ -1,5 +1,3 @@
-const version = VERSION;
-
 export default from './adapter';
 export { updateFlags } from './adapter';
 

--- a/packages/react-broadcast/modules/index.js
+++ b/packages/react-broadcast/modules/index.js
@@ -1,5 +1,3 @@
-const version = VERSION;
-
 export {
   FeatureToggled,
   injectFeatureToggle,

--- a/packages/react-redux/modules/index.js
+++ b/packages/react-redux/modules/index.js
@@ -1,5 +1,3 @@
-const version = VERSION;
-
 export {
   createFlopFlipEnhancer,
   STATE_SLICE as FLOPFLIP_STATE_SLICE,

--- a/packages/react/modules/index.js
+++ b/packages/react/modules/index.js
@@ -1,5 +1,3 @@
-const version = VERSION;
-
 export {
   injectFeatureToggle,
   injectFeatureToggles,

--- a/packages/splitio-adapter/modules/index.js
+++ b/packages/splitio-adapter/modules/index.js
@@ -1,4 +1,3 @@
-const version = VERSION;
-
 export default from './adapter';
-export { version };
+
+export { version } from '../package.json';


### PR DESCRIPTION
🚨 The currently published version of the `splitio-adapter` is broken because it doesn't export the version from `package.json` and the `VERSION` replacement got removed some commits ago.

I also cleaned the remainings `const version = VERSION;` useless now.