### PR TITLE
Refactor LaunchDarkly adapter to use named exports

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.js
@@ -10,7 +10,7 @@ import type {
 } from '@flopflip/types';
 import warning from 'warning';
 import isEqual from 'lodash.isequal';
-import ldClient from 'ldclient-js';
+import { initialize as initializeLaunchDarklyClient } from 'ldclient-js';
 import camelCase from 'lodash.camelcase';
 
 type Client = {
@@ -92,7 +92,7 @@ const ensureUser = (user: User): User => ({
   ...user,
 });
 const initializeClient = (clientSideId: string, user: User): Client =>
-  ldClient.initialize(clientSideId, user);
+  initializeLaunchDarklyClient(clientSideId, user);
 const changeUserContext = (nextUser: User): Promise<any> =>
   adapterState.client && adapterState.client.identify
     ? adapterState.client.identify(nextUser)

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -2,7 +2,9 @@ import ldClient from 'ldclient-js';
 import warning from 'warning';
 import adapter, { camelCaseFlags, createAnonymousUserKey } from './adapter';
 
-jest.mock('ldclient-js');
+jest.mock('ldclient-js', () => ({
+  initialize: jest.fn(),
+}));
 jest.mock('warning');
 
 const clientSideId = '123-abc';


### PR DESCRIPTION
In their latest release the LaunchDarkly team deprecated the default export of the client favouring the named export. This adapts the client to that to avoid future breakage.