### PR TITLE
BREAKING(react): invoke children in any case, render on match

### DIFF
--- a/packages/react/modules/components/feature-toggled/__snapshots__/feature-toggled.spec.js.snap
+++ b/packages/react/modules/components/feature-toggled/__snapshots__/feature-toggled.spec.js.snap
@@ -4,7 +4,13 @@ exports[`when feature disabled with untoggled component should match snapshot 1`
 
 exports[`when feature disabled without untoggled component should match snapshot 1`] = `""`;
 
-exports[`when feature enabled with \`children\` should match snapshot 1`] = `<FeatureComponent />`;
+exports[`when feature enabled with \`children\` being a \`function\` should match snapshot 1`] = `
+<div>
+  FeatureComponent
+</div>
+`;
+
+exports[`when feature enabled with \`children\` being a \`node\` should match snapshot 1`] = `<FeatureComponent />`;
 
 exports[`when feature enabled with \`render\` should match snapshot 1`] = `
 <div>

--- a/packages/react/modules/components/feature-toggled/feature-toggled.js
+++ b/packages/react/modules/components/feature-toggled/feature-toggled.js
@@ -24,18 +24,17 @@ export default class FeatureToggled extends React.PureComponent {
 
   render() {
     if (this.props.isFeatureEnabled) {
-      if (typeof this.props.children === 'function')
-        return this.props.children();
-
       if (this.props.toggledComponent)
         return React.createElement(this.props.toggledComponent);
 
       if (this.props.children && !isEmptyChildren(this.props.children))
         return React.Children.only(this.props.children);
+
+      if (typeof this.props.render === 'function') return this.props.render();
     }
 
-    if (typeof this.props.render === 'function')
-      return this.props.render({
+    if (typeof this.props.children === 'function')
+      return this.props.children({
         isFeatureEnabled: this.props.isFeatureEnabled,
       });
 

--- a/packages/react/modules/components/feature-toggled/feature-toggled.spec.js
+++ b/packages/react/modules/components/feature-toggled/feature-toggled.spec.js
@@ -62,27 +62,56 @@ describe('when feature enabled', () => {
   let wrapper;
 
   describe('with `children`', () => {
-    beforeEach(() => {
-      wrapper = shallow(
-        <FeatureToggled
-          isFeatureEnabled
-          untoggledComponent={UntoggledComponent}
-        >
-          <FeatureComponent />
-        </FeatureToggled>
-      );
+    describe('being a `node`', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <FeatureToggled
+            isFeatureEnabled
+            untoggledComponent={UntoggledComponent}
+          >
+            <FeatureComponent />
+          </FeatureToggled>
+        );
+      });
+
+      it('should match snapshot', () => {
+        expect(wrapper).toMatchSnapshot();
+      });
+
+      it('should not render the `UntoggledComponent`', () => {
+        expect(wrapper).not.toRender(UntoggledComponent);
+      });
+
+      it('should render the `FeatureComponent`', () => {
+        expect(wrapper).toRender(FeatureComponent);
+      });
     });
 
-    it('should match snapshot', () => {
-      expect(wrapper).toMatchSnapshot();
-    });
+    describe('being a `function`', () => {
+      let props;
+      beforeEach(() => {
+        props = {
+          isFeatureEnabled: true,
+          untoggledComponent: UntoggledComponent,
+          children: jest.fn(() => <div>FeatureComponent</div>),
+        };
 
-    it('should not render the `UntoggledComponent`', () => {
-      expect(wrapper).not.toRender(UntoggledComponent);
-    });
+        wrapper = shallow(<FeatureToggled {...props} />);
+      });
 
-    it('should render the `FeatureComponent`', () => {
-      expect(wrapper).toRender(FeatureComponent);
+      it('should match snapshot', () => {
+        expect(wrapper).toMatchSnapshot();
+      });
+
+      it('should invoke `children`', () => {
+        expect(props.children).toHaveBeenCalled();
+      });
+
+      it('should invoke `children` with `isFeatureEnabled`', () => {
+        expect(props.children).toHaveBeenCalledWith({
+          isFeatureEnabled: props.isFeatureEnabled,
+        });
+      });
     });
   });
 
@@ -128,12 +157,6 @@ describe('when feature enabled', () => {
 
     it('should invoke `render`', () => {
       expect(props.render).toHaveBeenCalled();
-    });
-
-    it('should invoke `render` with `isFeatureEnabled`', () => {
-      expect(props.render).toHaveBeenCalledWith({
-        isFeatureEnabled: props.isFeatureEnabled,
-      });
     });
   });
 });


### PR DESCRIPTION
This fixes the behaviour of our render props on `FeatureToggled`. Generally `render` should only be invoked whenever there is a match. Whereas `children` (whenever a function) should always be invoked with `props`. Sadly, we decided to take this the wrong way round. 

There might be no right way in this defacto but `react-router` serves as an example here and community homogeneity seems favourable.