### PR TITLE
Fix UMD builds caused by flow and rollup in combination with imports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -47,7 +47,7 @@
         "react",
         "flow"
       ],
-      "plugins": ["external-helpers", "babel-plugin-transform-flow-strip-types"]
+      "plugins": ["external-helpers"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "^6.24.1",
-    "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-flow": "^6.23.0",
     "check-node-version": "^3.1.1",
     "codecov": "^3.0.0",
@@ -88,6 +87,7 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify": "^2.0.1",
+    "rollup-plugin-flow": "^1.1.1",
     "rollup-watch": "^4.3.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
       "npm run format:js",
       "git add"
     ],
+    "packages/**/*.js": [
+      "npm run fix:eslint",
+      "npm run format:js",
+      "git add"
+    ],
     "packages/**/*.ts": [
       "npm run format:ts",
       "git add"

--- a/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -2,7 +2,7 @@
 
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
-import * as React from 'react';
+import React, { type ComponentType } from 'react';
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
 import { branchOnFeatureToggle, DEFAULT_FLAG_PROP_KEY } from '@flopflip/react';
 import injectFeatureToggle from './../inject-feature-toggle';
@@ -12,10 +12,8 @@ type ProvidedProps = {};
 
 export default <RequiredProps, ProvidedProps>(
   { flag, variation }: { flag: FlagName, variation?: FlagVariation },
-  UntoggledComponent?: React.ComponentType<any>
-) => (
-  WrappedComponent: React.ComponentType<$Diff<RequiredProps, ProvidedProps>>
-) =>
+  UntoggledComponent?: ComponentType<any>
+) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   compose(
     setDisplayName(wrapDisplayName(WrappedComponent, 'branchOnFeatureToggle')),
     injectFeatureToggle(flag),

--- a/packages/react-broadcast/modules/components/configure/configure.js
+++ b/packages/react-broadcast/modules/components/configure/configure.js
@@ -9,6 +9,7 @@ import type {
 } from '@flopflip/types';
 
 import * as React from 'react';
+import { PureComponent } from 'react';
 import { FlagsSubscription } from '@flopflip/react';
 import { Broadcast } from 'react-broadcast';
 import { FLAGS_CHANNEL } from '../../constants';
@@ -24,7 +25,7 @@ type State = {
   flags: Flags,
 };
 
-export default class Configure extends React.PureComponent<Props, State> {
+export default class Configure extends PureComponent<Props, State> {
   static displayName = 'ConfigureFlopflip';
 
   static defaultProps = {

--- a/packages/react-broadcast/modules/components/configure/configure.js
+++ b/packages/react-broadcast/modules/components/configure/configure.js
@@ -8,14 +8,13 @@ import type {
   AdapterStatus,
 } from '@flopflip/types';
 
-import * as React from 'react';
-import { PureComponent } from 'react';
+import React, { PureComponent, type ComponentType, type Node } from 'react';
 import { FlagsSubscription } from '@flopflip/react';
 import { Broadcast } from 'react-broadcast';
 import { FLAGS_CHANNEL } from '../../constants';
 
 type Props = {
-  children: React.Node,
+  children: Node,
   shouldDeferAdapterConfiguration?: boolean,
   defaultFlags?: Flags,
   adapterArgs: AdapterArgs,
@@ -50,7 +49,7 @@ export default class Configure extends PureComponent<Props, State> {
   handleUpdateStatus = (status: AdapterStatus): void =>
     this.setState(prevState => ({ ...prevState, ...status }));
 
-  render(): React.Node {
+  render(): Node {
     return (
       <FlagsSubscription
         adapter={this.props.adapter}

--- a/packages/react-broadcast/modules/components/feature-toggled/index.js
+++ b/packages/react-broadcast/modules/components/feature-toggled/index.js
@@ -1,16 +1,15 @@
 // @flow
 
-import * as React from 'react';
-import { PureComponent } from 'react';
+import React, { PureComponent, type ComponentType, type Node } from 'react';
 import warning from 'warning';
 import ToggleFeature from '../toggle-feature';
 
 type Props = {
-  children?: React.Node,
+  children?: Node,
 };
 
 export default class FeatureToggled extends PureComponent<Props> {
-  render(): React.Element<any> {
+  render(): Node {
     warning(
       false,
       '`<FeatureToggled />` has been deprecated, please us `<ToggleFeature />`'

--- a/packages/react-broadcast/modules/components/feature-toggled/index.js
+++ b/packages/react-broadcast/modules/components/feature-toggled/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react';
+import { PureComponent } from 'react';
 import warning from 'warning';
 import ToggleFeature from '../toggle-feature';
 
@@ -8,7 +9,7 @@ type Props = {
   children?: React.Node,
 };
 
-export default class FeatureToggled extends React.PureComponent<Props> {
+export default class FeatureToggled extends PureComponent<Props> {
   render(): React.Element<any> {
     warning(
       false,

--- a/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -2,7 +2,7 @@
 
 import type { FlagName } from '@flopflip/types';
 
-import * as React from 'react';
+import React, { type ComponentType } from 'react';
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
 import { injectFeatureToggle, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
 import withFlagSubscription from '../with-flag-subscription/';
@@ -13,9 +13,7 @@ type ProvidedProps = {};
 export default <RequiredProps, ProvidedProps>(
   flagName: FlagName,
   propKey?: string
-) => (
-  WrappedComponent: React.ComponentType<$Diff<RequiredProps, ProvidedProps>>
-) =>
+) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   compose(
     setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggle')),
     withFlagSubscription(ALL_FLAGS_PROP_KEY),

--- a/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -2,7 +2,7 @@
 
 import type { FlagName } from '@flopflip/types';
 
-import * as React from 'react';
+import React, { type ComponentType } from 'react';
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
 import { injectFeatureToggles, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
 import withFlagSubscription from '../with-flag-subscription/';
@@ -18,9 +18,7 @@ export default <RequiredProps, ProvidedProps>(
     ownProps: ProvidedProps,
     propKey: string
   ) => boolean
-) => (
-  WrappedComponent: React.ComponentType<$Diff<RequiredProps, ProvidedProps>>
-) =>
+) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   compose(
     setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggles')),
     withFlagSubscription(ALL_FLAGS_PROP_KEY),

--- a/packages/react-broadcast/modules/components/with-flag-subscription/with-flag-subscription.js
+++ b/packages/react-broadcast/modules/components/with-flag-subscription/with-flag-subscription.js
@@ -3,6 +3,7 @@
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
 import * as React from 'react';
+import { PureComponent } from 'react';
 import { wrapDisplayName } from 'recompose';
 import { Subscriber } from 'react-broadcast';
 import { FLAGS_CHANNEL } from '../../constants';
@@ -13,7 +14,7 @@ type ProvidedProps = {};
 const withFlagSubscription = (propKey: string) => (
   WrappedComponent: React.ComponentType<RequiredProps>
 ) => {
-  class WithFlagSubscription extends React.PureComponent<
+  class WithFlagSubscription extends PureComponent<
     $Diff<RequiredProps, ProvidedProps>
   > {
     static displayName = wrapDisplayName(

--- a/packages/react-broadcast/modules/components/with-flag-subscription/with-flag-subscription.js
+++ b/packages/react-broadcast/modules/components/with-flag-subscription/with-flag-subscription.js
@@ -2,8 +2,7 @@
 
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
-import * as React from 'react';
-import { PureComponent } from 'react';
+import React, { PureComponent, type ComponentType, type Node } from 'react';
 import { wrapDisplayName } from 'recompose';
 import { Subscriber } from 'react-broadcast';
 import { FLAGS_CHANNEL } from '../../constants';
@@ -12,7 +11,7 @@ type RequiredProps = {};
 type ProvidedProps = {};
 
 const withFlagSubscription = (propKey: string) => (
-  WrappedComponent: React.ComponentType<RequiredProps>
+  WrappedComponent: ComponentType<RequiredProps>
 ) => {
   class WithFlagSubscription extends PureComponent<
     $Diff<RequiredProps, ProvidedProps>
@@ -21,7 +20,7 @@ const withFlagSubscription = (propKey: string) => (
       WrappedComponent,
       'withFlagSubscription'
     );
-    render(): React.Node {
+    render(): Node {
       return (
         <Subscriber channel={FLAGS_CHANNEL}>
           {data => (

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -2,7 +2,7 @@
 
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
-import * as React from 'react';
+import React, { type ComponentType } from 'react';
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
 import { branchOnFeatureToggle, DEFAULT_FLAG_PROP_KEY } from '@flopflip/react';
 import injectFeatureToggle from './../inject-feature-toggle';
@@ -12,10 +12,8 @@ type ProvidedProps = {};
 
 export default <RequiredProps, ProvidedProps>(
   { flag, variation }: { flag: FlagName, variation: FlagVariation },
-  UntoggledComponent: React.ComponentType<any>
-) => (
-  WrappedComponent: React.ComponentType<$Diff<RequiredProps, ProvidedProps>>
-) =>
+  UntoggledComponent: ComponentType<any>
+) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   compose(
     setDisplayName(wrapDisplayName(WrappedComponent, 'branchOnFeatureToggle')),
     injectFeatureToggle(flag),

--- a/packages/react-redux/modules/components/configure/configure.js
+++ b/packages/react-redux/modules/components/configure/configure.js
@@ -8,6 +8,7 @@ import type {
 } from '@flopflip/types';
 
 import * as React from 'react';
+import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { FlagsSubscription } from '@flopflip/react';
 import { updateStatus, updateFlags } from './../../ducks';
@@ -27,10 +28,7 @@ type State = {
   flags: Flags,
 };
 
-export class Configure extends React.PureComponent<
-  Props & ConnectedProps,
-  State
-> {
+export class Configure extends PureComponent<Props & ConnectedProps, State> {
   static displayName = 'ConfigureFlopflip';
 
   static defaultProps = {

--- a/packages/react-redux/modules/components/configure/configure.js
+++ b/packages/react-redux/modules/components/configure/configure.js
@@ -7,14 +7,13 @@ import type {
   AdapterStatus,
 } from '@flopflip/types';
 
-import * as React from 'react';
-import { PureComponent } from 'react';
+import React, { PureComponent, type ComponentType, type Node } from 'react';
 import { connect } from 'react-redux';
 import { FlagsSubscription } from '@flopflip/react';
 import { updateStatus, updateFlags } from './../../ducks';
 
 type Props = {
-  children?: React.Node,
+  children?: Node,
   shouldDeferAdapterConfiguration?: boolean,
   defaultFlags?: Flags,
   adapterArgs: AdapterArgs,
@@ -37,7 +36,7 @@ export class Configure extends PureComponent<Props & ConnectedProps, State> {
     shouldDeferAdapterConfiguration: false,
   };
 
-  render(): React.Node {
+  render(): Node {
     return (
       <FlagsSubscription
         adapter={this.props.adapter}

--- a/packages/react-redux/modules/components/feature-toggled/index.js
+++ b/packages/react-redux/modules/components/feature-toggled/index.js
@@ -1,16 +1,15 @@
 // @flow
 
-import * as React from 'react';
-import { PureComponent } from 'react';
+import React, { PureComponent, type ComponentType, type Node } from 'react';
 import warning from 'warning';
 import ToggleFeature from '../toggle-feature';
 
 type Props = {
-  children?: React.Node,
+  children?: Node,
 };
 
 export default class FeatureToggled extends PureComponent<Props> {
-  render(): React.Element<any> {
+  render(): Node {
     warning(
       false,
       '`<FeatureToggled />` has been deprecated, please us `<ToggleFeature />`'

--- a/packages/react-redux/modules/components/feature-toggled/index.js
+++ b/packages/react-redux/modules/components/feature-toggled/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react';
+import { PureComponent } from 'react';
 import warning from 'warning';
 import ToggleFeature from '../toggle-feature';
 
@@ -8,7 +9,7 @@ type Props = {
   children?: React.Node,
 };
 
-export default class FeatureToggled extends React.PureComponent<Props> {
+export default class FeatureToggled extends PureComponent<Props> {
   render(): React.Element<any> {
     warning(
       false,

--- a/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -2,7 +2,7 @@
 
 import type { FlagName } from '@flopflip/types';
 
-import * as React from 'react';
+import React, { type ComponentType } from 'react';
 import { connect } from 'react-redux';
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
 import { selectFlags } from '../../ducks';
@@ -17,7 +17,7 @@ export const mapStateToProps = (state: mixed) => ({
 });
 
 export default (flagName: FlagName, propKey?: string) => (
-  WrappedComponent: React.ComponentType<$Diff<RequiredProps, ProvidedProps>>
+  WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>
 ) =>
   /* istanbul ignore next */
   compose(

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -2,7 +2,7 @@
 
 import type { FlagName } from '@flopflip/types';
 
-import * as React from 'react';
+import React, { type ComponentType } from 'react';
 import { connect } from 'react-redux';
 import { compose, setDisplayName, wrapDisplayName } from 'recompose';
 import { selectFlags } from '../../ducks';
@@ -24,9 +24,7 @@ export default (
     ownProps: ProvidedProps,
     propKey: string
   ) => boolean
-) => (
-  WrappedComponent: React.ComponentType<$Diff<RequiredProps, ProvidedProps>>
-) =>
+) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   /* istanbul ignore next */
   compose(
     setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggles')),

--- a/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -2,16 +2,16 @@
 
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
-import * as React from 'react';
+import React, { type ComponentType } from 'react';
 import { branch, renderNothing, renderComponent } from 'recompose';
 import isFeatureEnabled from '../../helpers/is-feature-enabled';
 import { DEFAULT_FLAG_PROP_KEY } from '../../constants';
 
 const branchOnFeatureToggle = (
-  UntoggledComponent: React.ComponentType<any>,
+  UntoggledComponent: ComponentType<any>,
   flagName: FlagName = DEFAULT_FLAG_PROP_KEY,
   flagVariation: FlagVariation = true
-): React.ComponentType<any> =>
+): ComponentType<any> =>
   branch(
     props => !isFeatureEnabled(flagName, flagVariation)(props),
     UntoggledComponent ? renderComponent(UntoggledComponent) : renderNothing

--- a/packages/react/modules/components/flags-subscription/flags-subscription.js
+++ b/packages/react/modules/components/flags-subscription/flags-subscription.js
@@ -9,6 +9,7 @@ import type {
 } from '@flopflip/types';
 
 import * as React from 'react';
+import { PureComponent } from 'react';
 
 export const AdapterStates: {
   UNCONFIGURED: string,
@@ -29,7 +30,7 @@ type Props = {
 };
 type AdapterState = $Values<typeof AdapterStates>;
 
-export default class FlagsSubscription extends React.PureComponent<Props> {
+export default class FlagsSubscription extends PureComponent<Props> {
   static defaultProps = {
     shouldDeferAdapterConfiguration: false,
     children: null,

--- a/packages/react/modules/components/flags-subscription/flags-subscription.js
+++ b/packages/react/modules/components/flags-subscription/flags-subscription.js
@@ -8,8 +8,7 @@ import type {
   AdapterArgs,
 } from '@flopflip/types';
 
-import * as React from 'react';
-import { PureComponent } from 'react';
+import React, { PureComponent, type Node } from 'react';
 
 export const AdapterStates: {
   UNCONFIGURED: string,
@@ -83,7 +82,7 @@ export default class FlagsSubscription extends PureComponent<Props> {
     }
   }
 
-  render(): React.Node {
+  render(): Node {
     return React.Children.only(this.props.children);
   }
 }

--- a/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -2,7 +2,7 @@
 
 import type { FlagName, FlagValue } from '@flopflip/types';
 
-import * as React from 'react';
+import React, { type ComponentType } from 'react';
 import { compose, withProps } from 'recompose';
 import isNil from 'lodash.isnil';
 import { omitProps } from '../../hocs';
@@ -14,7 +14,7 @@ type ProvidedProps = {};
 const injectFeatureToggle = (
   flagName: FlagName,
   propKey: string = DEFAULT_FLAG_PROP_KEY
-): React.ComponentType<$Diff<RequiredProps, ProvidedProps>> =>
+): ComponentType<$Diff<RequiredProps, ProvidedProps>> =>
   compose(
     withProps((props: RequiredProps) => {
       const flagValue: FlagValue = props[ALL_FLAGS_PROP_KEY][flagName];

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -2,7 +2,7 @@
 
 import type { FlagName, Flags, Flag } from '@flopflip/types';
 
-import * as React from 'react';
+import React, { type ComponentType } from 'react';
 
 import { compose, withProps, shouldUpdate, shallowEqual } from 'recompose';
 import intersection from 'lodash.intersection';
@@ -48,7 +48,7 @@ const injectFeatureToggles = (
     ownProps: ProvidedProps,
     propKey: string
   ) => boolean = areOwnPropsEqual
-): React.ComponentType<$Diff<RequiredProps, ProvidedProps>> =>
+): ComponentType<$Diff<RequiredProps, ProvidedProps>> =>
   compose(
     withProps((props: RequiredProps) => ({
       [propKey]: filterFeatureToggles(props[ALL_FLAGS_PROP_KEY], flagNames),

--- a/packages/react/modules/components/switch-feature/switch-feature.js
+++ b/packages/react/modules/components/switch-feature/switch-feature.js
@@ -8,20 +8,19 @@ import type {
   AdapterArgs,
 } from '@flopflip/types';
 
-import * as React from 'react';
-import { PureComponent } from 'react';
+import React, { PureComponent, type Node, type Element } from 'react';
 
 type Props = {
-  children: React.Node,
+  children: Node,
 };
 
-const isEmptyChildren = (children: React.Node): boolean =>
+const isEmptyChildren = (children: Node): boolean =>
   React.Children.count(children) === 0;
 
 export default class SwitchFeature extends PureComponent<Props> {
-  render(): React.Node {
+  render(): Node {
     let variate: ?FlagVariation;
-    let child: ?React.Element<any>;
+    let child: ?Element<any>;
     React.Children.forEach(this.props.children, element => {
       if (variate == null && React.isValidElement(element)) {
         child = element;

--- a/packages/react/modules/components/switch-feature/switch-feature.js
+++ b/packages/react/modules/components/switch-feature/switch-feature.js
@@ -9,6 +9,7 @@ import type {
 } from '@flopflip/types';
 
 import * as React from 'react';
+import { PureComponent } from 'react';
 
 type Props = {
   children: React.Node,
@@ -17,7 +18,7 @@ type Props = {
 const isEmptyChildren = (children: React.Node): boolean =>
   React.Children.count(children) === 0;
 
-export default class SwitchFeature extends React.PureComponent<Props> {
+export default class SwitchFeature extends PureComponent<Props> {
   render(): React.Node {
     let variate: ?FlagVariation;
     let child: ?React.Element<any>;

--- a/packages/react/modules/components/toggle-feature/toggle-feature.js
+++ b/packages/react/modules/components/toggle-feature/toggle-feature.js
@@ -9,6 +9,7 @@ import type {
 } from '@flopflip/types';
 
 import * as React from 'react';
+import { PureComponent } from 'react';
 
 type Props = {
   untoggledComponent: React.ComponentType<any>,
@@ -21,7 +22,7 @@ type Props = {
 const isEmptyChildren = (children: React.Node): boolean =>
   React.Children.count(children) === 0;
 
-export default class ToggleFeature extends React.PureComponent<Props> {
+export default class ToggleFeature extends PureComponent<Props> {
   static displayName = 'ToggleFeature';
 
   static defaultProps = {

--- a/packages/react/modules/components/toggle-feature/toggle-feature.js
+++ b/packages/react/modules/components/toggle-feature/toggle-feature.js
@@ -8,18 +8,17 @@ import type {
   AdapterArgs,
 } from '@flopflip/types';
 
-import * as React from 'react';
-import { PureComponent } from 'react';
+import React, { PureComponent, type ComponentType, type Node } from 'react';
 
 type Props = {
-  untoggledComponent: React.ComponentType<any>,
-  toggledComponent: React.ComponentType<any>,
-  render: () => React.Node,
-  children: ({ isFeatureEnabled: boolean }) => React.Node,
+  untoggledComponent: ComponentType<any>,
+  toggledComponent: ComponentType<any>,
+  render: () => Node,
+  children: ({ isFeatureEnabled: boolean }) => Node,
   isFeatureEnabled: boolean,
 };
 
-const isEmptyChildren = (children: React.Node): boolean =>
+const isEmptyChildren = (children: Node): boolean =>
   React.Children.count(children) === 0;
 
 export default class ToggleFeature extends PureComponent<Props> {
@@ -32,7 +31,7 @@ export default class ToggleFeature extends PureComponent<Props> {
     children: null,
   };
 
-  render(): React.Node {
+  render(): Node {
     if (this.props.isFeatureEnabled) {
       if (this.props.toggledComponent)
         return React.createElement(this.props.toggledComponent);

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,7 @@ const uglify = require('rollup-plugin-uglify');
 const json = require('rollup-plugin-json');
 const builtins = require('rollup-plugin-node-builtins');
 const globals = require('rollup-plugin-node-globals');
+const flow = require('rollup-plugin-flow');
 const filesize = require('rollup-plugin-filesize');
 
 const env = process.env.NODE_ENV;
@@ -40,6 +41,7 @@ const config = {
       ignoreGlobal: true,
       exclude: ['packages/**'],
     }),
+    flow({ all: true }),
     babel({
       exclude: ['node_modules/**'],
       babelrc: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,7 +1218,7 @@ babylon@7.0.0-beta.31:
   version "7.0.0-beta.31"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
 
-babylon@^6.18.0:
+babylon@^6.15.0, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
@@ -2771,6 +2771,13 @@ flexbuffer@0.0.6:
 flow-bin@^0.62.0:
   version "0.62.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.62.0.tgz#14bca669a6e3f95c0bc0c2d1eb55ec4e98cb1d83"
+
+flow-remove-types@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/flow-remove-types/-/flow-remove-types-1.2.3.tgz#6131aefc7da43364bb8b479758c9dec7735d1a18"
+  dependencies:
+    babylon "^6.15.0"
+    vlq "^0.2.1"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -5690,6 +5697,13 @@ rollup-plugin-filesize@^1.5.0:
     filesize "^3.5.6"
     gzip-size "^3.0.0"
 
+rollup-plugin-flow@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-flow/-/rollup-plugin-flow-1.1.1.tgz#6ce568f1dd559666b77ab76b4bae251407528db6"
+  dependencies:
+    flow-remove-types "^1.1.0"
+    rollup-pluginutils "^1.5.1"
+
 rollup-plugin-includepaths@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-includepaths/-/rollup-plugin-includepaths-0.2.2.tgz#4b688f220aba88c682e3846b653ddd2eb107f1ac"
@@ -5743,7 +5757,7 @@ rollup-plugin-uglify@^2.0.1:
   dependencies:
     uglify-js "^3.0.9"
 
-rollup-pluginutils@^1.5.0, rollup-pluginutils@^1.5.2:
+rollup-pluginutils@^1.5.0, rollup-pluginutils@^1.5.1, rollup-pluginutils@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:


### PR DESCRIPTION
This literally ended a hour long journey.

In combination with rollup importing `import * as React from 'react'` instead of `import React from 'react'` causes an UMD bundle get receive code in `"var React__default = React['default'];"` rather than `"var React__default = 'default' in React ? React['default'] : React;"` in the factory of the UMD bundle. Causing the my library to not work. Being aware that I could import types separately from the packages which is not mentioned in the docs of flow solved this for me.
  