### PR TITLE
Pass args to configure the splitio client

### DIFF
--- a/packages/splitio-adapter/modules/adapter/adapter.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.js
@@ -54,12 +54,13 @@ const ensureUser = user => ({
   ...user,
 });
 
-const initializeClient = (authorizationKey, user) => {
+const initializeClient = (authorizationKey, user, params) => {
   const factory = splitio({
     core: {
       authorizationKey,
       key: user.key,
     },
+    ...params,
   });
 
   return {
@@ -95,11 +96,13 @@ const configure = ({
   user,
   onFlagsStateChange,
   onStatusStateChange,
+  ...adapterArgs
 }) => {
   adapterState.user = ensureUser(user);
   const { client, manager } = initializeClient(
     authorizationKey,
-    adapterState.user
+    adapterState.user,
+    adapterArgs
   );
   adapterState.client = client;
   adapterState.manager = manager;

--- a/packages/splitio-adapter/modules/adapter/adapter.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.js
@@ -54,13 +54,13 @@ const ensureUser = user => ({
   ...user,
 });
 
-const initializeClient = (authorizationKey, user, params) => {
+const initializeClient = (authorizationKey, user, options) => {
   const factory = splitio({
     core: {
       authorizationKey,
       key: user.key,
     },
-    ...params,
+    ...options,
   });
 
   return {

--- a/packages/splitio-adapter/modules/adapter/adapter.spec.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.spec.js
@@ -86,6 +86,60 @@ describe('when configuring', () => {
     });
   });
 
+  describe('with options', () => {
+    const options = {
+      additional: 'option',
+    };
+
+    beforeEach(() => {
+      return adapter.configure({
+        authorizationKey,
+        user: userWithKey,
+        options,
+        onStatusStateChange,
+        onFlagsStateChange,
+      });
+    });
+
+    it('should initialize the `splitio` client with `options`', () => {
+      expect(splitio).toHaveBeenCalledWith({
+        ...options,
+        core: {
+          authorizationKey,
+          key: userWithKey.key,
+        },
+      });
+    });
+  });
+
+  describe('with `core` options', () => {
+    const coreOptions = {
+      additional: 'core-option',
+    };
+
+    beforeEach(() => {
+      return adapter.configure({
+        authorizationKey,
+        user: userWithKey,
+        options: {
+          core: coreOptions,
+        },
+        onStatusStateChange,
+        onFlagsStateChange,
+      });
+    });
+
+    it('should initialize the `splitio` client with `core` options in `core` property', () => {
+      expect(splitio).toHaveBeenCalledWith({
+        core: {
+          ...coreOptions,
+          authorizationKey,
+          key: userWithKey.key,
+        },
+      });
+    });
+  });
+
   describe('when ready', () => {
     let factory;
     let onStub;


### PR DESCRIPTION
The splitio JS client can be configured with a lot of options (https://docs.split.io/docs/javascript-sdk-overview#section-configuration).

This brings the ability to pass an `adapterArgs` prop with the options we want to configure.

```
<ConfigureFlopFlip
  adapter={adapter}
  adapterArgs={{ authorizationKey, user, core: { labelsEnabled: false } }}
>
```

If you want to nest this behind an object key (like `adapterConfig` or something), let me know!