### PR TITLE
Add a `createFlopflipReducer` for `preloadedState` through reducer

### DIFF
--- a/demo/src/modules/index.js
+++ b/demo/src/modules/index.js
@@ -1,8 +1,11 @@
 import { combineReducers } from 'redux';
-import { flopflipReducer, FLOPFLIP_STATE_SLICE } from '@flopflip/react-redux';
+import {
+  createFlopflipReducer,
+  FLOPFLIP_STATE_SLICE,
+} from '@flopflip/react-redux';
 import counter from './counter';
 
 export default combineReducers({
-  [FLOPFLIP_STATE_SLICE]: flopflipReducer,
+  [FLOPFLIP_STATE_SLICE]: createFlopflipReducer(),
   counter,
 });

--- a/packages/react-redux/modules/ducks/flags/flags.js
+++ b/packages/react-redux/modules/ducks/flags/flags.js
@@ -13,10 +13,7 @@ export const UPDATE_FLAGS: string = '@flopflip/flags/update';
 const initialState: State = {};
 
 // Reducer
-export default function reducer(
-  state: State = initialState,
-  action: Action = {}
-) {
+const reducer = (state: State = initialState, action: Action = {}): State => {
   switch (action.type) {
     case UPDATE_FLAGS:
       return {
@@ -27,7 +24,13 @@ export default function reducer(
     default:
       return state;
   }
-}
+};
+export default reducer;
+
+export const createReducer = (initialState: Flags = initialState) => (
+  state: State = initialState,
+  action: Action = {}
+) => reducer(state, action);
 
 // Action Creators
 export const updateFlags = (flags: Flags): UpdateFlagsAction => ({

--- a/packages/react-redux/modules/ducks/flags/index.js
+++ b/packages/react-redux/modules/ducks/flags/index.js
@@ -1,2 +1,5 @@
-export { default as flagsReducer } from './flags';
+export {
+  default as flagsReducer,
+  createReducer as createFlagsReducer,
+} from './flags';
 export { UPDATE_FLAGS, updateFlags, selectFlag, selectFlags } from './flags';

--- a/packages/react-redux/modules/ducks/index.js
+++ b/packages/react-redux/modules/ducks/index.js
@@ -1,5 +1,9 @@
+// @flow
+
+import type { FlagName, FlagVariation, Flag, Flags } from '@flopflip/types';
+
 import { combineReducers } from 'redux';
-import { flagsReducer } from './flags';
+import { flagsReducer, createFlagsReducer } from './flags';
 import { statusReducer } from './status';
 
 export { updateStatus, UPDATE_STATUS } from './status';
@@ -9,3 +13,8 @@ export const flopflipReducer = combineReducers({
   flags: flagsReducer,
   status: statusReducer,
 });
+export const createFlopflipReducer = (preloadedState: Flags = {}) =>
+  combineReducers({
+    flags: createFlagsReducer(preloadedState),
+    status: statusReducer,
+  });

--- a/packages/react-redux/modules/ducks/status/status.js
+++ b/packages/react-redux/modules/ducks/status/status.js
@@ -10,10 +10,7 @@ export const UPDATE_STATUS: string = '@flopflip/status/update';
 const initialState: State = { isReady: false };
 
 // Reducer
-export default function reducer(
-  state: State = initialState,
-  action: Action = {}
-): State {
+const reducer = (state: State = initialState, action: Action = {}): State => {
   switch (action.type) {
     case UPDATE_STATUS:
       return {
@@ -24,7 +21,8 @@ export default function reducer(
     default:
       return state;
   }
-}
+};
+export default reducer;
 
 // Action Creators
 export const updateStatus = (status: AdapterStatus): UpdateStatusAction => ({

--- a/packages/react-redux/modules/index.js
+++ b/packages/react-redux/modules/index.js
@@ -3,6 +3,7 @@ export {
   STATE_SLICE as FLOPFLIP_STATE_SLICE,
 } from './store';
 export {
+  createFlopflipReducer,
   flopflipReducer,
   selectFlags as selectFeatureFlags,
   selectFlag as selectFeatureFlag,

--- a/readme.md
+++ b/readme.md
@@ -249,9 +249,33 @@ const store = createStore(
 )
 ```
 
-Whereas you would still wrap most or all of your application's tree in
-`ConfigureFlopFlip` to identify a user and setup the integration with
-LaunchDarkly
+Note that `@flopflip/react-redux` also exports a `createFlopflipReducer(preloadedState: Flags)`. By using a
+
+```js
+const defaultFlags = { flagA: true, flagB: false };
+
+combineReducers({
+  appReducer,
+  [FLOPFLIP_STATE_SLICE]: createFlopflipReducer(defaultFlags),
+});
+```
+
+you can pass `defaultFlags` as the `preloadedState` directly into the `flopflipReducer` and do not need to
+keep track of it in your applications's `initialState` as in
+
+```js
+const initialState = {
+  [FLOPFLIP_STATE_SLICE]: { flagA: true, flagB: false },
+};
+const store = createStore(
+  // ...as before
+  initialState
+  // ...as before
+);
+```
+
+In addition to initiating `flopflip` when creating your store, you would still wrap most or all of your application's tree in
+`ConfigureFlopFlip` to identify a user and setup the integration with LaunchDarkly or any other flag provider or adapter
 
 ```js
 import adapter from '@flopflip/launchdarkly-adapter';


### PR DESCRIPTION
> This pull request implements a higher-order reducer for the `flopflipReducer` to allow passing in a `preloadedState`.

- Closes #369

This pull request contains the following:

1. Update to the readme
2. Adding and exporting a `createFlopflipReducer`