### PR TITLE
fix(react): so that injectFeatureToggles only updates for keys

### DIFF
--- a/packages/react/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
+++ b/packages/react/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`injecting with single feature toggle should match snapshot 1`] = `
-<omitProps(TestComponent)
+<omitProps(onlyUpdateForKeys(TestComponent))
   @flopflip/flags={
     Object {
       "aFeatureToggle": true,

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -1,4 +1,4 @@
-import { compose, withProps } from 'recompose';
+import { compose, withProps, onlyUpdateForKeys } from 'recompose';
 import intersection from 'lodash.intersection';
 import { omitProps } from '../../hocs';
 import { ALL_FLAGS_PROP_KEY, DEFAULT_FLAGS_PROP_KEY } from '../../constants';
@@ -17,7 +17,8 @@ const injectFeatureToggles = (flagNames, propKey = DEFAULT_FLAGS_PROP_KEY) =>
     withProps(props => ({
       [propKey]: filterFeatureToggles(props[ALL_FLAGS_PROP_KEY], flagNames),
     })),
-    omitProps(ALL_FLAGS_PROP_KEY)
+    omitProps(ALL_FLAGS_PROP_KEY),
+    onlyUpdateForKeys(flagNames)
   );
 
 export default injectFeatureToggles;


### PR DESCRIPTION
In #75 it was outlines that due to the fact that we treat flags as immutable (creating referentially different ones) we also re-render components wastefully which compose with `injectFeatureToggles`. 

This pull request attempts to reduce the wasteful renders by using `onlyUpdateForKeys` by `recompose`. It restricts re-renders only by the `flagNames` requested..

Closes #76 