### PR TITLE
Fixes CircleCI to run run-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,11 @@ aliases:
     name: Installing
     # Ignoring scripts (e.g. post-install) to gain more control
     # in the jobs to only e.g. build when explicitely needed.
-    command: yarn install --pure-lockfile --ignore-scripts
+    command: yarn install --pure-lockfile
 
   - &bootstrap
     name: Bootstraping
-    # Limiting the default concurrency (4) of lerna to 2
-    # as the build otherwise dies due to resouce restrictions.
-    command: yarn bootstrap --concurrency=2
+    command: yarn bootstrap
   
   - &lint
     name: Linting

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "name": "flopflip",
   "description": "Monorepository for flipflop and its projects e.g. react-redux, react and the wrapper",
   "scripts": {
-    "postinstall": "npm run bootstrap && npm run build",
-    "bootstrap": "check-node-version --package --print",
+    "postinstall": "npm run bootstrap",
+    "bootstrap": "check-node-version --package --print && npm run bootstrap:lerna",
+    "bootstrap:lerna": "lerna boostrap --concurrency=2",
     "develop": "jest --projects .jestrc.*.json --watch",
     "lint": "jest --config .jestrc.lint.json",
     "flow": "flow",


### PR DESCRIPTION
Run scripts were disabled as lerna died otherwise on CI with too much concurrency. The work around was to orchestrate more manually. However this now breaks for adding BuckleScript bindings. This is an attempt to fix the issue.