### PR TITLE
fix(ts-bindings): add flag, variation, isFeatureEnabled to optional for toggle components

### DIFF
--- a/packages/react-broadcast/typings/index.d.ts
+++ b/packages/react-broadcast/typings/index.d.ts
@@ -2,5 +2,10 @@
 // TypeScript Version: 2.x
 
 declare module '@flopflip/react-broadcast' {
+  import Flag from '@flopflip/types';
   export * from '@flopflip/types';
+
+  export interface ToggleComponentProps extends Flag {
+    isFeatureEnabled?: boolean;
+  }
 }

--- a/packages/react-redux/typings/index.d.ts
+++ b/packages/react-redux/typings/index.d.ts
@@ -2,9 +2,13 @@
 // TypeScript Version: 2.x
 
 declare module '@flopflip/react-redux' {
-  import { FlagName, Flags } from '@flopflip/types';
+  import { Flag, FlagName, Flags } from '@flopflip/types';
 
   export * from '@flopflip/types';
   export function selectFlags(state: {}): Flags;
   export function selectFlag(flagName: FlagName): (state: {}) => Flags;
+
+  export interface ToggleComponentProps extends Flag {
+    isFeatureEnabled?: boolean;
+  }
 }


### PR DESCRIPTION
The [documentation for ToggleFeature](https://github.com/tdeekens/flopflip#togglefeature) states to support and required use of `flag` and `variation` properties but the TS defns are missing them.

Add these two properties for the `Toggle` components in react-broadcast & react-redux, leave original `Toggle` components from react package alone as it is correct.



