### PR TITLE
fix(launchdarkly-adapter): change of user context

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.js
@@ -84,10 +84,17 @@ const changeUserContext = (nextUser: User): Promise<any> =>
         new Error('Can not change user context: client not yet initialized.')
       );
 const updateUserContext = (updatedUserProps: User): Promise<any> => {
+  const isAdapterReady = adapterState.isConfigured && adapterState.isReady;
+
   warning(
-    adapterState.isConfigured && adapterState.isReady,
+    isAdapterReady,
     '@flopflip/launchdarkly-adapter: adapter not ready and configured. User context can not be updated before.'
   );
+
+  if (!isAdapterReady)
+    return Promise.reject(
+      new Error('Can not update user context: adapter not yet ready.')
+    );
 
   return changeUserContext({ ...adapterState.user, ...updatedUserProps });
 };

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -1,4 +1,5 @@
 import ldClient from 'ldclient-js';
+import warning from 'warning';
 import adapter, { camelCaseFlags, createAnonymousUserKey } from './adapter';
 
 const clientSideId = '123-abc';
@@ -16,6 +17,7 @@ const createClient = jest.fn(apiOverwrites => ({
 }));
 
 jest.mock('ldclient-js');
+jest.mock('warning');
 
 describe('when configuring', () => {
   let onStatusStateChange;
@@ -33,6 +35,24 @@ describe('when configuring', () => {
       return expect(adapter.reconfigure({ user: userWithKey })).rejects.toEqual(
         expect.any(Error)
       );
+    });
+  });
+
+  describe('when changing user context before configured', () => {
+    const updatedUserProps = {
+      bar: 'baz',
+      foo: 'far',
+    };
+    let updatingOfUserContext;
+
+    beforeEach(() => {
+      updatingOfUserContext = adapter.updateUserContext(updatedUserProps);
+
+      return updatingOfUserContext.catch(() => {});
+    });
+
+    it('should reject `updateUserContext`', () => {
+      expect(updatingOfUserContext).rejects.toEqual(expect.any(Error));
     });
   });
 


### PR DESCRIPTION
Improves and fixes error handling when updating the user context before the adapter is ready.

- Now properly rejects the promise
- Early returns the function
- Added tests