### PR TITLE
Add TypeScript definitions for `react-redux` and `react-broadcast`

### DIFF
--- a/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -8,13 +8,11 @@ import { branchOnFeatureToggle, DEFAULT_FLAG_PROP_KEY } from '@flopflip/react';
 import injectFeatureToggle from './../inject-feature-toggle';
 
 type RequiredProps = {};
-type ProvidedProps = {
-  [propKey: string]: FlagVariation | void,
-};
+type ProvidedProps = {};
 
 export default <RequiredProps, ProvidedProps>(
-  { flag, variation }: { flag: FlagName, variation: FlagVariation },
-  UntoggledComponent: React.ComponentType<any>
+  { flag, variation }: { flag: FlagName, variation?: FlagVariation },
+  UntoggledComponent?: React.ComponentType<any>
 ) => (
   WrappedComponent: React.ComponentType<$Diff<RequiredProps, ProvidedProps>>
 ) =>

--- a/packages/react-broadcast/modules/components/configure/configure.js
+++ b/packages/react-broadcast/modules/components/configure/configure.js
@@ -14,7 +14,7 @@ import { Broadcast } from 'react-broadcast';
 import { FLAGS_CHANNEL } from '../../constants';
 
 type Props = {
-  children: number,
+  children: React.Node,
   shouldDeferAdapterConfiguration?: boolean,
   defaultFlags?: Flags,
   adapterArgs: AdapterArgs,

--- a/packages/react-broadcast/package.json
+++ b/packages/react-broadcast/package.json
@@ -19,6 +19,8 @@
     "readme.md",
     "dist/**"
   ],
+    "types": "./types/index.d.ts",
+
   "publishConfig": {
     "access": "public"
   },

--- a/packages/react-broadcast/types/index.d.ts
+++ b/packages/react-broadcast/types/index.d.ts
@@ -1,0 +1,77 @@
+// Type definitions for @flopflip/react-broadcast 5.x
+// TypeScript Version: 2.x
+
+declare module '@flopflip/react-broadcast' {
+  import * as React from 'react';
+
+  export type Diff<T extends string, U extends string> = ({ [P in T]: P } &
+    { [P in U]: never } & { [x: string]: never })[T];
+  export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+
+  export interface ComponentEnhancerWithProps<ProvidedProps, RerquiredProps> {
+    <P extends ProvidedProps>(component: Component<P>): React.ComponentType<
+      Omit<P, keyof ProvidedProps> & RerquiredProps
+    >;
+  }
+
+  export type FlagName = string;
+  export type FlagVariation = boolean | string;
+  export interface Flag {
+    flag: FlagName;
+    variation?: FlagVariation;
+  }
+  export type Flags = { [FlagName]: FlagVariation };
+  export type AdapterArgs = {
+    user: {
+      key?: string;
+    };
+    onFlagsStateChange: () => void;
+    onStatusStateChange: () => void;
+  };
+  export type Adapter = {
+    configure: (adapterArgs: AdapterArgs) => Promise<any>;
+    reconfigure: (adapterArgs: AdapterArgs) => Promise<any>;
+  };
+
+  export interface ToggleComponentProps {
+    toggledComponent?: React.ComponentType<any>;
+    untoggledComponent?: React.ComponentType<any>;
+    render?: () => React.ReactNode;
+    children?:
+      | (({ isFeatureEnabled: boolean }) => React.ReactNode)
+      | React.ReactNode;
+    isFeatureEnabled: boolean;
+  }
+  export interface ConfigureComponentProps {
+    shouldDeferAdapterConfiguration?: boolean;
+    defaultFlags?: Flags;
+    adapterArgs: AdapterArgs;
+    adapter: Adapter;
+    children: React.ReactNode;
+  }
+
+  export function branchOnFeatureToggle<P extends {}>(
+    flag: Flag,
+    UntoggledComponent?: React.ComponentType<P>
+  ): ComponentEnhancerWithProps<P, P>;
+
+  export function injectFeatureToggle(
+    flagName: FlagName,
+    propKey?: string
+  ): ComponentEnhancerWithProps<Flag, {}>;
+
+  export function injectFeatureToggles(
+    flagNames: Array<Flag>,
+    propKey?: string
+  ): ComponentEnhancerWithProps<{ [propKey: string]: Flags }, {}>;
+
+  export class ToggleFeature extends React.Component<
+    ToggleComponentProps,
+    any
+  > {}
+
+  export class ConfigureFlopflip extends React.Component<
+    ConfigureComponentProps,
+    any
+  > {}
+}

--- a/packages/react-broadcast/types/index.d.ts
+++ b/packages/react-broadcast/types/index.d.ts
@@ -9,9 +9,9 @@ declare module '@flopflip/react-broadcast' {
   export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
   export interface ComponentEnhancerWithProps<ProvidedProps, RerquiredProps> {
-    <P extends ProvidedProps>(component: Component<P>): React.ComponentType<
-      Omit<P, keyof ProvidedProps> & RerquiredProps
-    >;
+    <P extends ProvidedProps>(
+      component: React.ComponentType<P>
+    ): React.ComponentType<Omit<P, keyof ProvidedProps> & RerquiredProps>;
   }
 
   export type FlagName = string;
@@ -20,7 +20,7 @@ declare module '@flopflip/react-broadcast' {
     flag: FlagName;
     variation?: FlagVariation;
   }
-  export type Flags = { [FlagName]: FlagVariation };
+  export type Flags = { [flagName: string]: FlagVariation };
   export type AdapterArgs = {
     user: {
       key?: string;
@@ -49,6 +49,9 @@ declare module '@flopflip/react-broadcast' {
     adapter: Adapter;
     children: React.ReactNode;
   }
+  export interface SwitcComponenthProps {
+    children?: React.ReactNode;
+  }
 
   export function branchOnFeatureToggle<P extends {}>(
     flag: Flag,
@@ -65,6 +68,11 @@ declare module '@flopflip/react-broadcast' {
     propKey?: string
   ): ComponentEnhancerWithProps<{ [propKey: string]: Flags }, {}>;
 
+  export class SwitchFeature extends React.Component<
+    SwitcComponenthProps,
+    any
+  > {}
+
   export class ToggleFeature extends React.Component<
     ToggleComponentProps,
     any
@@ -74,4 +82,7 @@ declare module '@flopflip/react-broadcast' {
     ConfigureComponentProps,
     any
   > {}
+
+  export function selectFlags(state: {}): Flags;
+  export function selectFlag(flagName: FlagName): (state: {}) => Flags;
 }

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -8,9 +8,7 @@ import { branchOnFeatureToggle, DEFAULT_FLAG_PROP_KEY } from '@flopflip/react';
 import injectFeatureToggle from './../inject-feature-toggle';
 
 type RequiredProps = {};
-type ProvidedProps = {
-  [propKey: string]: FlagVariation | void,
-};
+type ProvidedProps = {};
 
 export default <RequiredProps, ProvidedProps>(
   { flag, variation }: { flag: FlagName, variation: FlagVariation },

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -19,6 +19,7 @@
     "readme.md",
     "dist/**"
   ],
+  "types": "./types/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/react-redux/types/index.d.ts
+++ b/packages/react-redux/types/index.d.ts
@@ -1,0 +1,77 @@
+// Type definitions for @flopflip/react-redux 5.x
+// TypeScript Version: 2.x
+
+declare module '@flopflip/react-redux' {
+  import * as React from 'react';
+
+  export type Diff<T extends string, U extends string> = ({ [P in T]: P } &
+    { [P in U]: never } & { [x: string]: never })[T];
+  export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+
+  export interface ComponentEnhancerWithProps<ProvidedProps, RerquiredProps> {
+    <P extends ProvidedProps>(component: Component<P>): React.ComponentType<
+      Omit<P, keyof ProvidedProps> & RerquiredProps
+    >;
+  }
+
+  export type FlagName = string;
+  export type FlagVariation = boolean | string;
+  export interface Flag {
+    flag: FlagName;
+    variation?: FlagVariation;
+  }
+  export type Flags = { [FlagName]: FlagVariation };
+  export type AdapterArgs = {
+    user: {
+      key?: string;
+    };
+    onFlagsStateChange: () => void;
+    onStatusStateChange: () => void;
+  };
+  export type Adapter = {
+    configure: (adapterArgs: AdapterArgs) => Promise<any>;
+    reconfigure: (adapterArgs: AdapterArgs) => Promise<any>;
+  };
+
+  export interface ToggleComponentProps {
+    toggledComponent?: React.ComponentType<any>;
+    untoggledComponent?: React.ComponentType<any>;
+    render?: () => React.ReactNode;
+    children?:
+      | (({ isFeatureEnabled: boolean }) => React.ReactNode)
+      | React.ReactNode;
+    isFeatureEnabled: boolean;
+  }
+  export interface ConfigureComponentProps {
+    shouldDeferAdapterConfiguration?: boolean;
+    defaultFlags?: Flags;
+    adapterArgs: AdapterArgs;
+    adapter: Adapter;
+    children: React.ReactNode;
+  }
+
+  export function branchOnFeatureToggle<P extends {}>(
+    flag: Flag,
+    UntoggledComponent?: React.ComponentType<P>
+  ): ComponentEnhancerWithProps<P, P>;
+
+  export function injectFeatureToggle(
+    flagName: FlagName,
+    propKey?: string
+  ): ComponentEnhancerWithProps<Flag, {}>;
+
+  export function injectFeatureToggles(
+    flagNames: Array<Flag>,
+    propKey?: string
+  ): ComponentEnhancerWithProps<{ [propKey: string]: Flags }, {}>;
+
+  export class ToggleFeature extends React.Component<
+    ToggleComponentProps,
+    any
+  > {}
+
+  export class ConfigureFlopflip extends React.Component<
+    ConfigureComponentProps,
+    any
+  > {}
+}

--- a/packages/react-redux/types/index.d.ts
+++ b/packages/react-redux/types/index.d.ts
@@ -9,9 +9,9 @@ declare module '@flopflip/react-redux' {
   export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
   export interface ComponentEnhancerWithProps<ProvidedProps, RerquiredProps> {
-    <P extends ProvidedProps>(component: Component<P>): React.ComponentType<
-      Omit<P, keyof ProvidedProps> & RerquiredProps
-    >;
+    <P extends ProvidedProps>(
+      component: React.ComponentType<P>
+    ): React.ComponentType<Omit<P, keyof ProvidedProps> & RerquiredProps>;
   }
 
   export type FlagName = string;
@@ -20,7 +20,7 @@ declare module '@flopflip/react-redux' {
     flag: FlagName;
     variation?: FlagVariation;
   }
-  export type Flags = { [FlagName]: FlagVariation };
+  export type Flags = { [flagName: string]: FlagVariation };
   export type AdapterArgs = {
     user: {
       key?: string;

--- a/packages/react/modules/components/toggle-feature/toggle-feature.js
+++ b/packages/react/modules/components/toggle-feature/toggle-feature.js
@@ -14,7 +14,7 @@ type Props = {
   untoggledComponent: React.ComponentType<any>,
   toggledComponent: React.ComponentType<any>,
   render: () => React.Node,
-  children: ({ isFeatureEnabled: boolean }) => React.Node | React.Node,
+  children: ({ isFeatureEnabled: boolean }) => React.Node,
   isFeatureEnabled: boolean,
 };
 

--- a/packages/react/modules/types.js
+++ b/packages/react/modules/types.js
@@ -14,8 +14,8 @@ export type AdapterStatus = {
   isConfigured?: boolean,
 };
 export type Adapter = {
-  configure: AdapterArgs => Promise<any>,
-  reconfigure: AdapterArgs => Promise<any>,
+  configure: (adapterArgs: AdapterArgs) => Promise<any>,
+  reconfigure: (adapterArgs: AdapterArgs) => Promise<any>,
 };
 type State = {
   +flags: Flags,


### PR DESCRIPTION
After having migrated all code to flow-type I wanted to offer TypeScript definitions files.

### Why TypeScript definitions?

Generally IDE support for TypeScript is quite advanced, many developers use VSCode and we can give inline type hints.

### Why not PR to definitely-typed?

I don't mind hosting the definitions linked by a `package.json` entry. Types don't get out of sync and don't have to be versioned in another repository. While developers would have to install `@types/flipflip/react-broadcast` mostly manually. All too much maintenance overhead for me instead of just keeping them here.

### Why not flow-types?

Flow has also has a `flow-typed` repository with types. However, I've seen a little amount of developers having flow setup in their IDE either installing types or expecting IDE integrations to give hints. I could probably also just link or re-export the internally held definitions or that already happens automatically with some setups.

### Why am I really doing this?

Learn about type systems.