### PR TITLE
Remove unnecessary `lerna bootstrap` command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,6 @@ aliases:
     # Ignoring scripts (e.g. post-install) to gain more control
     # in the jobs to only e.g. build when explicitely needed.
     command: yarn install --pure-lockfile
-
-  - &bootstrap
-    name: Bootstraping
-    command: yarn bootstrap
   
   - &lint
     name: Linting
@@ -75,7 +71,6 @@ jobs:
       - checkout
       - run: *install
       - restore-cache: *restore_yarn_cache
-      - run: *bootstrap
       - run: *build
   lint:
     <<: *node8Environment
@@ -83,7 +78,6 @@ jobs:
       - checkout
       - restore-cache: *restore_yarn_cache
       - run: *install
-      - run: *bootstrap
       - run: *lint
   type_check:
     <<: *node8Environment
@@ -91,7 +85,6 @@ jobs:
       - checkout
       - restore-cache: *restore_yarn_cache
       - run: *install
-      - run: *bootstrap
       - run: *build
       - run: *type_check
   build_test_unit_node_6:
@@ -100,7 +93,6 @@ jobs:
       - checkout
       - restore-cache: *restore_yarn_cache
       - run: *install
-      - run: *bootstrap
       - run: *build
       - run: *unit_test
   build_test_unit_node_8:
@@ -109,7 +101,6 @@ jobs:
       - checkout
       - restore-cache: *restore_yarn_cache
       - run: *install
-      - run: *bootstrap
       - run: *build
       - run: *unit_test_with_coverage
 

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+workspaces-experimental true

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "name": "flopflip",
   "description": "Monorepository for flipflop and its projects e.g. react-redux, react and the wrapper",
   "scripts": {
-    "postinstall": "npm run bootstrap",
-    "bootstrap": "check-node-version --package --print && npm run bootstrap:lerna",
-    "bootstrap:lerna": "lerna boostrap --concurrency=2",
+    "postinstall": "check-node-version --package --print",
     "develop": "jest --projects .jestrc.*.json --watch",
     "lint": "jest --config .jestrc.lint.json",
     "flow": "flow",


### PR DESCRIPTION
When using yarn workspaces, it's not necessary to run `lerna bootstrap`
as it might get into an infinite loop when execute on postinstall step.
See https://github.com/lerna/lerna/issues/1125 and related issues

In case the prepublish and prepare script hooks need to be executed, you
can simply trigger those "manually" in the postinstall script.
```
"postinstall": "check-node-version --package --print && lerna run prepublish && lerna run prepare"
```

Side note: is the `build` step supposed to be executed separately from the "installation" step?

```
$ yarn
$ yarn build
```