### PR TITLE
Improve documentation for flopflip

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,8 +178,8 @@ without Redux.
 
 You can setup flopflip to work in two ways.
 
-1. Using `ConfigureFlopFlip` for simpler use cases, or...
-2. With a Redux `store enhancer`.
+1. Using [`ConfigureFlopFlip`](#setup-using-components) for simpler use cases, or...
+2. With a Redux [`store enhancer`](#setup-through-a-redux-store-enhancer).
 
 If you only need to toggle some React components you can get by without using the Redux store. If you need to use some feature flags directly (e.g. some side effects in redux-thunks, redux-sagas or other places) it might make more sense to expose these flags through Redux with the store enhancer.
 


### PR DESCRIPTION
Trying to make it more clear that

1. LaunchDarkly is not needed to use this package
2. The different options you have for installing this package (store enhancer or context component)

I have a question about the following copy:

> Setup through a Redux store enhancer
> reducer & STATE_SLICE
Another way to configure flopflip is using a store enhancer. For this a flopflip reducer should be wired up with a combineReducers within your application in coordination with the STATE_SLICE which is used internally too to manage the location of the feature toggle states. **This setup eliminates the need to use ConfigureFlopFlip somewhere else in your application's component tree.**

however In issue #369 you said:

 >  Lasly, the ConfigureFlopflip accepts defaultFlags too. This is also mentioned in the readme. The relevant code snippet is here.

ConfigureFlopflip is not meant to be used together with the store enhancer right? Just making sure I'm writing the correct things.
