### PR TITLE
Add reference when non normalised flag names are encountered

### DIFF
--- a/packages/react/modules/helpers/is-feature-enabled/is-feature-enabled.js
+++ b/packages/react/modules/helpers/is-feature-enabled/is-feature-enabled.js
@@ -1,3 +1,5 @@
+import camelCase from 'lodash.camelcase';
+import warning from 'warning';
 import { DEFAULT_FLAG_PROP_KEY } from '../../constants';
 
 /**
@@ -12,6 +14,13 @@ import { DEFAULT_FLAG_PROP_KEY } from '../../constants';
 const isFeatureEnabled = (
   flagName = DEFAULT_FLAG_PROP_KEY,
   flagVariation = true
-) => props => props[flagName] === flagVariation;
+) => {
+  warning(
+    flagName === camelCase(flagName),
+    '@flopflip/react: passed flag name does not seem to be normalized which may result in unexpected toggling. Please refer to our readme for more information: https://github.com/tdeekens/flopflip#flag-normalization'
+  );
+
+  return props => props[flagName] === flagVariation;
+};
 
 export default isFeatureEnabled;

--- a/packages/react/modules/helpers/is-feature-enabled/is-feature-enabled.spec.js
+++ b/packages/react/modules/helpers/is-feature-enabled/is-feature-enabled.spec.js
@@ -1,4 +1,7 @@
+import warning from 'warning';
 import isFeatureEnabled from './is-feature-enabled';
+
+jest.mock('warning');
 
 describe('with existing flag', () => {
   describe('with flag variation', () => {
@@ -23,6 +26,20 @@ describe('with existing flag', () => {
       const props = { fooFlag: false };
       expect(isFeatureEnabled('fooFlag')(props)).toBe(false);
     });
+  });
+});
+
+describe('with non normalized flag', () => {
+  it('should indicate feature being disabled', () => {
+    const props = { fooFlag: true };
+    expect(isFeatureEnabled('foo-flag')(props)).toBe(false);
+  });
+
+  it('should invoke `warning`', () => {
+    const props = { fooFlag: false };
+    isFeatureEnabled('fooFlag')(props);
+
+    expect(warning).toHaveBeenCalled();
   });
 });
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,9 +37,11 @@
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "enzyme-to-json": "3.3.1",
+    "lodash.camelcase": "^4.3.0",
     "react": "16.2.0",
     "react-dom": "16.2.0",
-    "react-test-renderer": "16.2.0"
+    "react-test-renderer": "16.2.0",
+    "warning": "^3.0.0"
   },
   "peerDependencies": {
     "react": "^15.6.0 || ^16.0.0",

--- a/readme.md
+++ b/readme.md
@@ -268,7 +268,7 @@ share common logic.
 * `SwitchFeature` a component that renders its first <ToggleFeature> child based
   on the status of a passed feature flag
 
-[\_Note:](#flag-normalization)_ that all passed ˋflagNamesˋ passed as ˋflagˋ are a string. Depending on the adapter used \_these are normalized_ to be camel cased. This means that whenever a ˋfoo-flag-nameˋ is configured in e.g. LaunchDarkly or splitio it will have to be specified as ˋfooFlagNameˋ. The same applies for a ˋfoo_flag_nameˋ. This is meant to help using flags in an adapter agnostic way. Whenever a flag is otherwise passed in the non-normalized form it is likely to default to ˋfalseˋ which is unintended in most cases.
+[Note:](#flag-normalization)_ that all passed ˋflagNamesˋ passed as ˋflagˋ are a string. Depending on the adapter used \_these are normalized_ to be camel cased. This means that whenever a ˋfoo-flag-nameˋ is configured in e.g. LaunchDarkly or splitio it will have to be specified as ˋfooFlagNameˋ. The same applies for a ˋfoo_flag_nameˋ. This is meant to help using flags in an adapter agnostic way. Whenever a flag is otherwise passed in the non-normalized form it is likely to default to ˋfalseˋ which is unintended in most cases.
 
 #### `ToggleFeature`
 

--- a/readme.md
+++ b/readme.md
@@ -267,8 +267,8 @@ share common logic.
   the status of a passed feature flag
 * `SwitchFeature` a component that renders its first <ToggleFeature> child based
   on the status of a passed feature flag
-  
-_Note:_ that all passed ˋflagNamesˋ passed as ˋflagˋ are a string. Depending on the adapter used _these are normalized_ to be camel cased. This means that whenever a ˋfoo-flag-nameˋ is configured in e.g. LaunchDarkly or splitio it will have to be specified as ˋfooFlagNameˋ. The same applies for a ˋfoo_flag_nameˋ. This is meant to help using flags in an adapter agnostic way. Whenever a flag is otherwise passed in the non-normalized form it is likely to default to ˋfalseˋ which is unintended in most cases.
+
+[\_Note:](#flag-normalization)_ that all passed ˋflagNamesˋ passed as ˋflagˋ are a string. Depending on the adapter used \_these are normalized_ to be camel cased. This means that whenever a ˋfoo-flag-nameˋ is configured in e.g. LaunchDarkly or splitio it will have to be specified as ˋfooFlagNameˋ. The same applies for a ˋfoo_flag_nameˋ. This is meant to help using flags in an adapter agnostic way. Whenever a flag is otherwise passed in the non-normalized form it is likely to default to ˋfalseˋ which is unintended in most cases.
 
 #### `ToggleFeature`
 


### PR DESCRIPTION
> This pull request aims to to target a discussion around unexpected behaviour of the library when passing non-normalised flags.

I am still not too sure if I would like to add a `skipFlagNormalization` prop to `<ConfigureFlopflip> yet. In mean time - and even after - I think it's worthwhile to provide descriptive warnings to the user whenever the library encounters a situation where it might behave other than anticipated.

This means:

- Whenever a passed flag - either in `react-broadcast` or `react-redux` ends up in `isFeatureEnabled`
   - and the flag name does not seem normalized
   - then we warn the user with a reference to the respective readme section

Again, this same behaviour should exist whenever a `skipFlagNormalization` prop is added. However I see some problems with that still which can be discussed on the respective issue and elaborated on with PoCs.
