### PR TITLE
Improve method names in `ConfigureFlopflip`

### DIFF
--- a/packages/react/modules/components/configure-adapter/configure-adapter.js
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.js
@@ -66,7 +66,7 @@ export default class ConfigureAdapter extends PureComponent<Props, State> {
   setAdapterState = (nextAdapterState: AdapterState): void => {
     this.adapterState = nextAdapterState;
   };
-  setAdapterArgs = (nextAdapterArgs: AdapterArgs): void =>
+  applyAdapterArgs = (nextAdapterArgs: AdapterArgs): void =>
     this.setState(prevState => ({
       ...prevState,
       appliedAdapterArgs: nextAdapterArgs,
@@ -84,7 +84,7 @@ export default class ConfigureAdapter extends PureComponent<Props, State> {
   ): void =>
     this.adapterState === AdapterStates.CONFIGURED &&
     this.adapterState !== AdapterStates.CONFIGURING
-      ? this.setAdapterArgs(
+      ? this.applyAdapterArgs(
           mergeAdapterArgs(this.state.appliedAdapterArgs, {
             adapterArgs: nextAdapterArgs,
             options,
@@ -106,7 +106,7 @@ export default class ConfigureAdapter extends PureComponent<Props, State> {
     );
   };
   unsetPendingAdapterArgs = (): void => {
-    if (this.pendingAdapterArgs) this.setAdapterArgs(this.pendingAdapterArgs);
+    if (this.pendingAdapterArgs) this.applyAdapterArgs(this.pendingAdapterArgs);
 
     this.pendingAdapterArgs = null;
   };

--- a/packages/react/modules/components/configure-adapter/configure-adapter.js
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.js
@@ -28,7 +28,7 @@ type State = {
 };
 type AdapterState = $Values<typeof AdapterStates>;
 type AdapterReconfigurationOptions = {
-  exact?: boolean,
+  shouldOverwrite?: boolean,
 };
 type AdapterReconfiguration = {
   adapterArgs: AdapterArgs,
@@ -47,7 +47,9 @@ export const mergeAdapterArgs = (
   previousAdapterArgs: AdapterArgs,
   { adapterArgs: nextAdapterArgs, options = {} }: AdapterReconfiguration
 ): AdapterArgs =>
-  options.exact ? nextAdapterArgs : merge(previousAdapterArgs, nextAdapterArgs);
+  options.shouldOverwrite
+    ? nextAdapterArgs
+    : merge(previousAdapterArgs, nextAdapterArgs);
 
 export default class ConfigureAdapter extends PureComponent<Props, State> {
   static defaultProps = {
@@ -119,7 +121,16 @@ export default class ConfigureAdapter extends PureComponent<Props, State> {
 
   componentWillReceiveProps(nextProps: Props): void {
     if (nextProps.adapterArgs !== this.props.adapterArgs) {
-      this.reconfigureOrQueue(nextProps.adapterArgs, { exact: true });
+      /**
+       * NOTE:
+       *   To keep the component controlled changes to the `props.adapterArgs`
+       *   will always overwrite existing `adapterArgs`. Even when changs occured
+       *   from `ReconfigureFlopflip`. This aims to reduce confusion. Please open
+       *   an issue unless it does not. Maybe `adapterArgs` on this component will
+       *   become `defaultAdapterArgs` in the future and changes to them always
+       *   have to be carried out through `ReconfigureFlopflip`.
+       */
+      this.reconfigureOrQueue(nextProps.adapterArgs, { shouldOverwrite: true });
     }
   }
 

--- a/packages/react/modules/components/configure-adapter/configure-adapter.js
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.js
@@ -105,7 +105,7 @@ export default class ConfigureAdapter extends PureComponent<Props, State> {
       nextReconfiguration
     );
   };
-  unsetPendingAdapterArgs = (): void => {
+  applyPendingAdapterArgs = (): void => {
     if (this.pendingAdapterArgs) this.applyAdapterArgs(this.pendingAdapterArgs);
 
     this.pendingAdapterArgs = null;
@@ -133,7 +133,7 @@ export default class ConfigureAdapter extends PureComponent<Props, State> {
         .configure(this.state.appliedAdapterArgs)
         .then(() => {
           this.setAdapterState(AdapterStates.CONFIGURED);
-          this.unsetPendingAdapterArgs();
+          this.applyPendingAdapterArgs();
         });
     }
   }
@@ -166,7 +166,7 @@ export default class ConfigureAdapter extends PureComponent<Props, State> {
         .reconfigure(this.state.appliedAdapterArgs)
         .then(() => {
           this.setAdapterState(AdapterStates.CONFIGURED);
-          this.unsetPendingAdapterArgs();
+          this.applyPendingAdapterArgs();
         });
     }
   }

--- a/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
@@ -424,7 +424,7 @@ describe('interacting', () => {
     user: 'next-user',
   };
 
-  describe('setAdapterArgs', () => {
+  describe('applyAdapterArgs', () => {
     describe('when configured', () => {
       beforeEach(() => {
         props = createTestProps();
@@ -435,7 +435,7 @@ describe('interacting', () => {
         );
 
         wrapper.instance().setAdapterState(AdapterStates.CONFIGURED);
-        wrapper.instance().setAdapterArgs(nextAdapterArgs, { exact: false });
+        wrapper.instance().applyAdapterArgs(nextAdapterArgs, { exact: false });
       });
 
       it('should update the `state` of `appliedAdapterArgs`', () => {
@@ -506,7 +506,7 @@ describe('interacting', () => {
           </ConfigureAdapter>
         );
 
-        jest.spyOn(wrapper.instance(), 'setAdapterArgs');
+        jest.spyOn(wrapper.instance(), 'applyAdapterArgs');
 
         wrapper.instance().setPendingAdapterArgs({
           adapterArgs: nextAdapterArgs,
@@ -516,12 +516,12 @@ describe('interacting', () => {
         wrapper.instance().unsetPendingAdapterArgs();
       });
 
-      it('should invoke `setAdapterArgs`', () => {
-        expect(wrapper.instance().setAdapterArgs).toHaveBeenCalled();
+      it('should invoke `applyAdapterArgs`', () => {
+        expect(wrapper.instance().applyAdapterArgs).toHaveBeenCalled();
       });
 
-      it('should invoke `setAdapterArgs` with `pendingAdapterArgs`', () => {
-        expect(wrapper.instance().setAdapterArgs).toHaveBeenCalledWith(
+      it('should invoke `applyAdapterArgs` with `pendingAdapterArgs`', () => {
+        expect(wrapper.instance().applyAdapterArgs).toHaveBeenCalledWith(
           expect.objectContaining(nextAdapterArgs)
         );
       });
@@ -540,13 +540,13 @@ describe('interacting', () => {
           </ConfigureAdapter>
         );
 
-        jest.spyOn(wrapper.instance(), 'setAdapterArgs');
+        jest.spyOn(wrapper.instance(), 'applyAdapterArgs');
 
         wrapper.instance().unsetPendingAdapterArgs();
       });
 
-      it('should not invoke `setAdapterArgs`', () => {
-        expect(wrapper.instance().setAdapterArgs).not.toHaveBeenCalled();
+      it('should not invoke `applyAdapterArgs`', () => {
+        expect(wrapper.instance().applyAdapterArgs).not.toHaveBeenCalled();
       });
     });
 
@@ -560,7 +560,7 @@ describe('interacting', () => {
             </ConfigureAdapter>
           );
 
-          jest.spyOn(wrapper.instance(), 'setAdapterArgs');
+          jest.spyOn(wrapper.instance(), 'applyAdapterArgs');
 
           wrapper.instance().setAdapterState(AdapterStates.CONFIGURED);
 
@@ -569,12 +569,12 @@ describe('interacting', () => {
             .reconfigureOrQueue(nextAdapterArgs, { exact: false });
         });
 
-        it('should invoke `setAdapterArgs`', () => {
-          expect(wrapper.instance().setAdapterArgs).toHaveBeenCalled();
+        it('should invoke `applyAdapterArgs`', () => {
+          expect(wrapper.instance().applyAdapterArgs).toHaveBeenCalled();
         });
 
-        it('should invoke `setAdapterArgs` with `nextAdapterArgs`', () => {
-          expect(wrapper.instance().setAdapterArgs).toHaveBeenCalledWith(
+        it('should invoke `applyAdapterArgs` with `nextAdapterArgs`', () => {
+          expect(wrapper.instance().applyAdapterArgs).toHaveBeenCalledWith(
             expect.objectContaining(nextAdapterArgs)
           );
         });

--- a/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
@@ -213,10 +213,10 @@ describe('lifecycle', () => {
         );
       });
 
-      it('should invoke `recongiureOrQueue` with `exact`', () => {
+      it('should invoke `recongiureOrQueue` with `shouldOverwrite`', () => {
         expect(wrapper.instance().reconfigureOrQueue).toHaveBeenCalledWith(
           expect.any(Object),
-          { exact: true }
+          { shouldOverwrite: true }
         );
       });
     });
@@ -435,7 +435,9 @@ describe('interacting', () => {
         );
 
         wrapper.instance().setAdapterState(AdapterStates.CONFIGURED);
-        wrapper.instance().applyAdapterArgs(nextAdapterArgs, { exact: false });
+        wrapper
+          .instance()
+          .applyAdapterArgs(nextAdapterArgs, { shouldOverwrite: false });
       });
 
       it('should update the `state` of `appliedAdapterArgs`', () => {
@@ -458,7 +460,7 @@ describe('interacting', () => {
       beforeEach(() => {
         wrapper.instance().setPendingAdapterArgs({
           adapterArgs: nextAdapterArgs,
-          options: { exact: false },
+          options: { exashouldOverwritect: false },
         });
       });
 
@@ -476,11 +478,11 @@ describe('interacting', () => {
       beforeEach(() => {
         wrapper.instance().setPendingAdapterArgs({
           adapterArgs: nextAdapterArgs,
-          options: { exact: false },
+          options: { shouldOverwrite: false },
         });
         wrapper.instance().setPendingAdapterArgs({
           adapterArgs: nextNextAdapterArgs,
-          options: { exact: false },
+          options: { shouldOverwrite: false },
         });
       });
 
@@ -510,7 +512,7 @@ describe('interacting', () => {
 
         wrapper.instance().setPendingAdapterArgs({
           adapterArgs: nextAdapterArgs,
-          options: { exact: false },
+          options: { shouldOverwrite: false },
         });
 
         wrapper.instance().applyPendingAdapterArgs();
@@ -566,7 +568,7 @@ describe('interacting', () => {
 
           wrapper
             .instance()
-            .reconfigureOrQueue(nextAdapterArgs, { exact: false });
+            .reconfigureOrQueue(nextAdapterArgs, { shouldOverwrite: false });
         });
 
         it('should invoke `applyAdapterArgs`', () => {
@@ -595,7 +597,7 @@ describe('interacting', () => {
 
           wrapper
             .instance()
-            .reconfigureOrQueue(nextAdapterArgs, { exact: false });
+            .reconfigureOrQueue(nextAdapterArgs, { shouldOverwrite: false });
         });
 
         it('should invoke `setPendingAdapterArgs`', () => {
@@ -610,7 +612,7 @@ describe('interacting', () => {
 
         it('should invoke `setPendingAdapterArgs` with `options`', () => {
           expect(wrapper.instance().setPendingAdapterArgs).toHaveBeenCalledWith(
-            expect.objectContaining({ options: { exact: false } })
+            expect.objectContaining({ options: { shouldOverwrite: false } })
           );
         });
       });
@@ -627,7 +629,7 @@ describe('interacting', () => {
 
   describe('helpers', () => {
     describe('mergeAdapterArgs', () => {
-      describe('when not `exact`', () => {
+      describe('when not `shouldOverwrite`', () => {
         const previousAdapterArgs = {
           'some-prop': 'was-present',
         };
@@ -639,7 +641,7 @@ describe('interacting', () => {
           expect(
             mergeAdapterArgs(previousAdapterArgs, {
               adapterArgs: nextAdapterArgs,
-              options: { exact: false },
+              options: { shouldOverwrite: false },
             })
           ).toEqual(expect.objectContaining(nextAdapterArgs));
         });
@@ -648,13 +650,13 @@ describe('interacting', () => {
           expect(
             mergeAdapterArgs(previousAdapterArgs, {
               adapterArgs: nextAdapterArgs,
-              options: { exact: false },
+              options: { shouldOverwrite: false },
             })
           ).toEqual(expect.objectContaining(previousAdapterArgs));
         });
       });
 
-      describe('when `exact`', () => {
+      describe('when `shouldOverwrite`', () => {
         const previousAdapterArgs = {
           'some-prop': 'was-present',
         };
@@ -666,7 +668,7 @@ describe('interacting', () => {
           expect(
             mergeAdapterArgs(previousAdapterArgs, {
               adapterArgs: nextAdapterArgs,
-              options: { exact: true },
+              options: { shouldOverwrite: true },
             })
           ).toEqual(expect.objectContaining(nextAdapterArgs));
         });
@@ -675,7 +677,7 @@ describe('interacting', () => {
           expect(
             mergeAdapterArgs(previousAdapterArgs, {
               adapterArgs: nextAdapterArgs,
-              options: { exact: true },
+              options: { shouldOverwrite: true },
             })
           ).not.toEqual(expect.objectContaining(previousAdapterArgs));
         });

--- a/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
@@ -98,7 +98,7 @@ describe('lifecycle', () => {
 
         describe('when the adapter configures', () => {
           beforeEach(() => {
-            jest.spyOn(wrapper.instance(), 'unsetPendingAdapterArgs');
+            jest.spyOn(wrapper.instance(), 'applyPendingAdapterArgs');
 
             return wrapper.instance().componentDidMount();
           });
@@ -119,9 +119,9 @@ describe('lifecycle', () => {
             );
           });
 
-          it('should `unsetPendingAdapterArgs`', () => {
+          it('should `applyPendingAdapterArgs`', () => {
             expect(
-              wrapper.instance().unsetPendingAdapterArgs
+              wrapper.instance().applyPendingAdapterArgs
             ).toHaveBeenCalled();
           });
         });
@@ -363,7 +363,7 @@ describe('lifecycle', () => {
 
             wrapper.instance().setAdapterState(AdapterStates.CONFIGURED);
 
-            jest.spyOn(wrapper.instance(), 'unsetPendingAdapterArgs');
+            jest.spyOn(wrapper.instance(), 'applyPendingAdapterArgs');
 
             return wrapper.instance().componentDidUpdate();
           });
@@ -385,9 +385,9 @@ describe('lifecycle', () => {
               );
             });
 
-            it('should `unsetPendingAdapterArgs`', () => {
+            it('should `applyPendingAdapterArgs`', () => {
               expect(
-                wrapper.instance().unsetPendingAdapterArgs
+                wrapper.instance().applyPendingAdapterArgs
               ).toHaveBeenCalled();
             });
           });
@@ -496,7 +496,7 @@ describe('interacting', () => {
     });
   });
 
-  describe('unsetPendingAdapterArgs', () => {
+  describe('applyPendingAdapterArgs', () => {
     describe('with `pendingAdapterArgs`', () => {
       beforeEach(() => {
         props = createTestProps();
@@ -513,7 +513,7 @@ describe('interacting', () => {
           options: { exact: false },
         });
 
-        wrapper.instance().unsetPendingAdapterArgs();
+        wrapper.instance().applyPendingAdapterArgs();
       });
 
       it('should invoke `applyAdapterArgs`', () => {
@@ -542,7 +542,7 @@ describe('interacting', () => {
 
         jest.spyOn(wrapper.instance(), 'applyAdapterArgs');
 
-        wrapper.instance().unsetPendingAdapterArgs();
+        wrapper.instance().applyPendingAdapterArgs();
       });
 
       it('should not invoke `applyAdapterArgs`', () => {

--- a/packages/react/modules/components/reconfigure-adapter/reconfigure-adapter.js
+++ b/packages/react/modules/components/reconfigure-adapter/reconfigure-adapter.js
@@ -7,7 +7,7 @@ import React, { PureComponent, type Node } from 'react';
 import { withReconfiguration } from '../configure-adapter';
 
 type Props = {
-  exact?: boolean,
+  shouldOverwrite?: boolean,
   user: User,
   reconfigure: (adapterArgs: AdapterArgs, { exact?: boolean }) => void,
   children: React.Component<any>,
@@ -17,7 +17,7 @@ export class ReconfigureAdapter extends PureComponent<Props> {
   static displayName = 'ReconfigureAdapter';
 
   static defaultProps = {
-    exact: false,
+    shouldOverwrite: false,
     children: null,
   };
 
@@ -27,7 +27,7 @@ export class ReconfigureAdapter extends PureComponent<Props> {
         user: this.props.user,
       },
       {
-        exact: this.props.exact,
+        shouldOverwrite: this.props.shouldOverwrite,
       }
     );
   }
@@ -38,7 +38,7 @@ export class ReconfigureAdapter extends PureComponent<Props> {
         user: this.props.user,
       },
       {
-        exact: this.props.exact,
+        shouldOverwrite: this.props.shouldOverwrite,
       }
     );
   }

--- a/packages/react/modules/components/reconfigure-adapter/reconfigure-adapter.spec.js
+++ b/packages/react/modules/components/reconfigure-adapter/reconfigure-adapter.spec.js
@@ -9,7 +9,7 @@ const createTestProps = props => ({
   user: {
     key: 'foo-user-key',
   },
-  exact: false,
+  shouldOverwrite: false,
   reconfigure: jest.fn(),
   children: ChildComponent,
 
@@ -67,11 +67,11 @@ describe('lifecycle', () => {
       );
     });
 
-    it('should invoke `reconfigure` with `exact`', () => {
+    it('should invoke `reconfigure` with `shouldOverwrite`', () => {
       expect(props.reconfigure).toHaveBeenCalledWith(
         expect.any(Object),
         expect.objectContaining({
-          exact: props.exact,
+          shouldOverwrite: props.shouldOverwrite,
         })
       );
     });
@@ -103,11 +103,11 @@ describe('lifecycle', () => {
       );
     });
 
-    it('should invoke `reconfigure` with `exact`', () => {
+    it('should invoke `reconfigure` with `shouldOverwrite`', () => {
       expect(props.reconfigure).toHaveBeenCalledWith(
         expect.any(Object),
         expect.objectContaining({
-          exact: props.exact,
+          shouldOverwrite: props.shouldOverwrite,
         })
       );
     });
@@ -116,8 +116,8 @@ describe('lifecycle', () => {
 
 describe('statics', () => {
   describe('defaultProps', () => {
-    it('should default `exact` to `false`', () => {
-      expect(ReconfigureAdapter.defaultProps.exact).toBe(false);
+    it('should default `shouldOverwrite` to `false`', () => {
+      expect(ReconfigureAdapter.defaultProps.shouldOverwrite).toBe(false);
     });
 
     it('should default `children` to `null`', () => {

--- a/readme.md
+++ b/readme.md
@@ -148,7 +148,7 @@ without Redux.
 * `ConfigureFlopFlip` a component to configure flopflip with an adapter
   (alternative to the store enhancer)
 * `ReconfigureFlopFlip` a component to reconfigure flopflip with new user properties
-  either merged or overwritting old properties (`exact` prop)
+  either merged or overwritting old properties (`shouldOverwrite` prop)
 * `branchOnFeatureToggle` a Higher-Order Component (HoC) to conditionally render
   components depending on feature toggle state
 * `injectFeatureToggle` a HoC to inject a feature toggle onto the `props` of a
@@ -265,13 +265,13 @@ Imagine having `ConfigureFlopflip` above a given component wrapped by a `Route`:
   <React.Fragment>
     <SomeOtherAppComponent />
     <Route
-      exact={false}
+      shouldOverwrite={false}
       path="/:projectKey"
       render={routerProps => (
         <React.Fragment>
           <MyRouteComponent />
           <ReconfigureFlopflip
-            exact={false}
+            shouldOverwrite={false}
             // Note: this should be memoised to not trigger wasteful `reconfiguration`s.
             user={{ projectKey: routerProps.projectKey }}
           />
@@ -284,8 +284,8 @@ Imagine having `ConfigureFlopflip` above a given component wrapped by a `Route`:
 
 Internally, `ReconfigureFlopFlip` will pass the `projectKey` to `ConfigureFlopFlip`, causing the adapter to automatically update the user context and therefore to flush new flags from the adapter (given they are provided by e.g. LaunchDarkly).
 
-_Note:_ Whenever `exact` is `true` the existing user configuration will be overwritten not merged. Use with care as any
-subsequent `exact={true}` will overwrite any previously passed `user` with `exact={false}` (default).
+_Note:_ Whenever `shouldOverwrite` is `true` the existing user configuration will be overwritten not merged. Use with care as any
+subsequent `shouldOverwrite={true}` will overwrite any previously passed `user` with `shouldOverwrite={false}` (default).
 
 ### `@flopflip/react-broadcast` `@flopflip/react-redux` API
 


### PR DESCRIPTION
Changes

- `setAdapterArgs` -> `applyAdapterArgs`
- `unsetPendingAdapterArgs` -> `applyPendingAdapterArgs`

NOTE: I will sneak in a breaking change (it's Easter Sunday and nobody has downloaded the new version nor uses `ReconfigureFlopflip`. `exact` is now `shouldOverwrite`. Not it also defaults to the same `defaultProp`.

/cc @emmenko I think you would like this. Thanks for being persistent on renaming `exact`. I think that props should default to `false` which creates better APIs for components. Non-default behaviour is an opt-in by switching things to true.