### PR TITLE
Update package.json

### DIFF
--- a/packages/localstorage-adapter/package.json
+++ b/packages/localstorage-adapter/package.json
@@ -10,7 +10,7 @@
     "build": "cross-env npm run build:es && npm run build:cjs",
     "build:watch": "cross-env npm run build:es -- -w",
     "build:es": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js -f es -i modules/index.js -o dist/@flopflip-localstorage-adapter.es.js",
-    "build:cjs": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js -f cjs -i modules/index.js -o dist/@flopflip-launchdarkly-adapter.cjs.js"
+    "build:cjs": "cross-env NODE_ENV=development rollup -c ../../rollup.config.js -f cjs -i modules/index.js -o dist/@flopflip-localstorage-adapter.cjs.js"
   },
   "files": [
     "readme.md",


### PR DESCRIPTION
the `build:cjs` script was wrongly referencing `launchdarkly-adapter`, which resulted in an error when importing the module (since `main` references `dist/@flopflip-localstorage-adapter.cjs.js`)