### PR TITLE
Fix launchdarkly splitio adapter reconfiguring without user

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.js
@@ -180,7 +180,7 @@ const reconfigure = ({
       )
     );
 
-  if (adapterState.user.key !== user.key) {
+  if (adapterState.user && adapterState.user.key !== user.key) {
     adapterState.user = ensureUser(user);
 
     return changeUserContext(adapterState.user);

--- a/packages/splitio-adapter/modules/adapter/adapter.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.js
@@ -227,7 +227,7 @@ const reconfigure = ({
           '@flopflip/splitio-adapter: please configure adapter before reconfiguring.'
         )
       );
-    if (adapterState.user.key !== user.key) {
+    if (adapterState.user && adapterState.user.key !== user.key) {
       let flagNames: Array<FlagName>;
       let flags: Flags;
 


### PR DESCRIPTION
This pull request aims to fix a bug reported in #187. When reconfiguring with a non-existing user the check would cause the adapter to throw.

Closes #195 