### PR TITLE
Define bucklescript bindings (for react-broadcast)

### DIFF
--- a/packages/bs-flopflip/.gitignore
+++ b/packages/bs-flopflip/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+
+# BuckleScript
+.merlin
+.bsb.lock
+lib
+*.bs.js

--- a/packages/bs-flopflip/README.md
+++ b/packages/bs-flopflip/README.md
@@ -7,16 +7,16 @@
 #### yarn
 
 ```bash
-$ yarn add bs-flopflip
+$ yarn add @flopflip/bs-flopflip
 ```
 
 #### bsconfig
 
-Add `bs-flopflip` to your `bs-dependencies`: **bsconfig.json**
+Add `@flopflip/bs-flopflip` to your `bs-dependencies`: **bsconfig.json**
 
 ```json
 "bs-dependencies": [
-  "bs-flopflip",
+  "@flopflip/bs-flopflip",
   ...
 ]
 ```

--- a/packages/bs-flopflip/README.md
+++ b/packages/bs-flopflip/README.md
@@ -1,0 +1,26 @@
+# `bs-flopflip`
+
+[BuckleScript](https://github.com/bucklescript/bucklescript) bindings for [flopflip](https://github.com/tdeekens/flopflip) packages - **WIP**
+
+## Install and setup
+
+#### yarn
+
+```bash
+$ yarn add bs-flopflip
+```
+
+#### bsconfig
+
+Add `bs-flopflip` to your `bs-dependencies`: **bsconfig.json**
+
+```json
+"bs-dependencies": [
+  "bs-flopflip",
+  ...
+]
+```
+
+## Usage
+
+_Coming soon_

--- a/packages/bs-flopflip/bsconfig.json
+++ b/packages/bs-flopflip/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "bs-flopflip",
+  "name": "@flopflip/bs-flopflip",
   "sources": [
     {
       "dir": "src",

--- a/packages/bs-flopflip/bsconfig.json
+++ b/packages/bs-flopflip/bsconfig.json
@@ -1,0 +1,26 @@
+{
+  "name": "bs-flopflip",
+  "sources": [
+    {
+      "dir": "src",
+      "public": "all"
+    },
+    {
+      "dir": "examples",
+      "type": "dev"
+    }
+  ],
+  "bs-dependencies": ["reason-react"],
+  "bsc-flags": ["-bs-super-errors"],
+  "reason": {
+    "react-jsx": 2
+  },
+  "refmt": 3,
+  "package-specs": [
+    {
+      "module": "es6",
+      "in-source": true
+    }
+  ],
+  "suffix": ".bs.js"
+}

--- a/packages/bs-flopflip/examples/react_broadcast.re
+++ b/packages/bs-flopflip/examples/react_broadcast.re
@@ -1,0 +1,48 @@
+/* Make all the module  */
+open ReactBroadcast;
+
+module UntoggledComponent = {
+  let component = ReasonReact.statelessComponent("UntoggledComponent");
+  let make = _children => {
+    ...component,
+    render: _self =>
+      <div>
+        (ReasonReact.stringToElement("At least there is a fallback!"))
+      </div>
+  };
+};
+
+/* ConfigureFlopFlip */
+module ExampleConfigureFlopFlip = {
+  let adapter: adapter = {
+    "configure": _args => Js.Promise.resolve(toAny("ok")),
+    "reconfigure": _args => Js.Promise.resolve(toAny("ok"))
+  };
+  let component = ReasonReact.statelessComponent("ExampleConfigureFlopFlip");
+  let make = _children => {
+    ...component,
+    render: _self =>
+      <ConfigureFlopFlip
+        adapter
+        adapterArgs={
+          "clientSideId": "123",
+          "user": Js.Nullable.return({"key": Js.Nullable.return("123")})
+        }>
+        <div />
+      </ConfigureFlopFlip>
+  };
+};
+
+/* ToggleFeature: https://github.com/tdeekens/flopflip#togglefeature */
+module ExampleToggleFeature = {
+  /* https://reasonml.github.io/reason-react/docs/en/component-as-prop.html */
+  let untoggledComponent = () => <UntoggledComponent />;
+  let component = ReasonReact.statelessComponent("ExampleToggleFeature");
+  let make = _children => {
+    ...component,
+    render: _self =>
+      <ToggleFeature flag="profile" untoggledComponent>
+        (ReasonReact.stringToElement("I might be gone or there!"))
+      </ToggleFeature>
+  };
+};

--- a/packages/bs-flopflip/package.json
+++ b/packages/bs-flopflip/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "bs-flopflip",
+  "name": "@flopflip/bs-flopflip",
   "version": "0.1.0",
   "description": "BuckleScript bindings for flopflip",
   "license": "MIT",

--- a/packages/bs-flopflip/package.json
+++ b/packages/bs-flopflip/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/tdeekens/flopflip#readme",
   "scripts": {
-    "prebuild": "npm run clean",
+    "prebuild": "bsb -clean-world",
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",

--- a/packages/bs-flopflip/package.json
+++ b/packages/bs-flopflip/package.json
@@ -1,0 +1,43 @@
+{
+  "private": true,
+  "name": "bs-flopflip",
+  "version": "0.1.0",
+  "description": "BuckleScript bindings for flopflip",
+  "license": "MIT",
+  "author": "Nicola Molinari <me@emmenko.org> (http://emmenko.org)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tdeekens/flopflip.git"
+  },
+  "bugs": {
+    "url": "https://github.com/tdeekens/flopflip/issues"
+  },
+  "homepage": "https://github.com/tdeekens/flopflip#readme",
+  "scripts": {
+    "prebuild": "npm run clean",
+    "build": "bsb -make-world",
+    "start": "bsb -make-world -w",
+    "clean": "bsb -clean-world",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "peerDependencies": {
+    "bs-platform": "^2.1.0"
+  },
+  "devDependencies": {
+    "@flopflip/react-broadcast": "*",
+    "bs-platform": "^2.1.0",
+    "reason-react": "^0.3.0"
+  },
+  "keywords": [
+    "feature-flags",
+    "feature-toggles",
+    "LaunchDarkly",
+    "client",
+    "reason",
+    "bucklescript",
+    "bindings"
+  ]
+}

--- a/packages/bs-flopflip/src/reactBroadcast.re
+++ b/packages/bs-flopflip/src/reactBroadcast.re
@@ -1,0 +1,131 @@
+type any;
+
+/* Since in ReasonReact we can't pass a component module as a prop (*),
+   we need to pass it as a function, which is still a React component.
+   https://reasonml.github.io/reason-react/docs/en/component-as-prop.html
+
+   (*) well, we kind of can 😅
+   [from the Discord channel:
+     "Sure you can, just give it a signature"
+     https://astrada.github.io/reason-react-playground/?reason=LYewJgrgNgpgBAFwJ4Ad4CUQQfAvHAbwCg45YE5gBDAaxgC44AKAPxSoQAt6BnBAJwCWAOwDmAGjhV+-KkiboYVHiGGKqAYwQA6fkq0BRWMBjCEASnNxcAPjjqVa-To0hgKVaYQKlj9Vu0+DhhYHh5JB1V-HWEQRQQqERgwAAV+EBRw+18o521NBEFVUJ5zAG4iAF8KolBIWHssHH5rQhIyGApXd08zVsinAsCEnBKAYTcPYS8mACJMbBh+WfL28kpaPGY9YTAlxiY66AwmmCtbbOVcob0CoxgTM3O7YlJSbQ-uqa9xdtI-uA7Pb8RgAfR4IQAZtYXgDSOt0ot+ABlEZbWbAJCo4KzCpvN5wyjgY6NRatV74t7rL69Cj4AbRYbBcaTWlzBY4FZ4ynwzobOitVjsLiSUEaTiCKBgHbPNo8-EfbQ06ZmX7ygnq0hA-ZwcFQmGE-EASAAPGBBAA3GyGt5Go0+K6DAJ8IRiAAqIHuj28iOa2JwcAA1IG4MLOJYbaRTQB6c1Wm2VQnVQmE7X8Q7Ehoc+CMbOrfGJnntZPJojRAAiAHkALKKXSmYEer1eADqgi4AEkwEx2ibs-xrQqPkwR0cs6dLAaeaa44PKUbSH3TqGOJxcLNo1RZnBo3PjYvsyuuOvowAjbe7m0m2OWmzmXvR-s2SSzFB6C2CGAAdy5QA
+   ]
+   */
+type reactClassForComponentProp = unit => ReasonReact.reactElement;
+
+type flagName = string;
+
+type flagVariation;
+
+type flag = {
+  .
+  "flag": flagName,
+  "variation": option(flagVariation)
+};
+
+type flags = Js.Dict.t(flagVariation);
+
+type adapterArgs = {
+  .
+  "clientSideId": string,
+  "user": Js.Nullable.t({. "key": Js.Nullable.t(string)})
+};
+
+type adapter = {
+  .
+  "configure": adapterArgs => Js.Promise.t(any),
+  "reconfigure": adapterArgs => Js.Promise.t(any)
+};
+
+/* Helpers */
+let optionToBool = optional =>
+  switch optional {
+  | Some(_) => true
+  | _ => false
+  };
+
+external toAny : 'a => any = "%identity";
+
+/* Module definitions (the actual bindings) */
+[@bs.module "@flopflip/react-broadcast"]
+external branchOnFeatureToggle :
+  (
+    ~flag: flag,
+    ~untoggledComponent: option(ReasonReact.reactClass)=?,
+    unit,
+    ReasonReact.reactClass
+  ) =>
+  ReasonReact.reactClass =
+  "branchOnFeatureToggle";
+
+[@bs.module "@flopflip/react-broadcast"]
+external injectFeatureToggle :
+  (
+    ~flagName: flagName,
+    ~propKey: option(string)=?,
+    unit,
+    ReasonReact.reactClass
+  ) =>
+  ReasonReact.reactClass =
+  "injectFeatureToggle";
+
+[@bs.module "@flopflip/react-broadcast"]
+external injectFeatureToggles :
+  (
+    ~flagNames: array(flagName),
+    ~propKey: option(string)=?,
+    unit,
+    ReasonReact.reactClass
+  ) =>
+  ReasonReact.reactClass =
+  "injectFeatureToggles";
+
+module ConfigureFlopFlip = {
+  [@bs.module "@flopflip/react-broadcast"]
+  external reactClass : ReasonReact.reactClass = "ConfigureFlopFlip";
+  let make =
+      (
+        ~shouldDeferAdapterConfiguration: option(bool)=?,
+        ~defaultFlags: option(flags)=?,
+        ~adapterArgs: adapterArgs,
+        ~adapter: adapter,
+        children
+      ) =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass,
+      ~props={
+        "shouldDeferAdapterConfiguration":
+          Js.Boolean.to_js_boolean(
+            optionToBool(shouldDeferAdapterConfiguration)
+          ),
+        "defaultFlags": Js.Null_undefined.from_opt(defaultFlags),
+        "adapterArgs": adapterArgs,
+        "adapter": adapter
+      },
+      children
+    );
+};
+
+module ToggleFeature = {
+  [@bs.module "@flopflip/react-broadcast"]
+  external reactClass : ReasonReact.reactClass = "ToggleFeature";
+  let make =
+      (
+        ~flag: flagName,
+        ~variation: option(flagVariation)=?,
+        ~untoggledComponent: option(reactClassForComponentProp)=?,
+        ~toggledComponent: option(reactClassForComponentProp)=?,
+        ~render: option(unit => ReasonReact.reactElement)=?,
+        children
+      ) =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass,
+      ~props={
+        "flag": flag,
+        "flagVariation": Js.Null_undefined.from_opt(variation),
+        "untoggledComponent": Js.Null_undefined.from_opt(untoggledComponent),
+        "toggledComponent": Js.Null_undefined.from_opt(toggledComponent),
+        "render": Js.Null_undefined.from_opt(render)
+      },
+      children
+    );
+};

--- a/packages/bs-flopflip/src/reactBroadcast.re
+++ b/packages/bs-flopflip/src/reactBroadcast.re
@@ -46,39 +46,6 @@ let optionToBool = optional =>
 external toAny : 'a => any = "%identity";
 
 /* Module definitions (the actual bindings) */
-[@bs.module "@flopflip/react-broadcast"]
-external branchOnFeatureToggle :
-  (
-    ~flag: flag,
-    ~untoggledComponent: option(ReasonReact.reactClass)=?,
-    unit,
-    ReasonReact.reactClass
-  ) =>
-  ReasonReact.reactClass =
-  "branchOnFeatureToggle";
-
-[@bs.module "@flopflip/react-broadcast"]
-external injectFeatureToggle :
-  (
-    ~flagName: flagName,
-    ~propKey: option(string)=?,
-    unit,
-    ReasonReact.reactClass
-  ) =>
-  ReasonReact.reactClass =
-  "injectFeatureToggle";
-
-[@bs.module "@flopflip/react-broadcast"]
-external injectFeatureToggles :
-  (
-    ~flagNames: array(flagName),
-    ~propKey: option(string)=?,
-    unit,
-    ReasonReact.reactClass
-  ) =>
-  ReasonReact.reactClass =
-  "injectFeatureToggles";
-
 module ConfigureFlopFlip = {
   [@bs.module "@flopflip/react-broadcast"]
   external reactClass : ReasonReact.reactClass = "ConfigureFlopFlip";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,6 +1384,10 @@ browserslist@^2.1.2:
     caniuse-lite "^1.0.30000760"
     electron-to-chromium "^1.3.27"
 
+bs-platform@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.1.0.tgz#63560ff8f7142c9c0631559df1c35590b9f6d8b2"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -5270,7 +5274,7 @@ react-display-name@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.0.tgz#0e1f7086e45a32d07764df35ed32ff16f1259790"
 
-react-dom@^16.2.0:
+"react-dom@>=15.0.0 || >=16.0.0", react-dom@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
@@ -5315,7 +5319,7 @@ react-test-renderer@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@^16.2.0:
+"react@>=15.0.0 || >=16.0.0", react@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
@@ -5404,6 +5408,13 @@ realpath-native@^1.0.0:
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
   dependencies:
     util.promisify "^1.0.0"
+
+reason-react@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.3.0.tgz#c3ad272ed2dd2757f6934fcaacba9b192b891f57"
+  dependencies:
+    react ">=15.0.0 || >=16.0.0"
+    react-dom ">=15.0.0 || >=16.0.0"
 
 recompose@^0.26.0:
   version "0.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,7 +70,7 @@
     common-tags "1.4.0"
     react-display-name "0.2.0"
 
-"@commitlint/cli@^5.2.6":
+"@commitlint/cli@^5.2.8":
   version "5.2.8"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-5.2.8.tgz#593e0d16d1d6ebba9994893a4cc933d1b212ae0c"
   dependencies:


### PR DESCRIPTION
This PR adds a new package `bs-flopflip` which is meant to contain all different [BuckleScript](https://bucklescript.github.io/) bindings to use those components in [ReasonML](https://reasonml.github.io/).

A binding is basically just the interop configuration between ReasonML <--> JS.

In this PR I focused on the bindings for the package `react-broadcast`. Please double check that the type definitions are exhaustive and the examples are correct.

> The Reason syntax should be fine, I haven't test the compiled JS though in a "real" react project.

If you want to see the output generated by BS, simply `cd` into the package and run `yarn start`. You will then see `*.bs.js` files next to the `*.re` files.

Feel free to comment in case you have any questions. 