### PR TITLE
fix(react-*): TypeScript typings for ToggleFeature

### DIFF
--- a/packages/react-broadcast/typings/index.d.ts
+++ b/packages/react-broadcast/typings/index.d.ts
@@ -2,24 +2,17 @@
 // TypeScript Version: 2.x
 
 declare module '@flopflip/react-broadcast' {
-  import { Flag } from '@flopflip/types';
+  import {
+    FlagName,
+    FlagVariation,
+    ToggleComponentCommonProps,
+  } from '@flopflip/types';
 
   export * from '@flopflip/types';
 
-  /**
-   * NOTE:
-   *   We do not extend `ToggleCOmponentProps` from `types`
-   *   as we do not want the `isFeatureEnabled` property
-   *   showing up.
-   *   Extending `Flag` however will add `flag` and `variation`.
-   */
-  export interface ToggleComponentProps extends Flag {
-    toggledComponent?: React.ComponentType<any>;
-    untoggledComponent?: React.ComponentType<any>;
-    render?: () => React.ReactNode;
-    children?:
-      | (({ isFeatureEnabled: boolean }) => React.ReactNode)
-      | React.ReactNode;
+  export interface ToggleComponentProps extends ToggleComponentCommonProps {
+    flag: FlagName;
+    variation?: FlagVariation;
   }
 
   export class ToggleFeature extends React.Component<

--- a/packages/react-broadcast/typings/index.d.ts
+++ b/packages/react-broadcast/typings/index.d.ts
@@ -2,5 +2,28 @@
 // TypeScript Version: 2.x
 
 declare module '@flopflip/react-broadcast' {
+  import { Flag } from '@flopflip/types';
+
   export * from '@flopflip/types';
+
+  /**
+   * NOTE:
+   *   We do not extend `ToggleCOmponentProps` from `types`
+   *   as we do not want the `isFeatureEnabled` property
+   *   showing up.
+   *   Extending `Flag` however will add `flag` and `variation`.
+   */
+  export interface ToggleComponentProps extends Flag {
+    toggledComponent?: React.ComponentType<any>;
+    untoggledComponent?: React.ComponentType<any>;
+    render?: () => React.ReactNode;
+    children?:
+      | (({ isFeatureEnabled: boolean }) => React.ReactNode)
+      | React.ReactNode;
+  }
+
+  export class ToggleFeature extends React.Component<
+    ToggleComponentProps,
+    any
+  > {}
 }

--- a/packages/react-redux/typings/index.d.ts
+++ b/packages/react-redux/typings/index.d.ts
@@ -2,24 +2,18 @@
 // TypeScript Version: 2.x
 
 declare module '@flopflip/react-redux' {
-  import { Flag, FlagName, Flags } from '@flopflip/types';
+  import {
+    FlagName,
+    FlagVariation,
+    Flags,
+    ToggleComponentCommonProps,
+  } from '@flopflip/types';
 
   export * from '@flopflip/types';
 
-  /**
-   * NOTE:
-   *   We do not extend `ToggleCOmponentProps` from `types`
-   *   as we do not want the `isFeatureEnabled` property
-   *   showing up.
-   *   Extending `Flag` however will add `flag` and `variation`.
-   */
-  export interface ToggleComponentProps extends Flag {
-    toggledComponent?: React.ComponentType<any>;
-    untoggledComponent?: React.ComponentType<any>;
-    render?: () => React.ReactNode;
-    children?:
-      | (({ isFeatureEnabled: boolean }) => React.ReactNode)
-      | React.ReactNode;
+  export interface ToggleComponentProps extends ToggleComponentCommonProps {
+    flag: FlagName;
+    variation?: FlagVariation;
   }
 
   export class ToggleFeature extends React.Component<

--- a/packages/react-redux/typings/index.d.ts
+++ b/packages/react-redux/typings/index.d.ts
@@ -2,9 +2,31 @@
 // TypeScript Version: 2.x
 
 declare module '@flopflip/react-redux' {
-  import { FlagName, Flags } from '@flopflip/types';
+  import { Flag, FlagName, Flags } from '@flopflip/types';
 
   export * from '@flopflip/types';
+
+  /**
+   * NOTE:
+   *   We do not extend `ToggleCOmponentProps` from `types`
+   *   as we do not want the `isFeatureEnabled` property
+   *   showing up.
+   *   Extending `Flag` however will add `flag` and `variation`.
+   */
+  export interface ToggleComponentProps extends Flag {
+    toggledComponent?: React.ComponentType<any>;
+    untoggledComponent?: React.ComponentType<any>;
+    render?: () => React.ReactNode;
+    children?:
+      | (({ isFeatureEnabled: boolean }) => React.ReactNode)
+      | React.ReactNode;
+  }
+
+  export class ToggleFeature extends React.Component<
+    ToggleComponentProps,
+    any
+  > {}
+
   export function selectFlags(state: {}): Flags;
   export function selectFlag(flagName: FlagName): (state: {}) => Flags;
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -33,13 +33,16 @@ declare module '@flopflip/types' {
     reconfigure: (adapterArgs: AdapterArgs) => Promise<any>;
   };
 
-  export interface ToggleComponentProps {
+  export interface ToggleComponentCommonProps {
     toggledComponent?: React.ComponentType<any>;
     untoggledComponent?: React.ComponentType<any>;
     render?: () => React.ReactNode;
     children?:
       | (({ isFeatureEnabled: boolean }) => React.ReactNode)
       | React.ReactNode;
+    isFeatureEnabled: boolean;
+  }
+  export interface ToggleComponentProps extends ToggleComponentCommonProps {
     isFeatureEnabled: boolean;
   }
   export interface ConfigureComponentProps {


### PR DESCRIPTION
Builds upon #244 and closes #244 to fix typings for ToggleFeature.