### PR TITLE
Update `launchdarkly-adapter` to utilize updated API of LD `js-client`

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.js
@@ -15,7 +15,7 @@ import camelCase from 'lodash.camelcase';
 type Client = {
   identify: (nextUser: User) => Promise<Object>,
   waitUntilReady: () => Promise<any>,
-  on: (state: string, (flagName: FlagName) => void) => void,
+  on: (eventName: string, (flagName: FlagName) => void) => void,
   allFlags: () => Flags | null,
 };
 type AdapterState = {

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.js
@@ -52,13 +52,13 @@ const subscribeToFlagsChanges = ({
       adapterState.client
     ) {
       adapterState.client.on(`change:${flagName}`, flagValue => {
-        const [normalzedFlagName, normalzedFlagValue] = normalizeFlag(
+        const [normalizedFlagName, normalizedFlagValue] = normalizeFlag(
           flagName,
           flagValue
         );
 
         onFlagsStateChange({
-          [normalzedFlagName]: normalzedFlagValue,
+          [normalizedFlagName]: normalizedFlagValue,
         });
       });
     }

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -10,6 +10,7 @@ const flags = { 'some-flag-1': true, 'some-flag-2': false };
 
 jest.mock('ldclient-js', () => ({
   initialize: jest.fn(() => ({
+    waitUntilReady: jest.fn(() => Promise.resolve()),
     on: jest.fn((_, cb) => cb()),
     allFlags: jest.fn(() => ({})),
   })),
@@ -77,6 +78,7 @@ describe('when configuring', () => {
       onStatusStateChange = jest.fn();
       onFlagsStateChange = jest.fn();
       client = {
+        waitUntilReady: jest.fn(() => Promise.resolve()),
         on: jest.fn((_, cb) => cb()),
         allFlags: jest.fn(() => flags),
       };
@@ -149,7 +151,8 @@ describe('when configuring', () => {
 
       beforeEach(() => {
         client = {
-          identify: jest.fn(),
+          identify: jest.fn(() => Promise.resolve()),
+          waitUntilReady: jest.fn(() => Promise.resolve()),
           on: jest.fn((_, cb) => cb()),
           allFlags: jest.fn(() => ({})),
         };
@@ -179,7 +182,8 @@ describe('when configuring', () => {
 
       beforeEach(() => {
         client = {
-          identify: jest.fn(),
+          identify: jest.fn(() => Promise.resolve()),
+          waitUntilReady: jest.fn(() => Promise.resolve()),
           on: jest.fn((_, cb) => cb()),
           allFlags: jest.fn(() => ({})),
         };
@@ -196,7 +200,7 @@ describe('when configuring', () => {
 
       describe('with partial prop update', () => {
         beforeEach(() => {
-          adapter.updateUserContext(updatedUserProps);
+          return adapter.updateUserContext(updatedUserProps);
         });
 
         it('should invoke `identify` on the client with the updated props', () => {
@@ -214,7 +218,10 @@ describe('when configuring', () => {
 
       describe('with full prop update', () => {
         beforeEach(() => {
-          adapter.updateUserContext({ ...userWithKey, ...updatedUserProps });
+          return adapter.updateUserContext({
+            ...userWithKey,
+            ...updatedUserProps,
+          });
         });
 
         it('should invoke `identify` on the client with the full props', () => {

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -7,14 +7,15 @@ const userWithoutKey = {
   group: 'foo-group',
 };
 const flags = { 'some-flag-1': true, 'some-flag-2': false };
+const createClient = jest.fn(apiOverwrites => ({
+  waitUntilReady: jest.fn(() => Promise.resolve()),
+  on: jest.fn((_, cb) => cb()),
+  allFlags: jest.fn(() => ({})),
 
-jest.mock('ldclient-js', () => ({
-  initialize: jest.fn(() => ({
-    waitUntilReady: jest.fn(() => Promise.resolve()),
-    on: jest.fn((_, cb) => cb()),
-    allFlags: jest.fn(() => ({})),
-  })),
+  ...apiOverwrites,
 }));
+
+jest.mock('ldclient-js');
 
 describe('when configuring', () => {
   let onStatusStateChange;
@@ -23,6 +24,8 @@ describe('when configuring', () => {
   beforeEach(() => {
     onStatusStateChange = jest.fn();
     onFlagsStateChange = jest.fn();
+
+    ldClient.initialize.mockReturnValue(createClient());
   });
 
   describe('when reconfiguring before configured', () => {
@@ -77,11 +80,9 @@ describe('when configuring', () => {
     beforeEach(() => {
       onStatusStateChange = jest.fn();
       onFlagsStateChange = jest.fn();
-      client = {
-        waitUntilReady: jest.fn(() => Promise.resolve()),
-        on: jest.fn((_, cb) => cb()),
+      client = createClient({
         allFlags: jest.fn(() => flags),
-      };
+      });
 
       ldClient.initialize.mockReturnValue(client);
 
@@ -150,12 +151,9 @@ describe('when configuring', () => {
       let client;
 
       beforeEach(() => {
-        client = {
+        client = createClient({
           identify: jest.fn(() => Promise.resolve()),
-          waitUntilReady: jest.fn(() => Promise.resolve()),
-          on: jest.fn((_, cb) => cb()),
-          allFlags: jest.fn(() => ({})),
-        };
+        });
 
         ldClient.initialize.mockReturnValue(client);
 
@@ -181,12 +179,9 @@ describe('when configuring', () => {
       };
 
       beforeEach(() => {
-        client = {
+        client = createClient({
           identify: jest.fn(() => Promise.resolve()),
-          waitUntilReady: jest.fn(() => Promise.resolve()),
-          on: jest.fn((_, cb) => cb()),
-          allFlags: jest.fn(() => ({})),
-        };
+        });
 
         ldClient.initialize.mockReturnValue(client);
 


### PR DESCRIPTION
The `js-client` of LaunchDarkly recently update its API with `waitUntilReady` and `identify` to return a Promise. This can simplify the adapter a little.