### PR TITLE
Reconfigure `launchdarkly-adapter` on non deep equality of users

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.js
@@ -9,6 +9,7 @@ import type {
   OnStatusStateChangeCallback,
 } from '@flopflip/types';
 import warning from 'warning';
+import isEqual from 'lodash.isequal';
 import { initialize } from 'ldclient-js';
 import camelCase from 'lodash.camelcase';
 
@@ -171,7 +172,7 @@ const configure = ({
 
 const reconfigure = ({
   clientSideId,
-  user,
+  user: nextUser,
   onFlagsStateChange,
   onStatusStateChange,
 }: {
@@ -187,8 +188,8 @@ const reconfigure = ({
       )
     );
 
-  if (adapterState.user && adapterState.user.key !== user.key) {
-    adapterState.user = ensureUser(user);
+  if (adapterState.user && !isEqual(adapterState.user, nextUser)) {
+    adapterState.user = ensureUser(nextUser);
 
     return changeUserContext(adapterState.user);
   }

--- a/packages/launchdarkly-adapter/package.json
+++ b/packages/launchdarkly-adapter/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "ldclient-js": "1.5.1",
+    "lodash.isequal ": "4.5.0",
     "lodash.camelcase": "4.3.0",
     "warning": "3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4742,6 +4742,11 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+"lodash.isequal @4.5.0":
+  name lodash.isequal
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
 lodash.isequal@^3.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-3.0.4.tgz#1c35eb3b6ef0cd1ff51743e3ea3cf7fdffdacb64"


### PR DESCRIPTION
> Previously the user `key` property was used to determine reconfiguring the adapter.

This might not be intended as other user properties can also change about which LD needs to be notified in case they change on the client.

This pull request changes the equality check some key equality to a deep equals check via lodash (note we use lodash for all utils).

Closes #268 