### PR TITLE
Add `selectFeatureFlags` and `selectFeatureFlag` selectors

### DIFF
--- a/packages/react-broadcast/modules/components/feature-toggled/feature-toggled.js
+++ b/packages/react-broadcast/modules/components/feature-toggled/feature-toggled.js
@@ -1,12 +1,12 @@
 import { compose, withProps } from 'recompose';
-import { FeatureToggled, isFeatureEnabled, ALL_FLAGS } from '@flopflip/react';
+import { FeatureToggled, isFeatureEnabled, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
 import withFlagSubscription from '../with-flag-subscription/';
 
 export default compose(
-  withFlagSubscription(ALL_FLAGS),
+  withFlagSubscription(ALL_FLAGS_PROP_KEY),
   withProps(props => ({
     isFeatureEnabled: isFeatureEnabled(props.flag, props.variate)(
-      props[ALL_FLAGS]
+      props[ALL_FLAGS_PROP_KEY]
     ),
   }))
 )(FeatureToggled);

--- a/packages/react-broadcast/modules/components/feature-toggled/feature-toggled.js
+++ b/packages/react-broadcast/modules/components/feature-toggled/feature-toggled.js
@@ -1,5 +1,9 @@
 import { compose, withProps } from 'recompose';
-import { FeatureToggled, isFeatureEnabled, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
+import {
+  FeatureToggled,
+  isFeatureEnabled,
+  ALL_FLAGS_PROP_KEY,
+} from '@flopflip/react';
 import withFlagSubscription from '../with-flag-subscription/';
 
 export default compose(

--- a/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -1,10 +1,10 @@
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
-import { injectFeatureToggle, ALL_FLAGS } from '@flopflip/react';
+import { injectFeatureToggle, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
 import withFlagSubscription from '../with-flag-subscription/';
 
 export default (flagName, propKey) => WrappedComponent =>
   compose(
-    withFlagSubscription(ALL_FLAGS),
+    withFlagSubscription(ALL_FLAGS_PROP_KEY),
     injectFeatureToggle(flagName, propKey),
     setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggle'))
   )(WrappedComponent);

--- a/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -1,10 +1,10 @@
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
-import { injectFeatureToggles, ALL_FLAGS } from '@flopflip/react';
+import { injectFeatureToggles, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
 import withFlagSubscription from '../with-flag-subscription/';
 
 export default (flagNames, propKey) => WrappedComponent =>
   compose(
-    withFlagSubscription(ALL_FLAGS),
+    withFlagSubscription(ALL_FLAGS_PROP_KEY),
     injectFeatureToggles(flagNames, propKey),
     setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggles'))
   )(WrappedComponent);

--- a/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
-import { injectFeatureToggle, ALL_FLAGS } from '@flopflip/react';
+import { injectFeatureToggle, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
 import { STATE_SLICE } from './../../store';
 
 export const mapStateToProps = state => ({
-  [ALL_FLAGS]: state[STATE_SLICE].flags,
+  [ALL_FLAGS_PROP_KEY]: state[STATE_SLICE].flags,
 });
 
 export default (flagName, propKey) => WrappedComponent =>

--- a/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux';
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
+import { selectFlags } from '../../ducks';
 import { injectFeatureToggle, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
 import { STATE_SLICE } from './../../store';
 
 export const mapStateToProps = state => ({
-  [ALL_FLAGS_PROP_KEY]: state[STATE_SLICE].flags,
+  [ALL_FLAGS_PROP_KEY]: selectFlags(state),
 });
 
 export default (flagName, propKey) => WrappedComponent =>

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
-import { injectFeatureToggles, ALL_FLAGS } from '@flopflip/react';
+import { injectFeatureToggles, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
 import { STATE_SLICE } from './../../store';
 
 export const mapStateToProps = state => ({
-  [ALL_FLAGS]: state[STATE_SLICE].flags,
+  [ALL_FLAGS_PROP_KEY]: state[STATE_SLICE].flags,
 });
 
 export default (flagNames, propKey) => WrappedComponent =>

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux';
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
+import { selectFlags } from '../../ducks';
 import { injectFeatureToggles, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
 import { STATE_SLICE } from './../../store';
 
 export const mapStateToProps = state => ({
-  [ALL_FLAGS_PROP_KEY]: state[STATE_SLICE].flags,
+  [ALL_FLAGS_PROP_KEY]: selectFlags(state),
 });
 
 export default (flagNames, propKey) => WrappedComponent =>

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
@@ -1,4 +1,4 @@
-import { ALL_FLAGS } from '@flopflip/react';
+import { ALL_FLAGS_PROP_KEY } from '@flopflip/react';
 import { STATE_SLICE } from './../../store';
 import { mapStateToProps } from './inject-feature-toggles';
 
@@ -13,8 +13,8 @@ describe('mapStateToProps', () => {
       };
     });
 
-    it('should map `flags` as `ALL_FLAGS` onto `props`', () => {
-      expect(mapStateToProps(state)[ALL_FLAGS]).toEqual(flags);
+    it('should map `flags` as `ALL_FLAGS_PROP_KEY` onto `props`', () => {
+      expect(mapStateToProps(state)[ALL_FLAGS_PROP_KEY]).toEqual(flags);
     });
   });
 
@@ -28,8 +28,8 @@ describe('mapStateToProps', () => {
       };
     });
 
-    it('should map `flags` as `ALL_FLAGS` onto `props`', () => {
-      expect(mapStateToProps(state)[ALL_FLAGS]).toEqual(flags);
+    it('should map `flags` as `ALL_FLAGS_PROP_KEY` onto `props`', () => {
+      expect(mapStateToProps(state)[ALL_FLAGS_PROP_KEY]).toEqual(flags);
     });
   });
 });

--- a/packages/react-redux/modules/ducks/flags/flags.js
+++ b/packages/react-redux/modules/ducks/flags/flags.js
@@ -1,3 +1,4 @@
+import isNil from 'lodash.isnil';
 import { STATE_SLICE } from '../../store';
 
 // Actions
@@ -29,6 +30,7 @@ export const updateFlags = flags => ({
 export const selectFlags = state => state[STATE_SLICE].flags;
 export const selectFlag = state => flagName => {
   const allFlags = selectFlags(state);
+  const flagValue = allFlags[flagName];
 
-  return allFlags ? allFlags[flagName] : undefined;
+  return isNil(flagValue) ? false : flagValue;
 };

--- a/packages/react-redux/modules/ducks/flags/flags.js
+++ b/packages/react-redux/modules/ducks/flags/flags.js
@@ -1,3 +1,5 @@
+import { STATE_SLICE } from '../../store';
+
 // Actions
 export const UPDATE_FLAGS = '@flopflip/flags/update';
 
@@ -22,3 +24,11 @@ export const updateFlags = flags => ({
   type: UPDATE_FLAGS,
   payload: flags,
 });
+
+// Selectors
+export const selectFlags = state => state[STATE_SLICE].flags;
+export const selectFlag = state => flagName => {
+  const allFlags = selectFlags(state);
+
+  return allFlags ? allFlags[flagName] : undefined;
+};

--- a/packages/react-redux/modules/ducks/flags/flags.spec.js
+++ b/packages/react-redux/modules/ducks/flags/flags.spec.js
@@ -1,4 +1,10 @@
-import reducer, { UPDATE_FLAGS, updateFlags } from './flags';
+import { STATE_SLICE } from '../../store';
+import reducer, {
+  UPDATE_FLAGS,
+  updateFlags,
+  selectFlag,
+  selectFlags,
+} from './flags';
 
 describe('constants', () => {
   it('should contain `flags/updateFlags`', () => {
@@ -60,6 +66,44 @@ describe('reducers', () => {
           ...payload,
           c: true,
         });
+      });
+    });
+  });
+});
+
+describe('selectors', () => {
+  let flags;
+  let state;
+
+  beforeEach(() => {
+    flags = {
+      flagA: true,
+      flagB: false,
+    };
+    state = {
+      [STATE_SLICE]: {
+        flags,
+      },
+    };
+  });
+
+  describe('selecting flags', () => {
+    it('should return all flags', () => {
+      expect(selectFlags(state)).toEqual(flags);
+    });
+  });
+
+  describe('selecting a flag', () => {
+    describe('when existing', () => {
+      it('should return the flag value', () => {
+        expect(selectFlag(state)('flagA')).toEqual(true);
+        expect(selectFlag(state)('flagB')).toEqual(false);
+      });
+    });
+
+    describe('when not existing', () => {
+      it('should return `undefined`', () => {
+        expect(selectFlag(state)('zFlag')).toBeUndefined();
       });
     });
   });

--- a/packages/react-redux/modules/ducks/flags/flags.spec.js
+++ b/packages/react-redux/modules/ducks/flags/flags.spec.js
@@ -102,8 +102,8 @@ describe('selectors', () => {
     });
 
     describe('when not existing', () => {
-      it('should return `undefined`', () => {
-        expect(selectFlag(state)('zFlag')).toBeUndefined();
+      it('should return `false`', () => {
+        expect(selectFlag(state)('zFlag')).toEqual(false);
       });
     });
   });

--- a/packages/react-redux/modules/ducks/flags/index.js
+++ b/packages/react-redux/modules/ducks/flags/index.js
@@ -1,2 +1,2 @@
 export { default as flagsReducer } from './flags';
-export { UPDATE_FLAGS, updateFlags } from './flags';
+export { UPDATE_FLAGS, updateFlags, selectFlag, selectFlags } from './flags';

--- a/packages/react-redux/modules/ducks/index.js
+++ b/packages/react-redux/modules/ducks/index.js
@@ -3,7 +3,7 @@ import { flagsReducer } from './flags';
 import { statusReducer } from './status';
 
 export { updateStatus, UPDATE_STATUS } from './status';
-export { updateFlags, UPDATE_FLAGS } from './flags';
+export { updateFlags, UPDATE_FLAGS, selectFlag, selectFlags } from './flags';
 
 export const flopflipReducer = combineReducers({
   flags: flagsReducer,

--- a/packages/react-redux/modules/index.js
+++ b/packages/react-redux/modules/index.js
@@ -8,6 +8,8 @@ export {
   updateFlags,
   UPDATE_STATUS,
   UPDATE_FLAGS,
+  selectFlags as selectFeatureFlags,
+  selectFlag as selectFeatureFlag,
 } from './ducks';
 export {
   FeatureToggled,

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@flopflip/react": "^4.0.4",
+    "lodash.isnil": "^4.0.0",
     "recompose": "^0.26.0"
   },
   "peerDependencies": {

--- a/packages/react/modules/components/inject-feature-toggle/__snapshots__/inject-feature-toggle.spec.js.snap
+++ b/packages/react/modules/components/inject-feature-toggle/__snapshots__/inject-feature-toggle.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`injecting with \`propKey\` should match snapshot 1`] = `
 <omitProps(TestComponent)
-  __flopflop_all_flags__={
+  @flopflip/flags={
     Object {
       "aFeatureToggle": true,
     }
@@ -13,7 +13,7 @@ exports[`injecting with \`propKey\` should match snapshot 1`] = `
 
 exports[`injecting without \`propKey\` should match snapshot 1`] = `
 <omitProps(TestComponent)
-  __flopflop_all_flags__={
+  @flopflip/flags={
     Object {
       "aFeatureToggle": true,
     }

--- a/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -1,16 +1,16 @@
 import { compose, withProps } from 'recompose';
 import isNil from 'lodash.isnil';
 import { omitProps } from '../../hocs';
-import { DEFAULT_FLAG_PROP_KEY, ALL_FLAGS } from '../../constants';
+import { DEFAULT_FLAG_PROP_KEY, ALL_FLAGS_PROP_KEY } from '../../constants';
 
 const injectFeatureToggle = (flagName, propKey = DEFAULT_FLAG_PROP_KEY) =>
   compose(
     withProps(props => {
-      const flagValue = props[ALL_FLAGS][flagName];
+      const flagValue = props[ALL_FLAGS_PROP_KEY][flagName];
 
       return { [propKey]: isNil(flagValue) ? false : flagValue };
     }),
-    omitProps(ALL_FLAGS)
+    omitProps(ALL_FLAGS_PROP_KEY)
   );
 
 export default injectFeatureToggle;

--- a/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
+++ b/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { ALL_FLAGS } from '../../constants';
+import { ALL_FLAGS_PROP_KEY } from '../../constants';
 import injectFeatureToggle from './inject-feature-toggle';
 
 describe('injecting', () => {
@@ -10,7 +10,7 @@ describe('injecting', () => {
 
   const flagName = 'aFeatureToggle';
   const createTestProps = custom => ({
-    [ALL_FLAGS]: { [flagName]: true },
+    [ALL_FLAGS_PROP_KEY]: { [flagName]: true },
     ...custom,
   });
 
@@ -33,7 +33,7 @@ describe('injecting', () => {
     });
 
     it("should pass the feature toggle's state as a `prop` of `propKey`", () => {
-      expect(wrapper).toHaveProp(propKey, props[ALL_FLAGS][flagName]);
+      expect(wrapper).toHaveProp(propKey, props[ALL_FLAGS_PROP_KEY][flagName]);
     });
   });
 

--- a/packages/react/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
+++ b/packages/react/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`injecting with single feature toggle should match snapshot 1`] = `
 <omitProps(TestComponent)
-  __flopflop_all_flags__={
+  @flopflip/flags={
     Object {
       "aFeatureToggle": true,
     }

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -1,7 +1,7 @@
 import { compose, withProps } from 'recompose';
 import intersection from 'lodash.intersection';
 import { omitProps } from '../../hocs';
-import { ALL_FLAGS, DEFAULT_FLAGS_PROP_KEY } from '../../constants';
+import { ALL_FLAGS_PROP_KEY, DEFAULT_FLAGS_PROP_KEY } from '../../constants';
 
 const filterFeatureToggles = (allFlags, demandedFlags) =>
   intersection(Object.keys(allFlags), demandedFlags).reduce(
@@ -15,9 +15,9 @@ const filterFeatureToggles = (allFlags, demandedFlags) =>
 const injectFeatureToggles = (flagNames, propKey = DEFAULT_FLAGS_PROP_KEY) =>
   compose(
     withProps(props => ({
-      [propKey]: filterFeatureToggles(props[ALL_FLAGS], flagNames),
+      [propKey]: filterFeatureToggles(props[ALL_FLAGS_PROP_KEY], flagNames),
     })),
-    omitProps(ALL_FLAGS)
+    omitProps(ALL_FLAGS_PROP_KEY)
   );
 
 export default injectFeatureToggles;

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
@@ -31,7 +31,10 @@ describe('injecting', () => {
     });
 
     it('should pass all requested feature toggles as a `prop`', () => {
-      expect(wrapper).toHaveProp(DEFAULT_FLAGS_PROP_KEY, props[ALL_FLAGS_PROP_KEY]);
+      expect(wrapper).toHaveProp(
+        DEFAULT_FLAGS_PROP_KEY,
+        props[ALL_FLAGS_PROP_KEY]
+      );
     });
 
     it("should pass the feature toggle's state as a `prop`", () => {
@@ -50,7 +53,10 @@ describe('injecting', () => {
     describe('with all toggles defined', () => {
       beforeEach(() => {
         props = createTestProps({
-          [ALL_FLAGS_PROP_KEY]: { [featureToggle]: true, [featureToggle2]: false },
+          [ALL_FLAGS_PROP_KEY]: {
+            [featureToggle]: true,
+            [featureToggle2]: false,
+          },
         });
 
         Component = injectFeatureToggles([featureToggle, featureToggle2])(
@@ -60,7 +66,10 @@ describe('injecting', () => {
       });
 
       it('should pass all requested feature toggles as a `prop`', () => {
-        expect(wrapper).toHaveProp(DEFAULT_FLAGS_PROP_KEY, props[ALL_FLAGS_PROP_KEY]);
+        expect(wrapper).toHaveProp(
+          DEFAULT_FLAGS_PROP_KEY,
+          props[ALL_FLAGS_PROP_KEY]
+        );
       });
     });
 
@@ -101,7 +110,10 @@ describe('injecting', () => {
     describe('with `propKey`', () => {
       beforeEach(() => {
         props = createTestProps({
-          [ALL_FLAGS_PROP_KEY]: { [featureToggle]: true, [featureToggle2]: false },
+          [ALL_FLAGS_PROP_KEY]: {
+            [featureToggle]: true,
+            [featureToggle2]: false,
+          },
         });
 
         Component = injectFeatureToggles(

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { ALL_FLAGS, DEFAULT_FLAGS_PROP_KEY } from '../../constants';
+import { ALL_FLAGS_PROP_KEY, DEFAULT_FLAGS_PROP_KEY } from '../../constants';
 import injectFeatureToggles from './inject-feature-toggles';
 
 describe('injecting', () => {
@@ -10,7 +10,7 @@ describe('injecting', () => {
 
   const featureToggle = 'aFeatureToggle';
   const createTestProps = custom => ({
-    [ALL_FLAGS]: { [featureToggle]: true },
+    [ALL_FLAGS_PROP_KEY]: { [featureToggle]: true },
     ...custom,
   });
 
@@ -31,12 +31,12 @@ describe('injecting', () => {
     });
 
     it('should pass all requested feature toggles as a `prop`', () => {
-      expect(wrapper).toHaveProp(DEFAULT_FLAGS_PROP_KEY, props[ALL_FLAGS]);
+      expect(wrapper).toHaveProp(DEFAULT_FLAGS_PROP_KEY, props[ALL_FLAGS_PROP_KEY]);
     });
 
     it("should pass the feature toggle's state as a `prop`", () => {
       expect(wrapper).toHaveProp(DEFAULT_FLAGS_PROP_KEY, {
-        [featureToggle]: props[ALL_FLAGS][featureToggle],
+        [featureToggle]: props[ALL_FLAGS_PROP_KEY][featureToggle],
       });
     });
   });
@@ -50,7 +50,7 @@ describe('injecting', () => {
     describe('with all toggles defined', () => {
       beforeEach(() => {
         props = createTestProps({
-          [ALL_FLAGS]: { [featureToggle]: true, [featureToggle2]: false },
+          [ALL_FLAGS_PROP_KEY]: { [featureToggle]: true, [featureToggle2]: false },
         });
 
         Component = injectFeatureToggles([featureToggle, featureToggle2])(
@@ -60,7 +60,7 @@ describe('injecting', () => {
       });
 
       it('should pass all requested feature toggles as a `prop`', () => {
-        expect(wrapper).toHaveProp(DEFAULT_FLAGS_PROP_KEY, props[ALL_FLAGS]);
+        expect(wrapper).toHaveProp(DEFAULT_FLAGS_PROP_KEY, props[ALL_FLAGS_PROP_KEY]);
       });
     });
 
@@ -87,7 +87,7 @@ describe('injecting', () => {
 
       it("should pass the feature toggle's state as a `prop`", () => {
         expect(wrapper).toHaveProp(DEFAULT_FLAGS_PROP_KEY, {
-          [featureToggle]: props[ALL_FLAGS][featureToggle],
+          [featureToggle]: props[ALL_FLAGS_PROP_KEY][featureToggle],
         });
       });
 
@@ -101,7 +101,7 @@ describe('injecting', () => {
     describe('with `propKey`', () => {
       beforeEach(() => {
         props = createTestProps({
-          [ALL_FLAGS]: { [featureToggle]: true, [featureToggle2]: false },
+          [ALL_FLAGS_PROP_KEY]: { [featureToggle]: true, [featureToggle2]: false },
         });
 
         Component = injectFeatureToggles(
@@ -112,7 +112,7 @@ describe('injecting', () => {
       });
 
       it('should map all feature toggles', () => {
-        expect(wrapper).toHaveProp('fooPropKey', props[ALL_FLAGS]);
+        expect(wrapper).toHaveProp('fooPropKey', props[ALL_FLAGS_PROP_KEY]);
       });
     });
   });

--- a/packages/react/modules/constants.js
+++ b/packages/react/modules/constants.js
@@ -1,3 +1,3 @@
 export const DEFAULT_FLAG_PROP_KEY = 'isFeatureEnabled';
 export const DEFAULT_FLAGS_PROP_KEY = 'featureToggles';
-export const ALL_FLAGS = '@flopflip/flags';
+export const ALL_FLAGS_PROP_KEY = '@flopflip/flags';

--- a/packages/react/modules/constants.js
+++ b/packages/react/modules/constants.js
@@ -1,3 +1,3 @@
 export const DEFAULT_FLAG_PROP_KEY = 'isFeatureEnabled';
 export const DEFAULT_FLAGS_PROP_KEY = 'featureToggles';
-export const ALL_FLAGS = '__flopflop_all_flags__';
+export const ALL_FLAGS = '@flopflip/flags';

--- a/packages/react/modules/index.js
+++ b/packages/react/modules/index.js
@@ -10,7 +10,7 @@ export { default as isFeatureEnabled } from './helpers/is-feature-enabled';
 export {
   DEFAULT_FLAG_PROP_KEY,
   DEFAULT_FLAGS_PROP_KEY,
-  ALL_FLAGS,
+  ALL_FLAGS_PROP_KEY,
 } from './constants';
 
 export { version } from '../package.json';

--- a/readme.md
+++ b/readme.md
@@ -429,6 +429,40 @@ export default injectFeatureToggle(flagsNames.TOGGLE_B)(Component);
 The feature flags will be available as `props` within the component allowing
 some custom decisions based on their value.
 
+### `@flopflip/react-redux` additional API & exports
+
+We also expose our internal selectors to access feature toggle(s) directly so
+that the use of `injectFeatureToggle` or `injectFeatureToggles` is not enforced
+or the only value to access flags from `@flopflip/react-redux`'s store slice.
+The two selectors `selectFeatureFlag` and `selectFeatureFlags` return the same
+values for flags as `injectFeatureToggle` and `injectFeatureToggles` would.
+
+An example usage for a connected component would be:
+
+```js
+const mapStateToProps = state => {
+  someOtherState: state.someOtherState,
+  isFeatureOn: selectFeatureFlag(state)('fooFlagName')
+}
+
+export default connect(mapStateToProps)(FooComponent)
+```
+
+instead of when using `injectFeatureToggle`:
+
+```js
+const mapStateToProps = state => {
+  someOtherState: state.someOtherState,
+}
+
+export default compose(
+  injectFeatureToggle('fooFlagName')
+  connect(mapStateToProps)
+)(FooComponent)
+```
+
+The same example above applies for `selectFeatureFlags`.
+
 #### `createFlopFlipEnhancer`
 
 Requires arguments of `clientSideId:string`, `user:object`.


### PR DESCRIPTION
> This pull request adds selectors and exposes them form the `react-redux` package.

With request from #68 we decided to refactor the package to use selectors for all flags and a single flag while also exposing them.

```js
const mapStateToProps = state => {
  someOtherState: state.someOtherState,
  isFeatureOn: selectFeatureFlag(state)('fooFlagName')
}

export default connect(mapStateToProps)(FooComponent)
```

Closes #68 