### PR TITLE
feat(memory-adapter): to have event emitter

### DIFF
--- a/packages/memory-adapter/modules/adapter/adapter.js
+++ b/packages/memory-adapter/modules/adapter/adapter.js
@@ -78,7 +78,7 @@ export const updateFlags = (flags: Flags): void => {
 
   invariant(
     isAdapterReady,
-    '@flopflip/launchdarkly-memory: adapter not ready and configured. Flags can not be updated before.'
+    '@flopflip/memory-adapter: adapter not ready and configured. Flags can not be updated before.'
   );
 
   if (!isAdapterReady) return;

--- a/packages/memory-adapter/package.json
+++ b/packages/memory-adapter/package.json
@@ -35,6 +35,7 @@
     "client"
   ],
   "dependencies": {
-    "invariant": "2.2.4"
+    "invariant": "2.2.4",
+    "mitt": "1.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6279,6 +6279,10 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
+mitt@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-1.1.3.tgz#528c506238a05dce11cd914a741ea2cc332da9b8"
+
 mixin-deep@^1.2.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"


### PR DESCRIPTION
Maybe this pattern will move into all adapters. It seems that sometimes the same adapter must work with multiple ConfigureFlopflips. The memory-adapter is only a good example as it's often used for testing.

The ld and splitio adapter support this already has they have an internal event emitter in the sdks.