### PR TITLE
Add ability to opt-out of flag subscription of ld-adapter

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.js
@@ -53,7 +53,7 @@ const normalizeFlag = (flagName: FlagName, flagValue?: FlagVariation): Flag => [
   flagValue === null || flagValue === undefined ? false : flagValue,
 ];
 
-const subscribeToFlagsChanges = ({
+const setupFlagSubcription = ({
   flagsFromSdk,
   onFlagsStateChange,
 }: {
@@ -167,13 +167,13 @@ const configure = ({
   user,
   onFlagsStateChange,
   onStatusStateChange,
-  shouldSubscribeToFlagChanges = true,
+  subscribeToFlagChanges = true,
 }: {
   clientSideId: string,
   user: User,
   onFlagsStateChange: OnFlagsStateChangeCallback,
   onStatusStateChange: OnStatusStateChangeCallback,
-  shouldSubscribeToFlagChanges: boolean,
+  subscribeToFlagChanges: boolean,
 }): Promise<any> => {
   adapterState.user = ensureUser(user);
   adapterState.client = initializeClient(clientSideId, adapterState.user);
@@ -184,8 +184,8 @@ const configure = ({
   }).then(({ flagsFromSdk }) => {
     adapterState.isConfigured = true;
 
-    if (shouldSubscribeToFlagChanges)
-      subscribeToFlagsChanges({
+    if (subscribeToFlagChanges)
+      setupFlagSubcription({
         flagsFromSdk,
         onFlagsStateChange,
       });

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -159,33 +159,35 @@ describe('when configuring', () => {
     });
 
     describe('with flag updates', () => {
-      beforeEach(() => {
-        // Reset due to preivous dispatches
-        onFlagsStateChange.mockClear();
+      describe('when `shouldSubscribeToFlagChanges`', () => {
+        beforeEach(() => {
+          // Reset due to preivous dispatches
+          onFlagsStateChange.mockClear();
 
-        // Checking for change:* callbacks and settings all flags to false.
-        client.on.mock.calls.forEach(([event, cb]) => {
-          if (event.startsWith('change:')) cb(false);
+          // Checking for change:* callbacks and settings all flags to false.
+          client.on.mock.calls.forEach(([event, cb]) => {
+            if (event.startsWith('change:')) cb(false);
+          });
+        });
+
+        it('should `dispatch` `onFlagsStateChange` action', () => {
+          expect(onFlagsStateChange).toHaveBeenCalled();
+        });
+
+        it('should `dispatch` `onFlagsStateChange` action with camel cased `flags`', () => {
+          expect(onFlagsStateChange).toHaveBeenCalledWith({
+            someFlag1: false,
+          });
+          expect(onFlagsStateChange).toHaveBeenCalledWith({
+            someFlag2: false,
+          });
         });
       });
+    });
 
-      it('should `dispatch` `onFlagsStateChange` action', () => {
-        expect(onFlagsStateChange).toHaveBeenCalled();
-      });
-
-      it('should `dispatch` `onFlagsStateChange` action with camel cased `flags`', () => {
-        expect(onFlagsStateChange).toHaveBeenCalledWith({
-          someFlag1: false,
-        });
-        expect(onFlagsStateChange).toHaveBeenCalledWith({
-          someFlag2: false,
-        });
-      });
-
-      describe('`getFlag`', () => {
-        it('should return the flag', () => {
-          expect(adapter.getFlag('someFlag2')).toBe(false);
-        });
+    describe('`getFlag`', () => {
+      it('should return the flag', () => {
+        expect(adapter.getFlag('someFlag2')).toBe(false);
       });
     });
 

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -159,7 +159,7 @@ describe('when configuring', () => {
     });
 
     describe('with flag updates', () => {
-      describe('when `shouldSubscribeToFlagChanges`', () => {
+      describe('when `subscribeToFlagChanges`', () => {
         beforeEach(() => {
           // Reset due to preivous dispatches
           onFlagsStateChange.mockClear();
@@ -181,6 +181,40 @@ describe('when configuring', () => {
           expect(onFlagsStateChange).toHaveBeenCalledWith({
             someFlag2: false,
           });
+        });
+      });
+
+      describe('when not `subscribeToFlagChanges`', () => {
+        beforeEach(async () => {
+          // Reset due to preivous dispatches
+          onFlagsStateChange.mockClear();
+          client.on.mockClear();
+
+          onStatusStateChange = jest.fn();
+          onFlagsStateChange = jest.fn();
+          client = createClient({
+            allFlags: jest.fn(() => flags),
+          });
+
+          ldClient.initialize.mockReturnValue(client);
+
+          await adapter.configure({
+            subscribeToFlagChanges: false,
+            clientSideId,
+            user: userWithKey,
+            onStatusStateChange,
+            onFlagsStateChange,
+          });
+
+          onFlagsStateChange.mockClear();
+          // Checking for change:* callbacks and settings all flags to false.
+          client.on.mock.calls.forEach(([event, cb]) => {
+            if (event.startsWith('change:')) cb(false);
+          });
+        });
+
+        it('should not `dispatch` `onFlagsStateChange` action', () => {
+          expect(onFlagsStateChange).not.toHaveBeenCalled();
         });
       });
     });


### PR DESCRIPTION
Closes #474 

This adds the ability to opt-out of the flags subscription by passing a `shouldSubcribeToFlagChanges: false` in the `adapterArgs` passed to `ConfigureFlopflip`.