### PR TITLE
Replace camelcase module by Lodash camelcase

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.js
@@ -1,5 +1,5 @@
 import { initialize } from 'ldclient-js';
-import camelCase from 'lodash.camelcase';
+import camelCase from 'just-camel-case';
 
 const adapterState = {
   isReady: false,

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.js
@@ -1,5 +1,5 @@
 import { initialize } from 'ldclient-js';
-import camelCase from 'camelcase';
+import camelCase from 'lodash.camelcase';
 
 const adapterState = {
   isReady: false,

--- a/packages/launchdarkly-adapter/package.json
+++ b/packages/launchdarkly-adapter/package.json
@@ -34,8 +34,8 @@
     "enzyme-to-json": "^3.2.2"
   },
   "dependencies": {
-    "camelcase": "^4.1.0",
-    "ldclient-js": "^1.1.12"
+    "ldclient-js": "^1.1.12",
+    "lodash.camelcase": "^4.3.0"
   },
   "keywords": [
     "feature-flags",

--- a/packages/launchdarkly-adapter/package.json
+++ b/packages/launchdarkly-adapter/package.json
@@ -34,8 +34,8 @@
     "enzyme-to-json": "^3.2.2"
   },
   "dependencies": {
-    "ldclient-js": "^1.1.12",
-    "lodash.camelcase": "^4.3.0"
+    "just-camel-case": "^2.0.0",
+    "ldclient-js": "^1.1.12"
   },
   "keywords": [
     "feature-flags",

--- a/packages/splitio-adapter/modules/adapter/adapter.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.js
@@ -1,5 +1,5 @@
 import splitio from '@splitsoftware/splitio';
-import camelCase from 'lodash.camelcase';
+import camelCase from 'just-camel-case';
 
 const adapterState = {
   isReady: false,

--- a/packages/splitio-adapter/modules/adapter/adapter.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.js
@@ -1,5 +1,5 @@
 import splitio from '@splitsoftware/splitio';
-import camelCase from 'camelcase';
+import camelCase from 'lodash.camelcase';
 
 const adapterState = {
   isReady: false,

--- a/packages/splitio-adapter/package.json
+++ b/packages/splitio-adapter/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@splitsoftware/splitio": "^9.3.6",
-    "camelcase": "^4.1.0"
+    "lodash.camelcase": "^4.3.0"
   },
   "keywords": [
     "feature-flags",

--- a/packages/splitio-adapter/package.json
+++ b/packages/splitio-adapter/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@splitsoftware/splitio": "^9.3.6",
-    "lodash.camelcase": "^4.3.0"
+    "just-camel-case": "^2.0.0"
   },
   "keywords": [
     "feature-flags",


### PR DESCRIPTION
We just had the same build problem you had when bundling all the dependencies. The problem is that Sindre Sorhus doesn't love the browser and target node. So he doesn't compile his modules.

We need to use this for the web and we use create-react-app. CRA doesn't compile the `node_modules` (https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify).

Hence, I switched to `lodash.camelcase` which behaves exactly the same. I let you revert the special rollup config you did if you want to.