### PR TITLE
Add support for client options to launchdarkly-adapater

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.js
@@ -19,6 +19,9 @@ type Client = {
   on: (eventName: string, (flagName: FlagName) => void) => void,
   allFlags: () => Flags | null,
 };
+type ClientOptions = {
+  fetchGoals?: boolean,
+};
 type AdapterState = {
   isReady: boolean,
   isConfigured: boolean,
@@ -93,8 +96,11 @@ const ensureUser = (user: User): User => ({
   key: user && user.key ? user.key : createAnonymousUserKey(),
   ...user,
 });
-const initializeClient = (clientSideId: string, user: User): Client =>
-  initializeLaunchDarklyClient(clientSideId, user);
+const initializeClient = (
+  clientSideId: string,
+  user: User,
+  clientOptions: ClientOptions
+): Client => initializeLaunchDarklyClient(clientSideId, user);
 const changeUserContext = (nextUser: User): Promise<any> =>
   adapterState.client && adapterState.client.identify
     ? adapterState.client.identify(nextUser)
@@ -165,18 +171,24 @@ const getInitialFlags = ({
 const configure = ({
   clientSideId,
   user,
+  clientOptions = {},
   onFlagsStateChange,
   onStatusStateChange,
   subscribeToFlagChanges = true,
 }: {
   clientSideId: string,
   user: User,
+  clientOptions: ClientOptions,
   onFlagsStateChange: OnFlagsStateChangeCallback,
   onStatusStateChange: OnStatusStateChangeCallback,
   subscribeToFlagChanges: boolean,
 }): Promise<any> => {
   adapterState.user = ensureUser(user);
-  adapterState.client = initializeClient(clientSideId, adapterState.user);
+  adapterState.client = initializeClient(
+    clientSideId,
+    adapterState.user,
+    clientOptions
+  );
 
   return getInitialFlags({
     onFlagsStateChange,


### PR DESCRIPTION
#### Summary

The `ld-client-js` has a concept of `options` we rebrand here to `clientOptions`. Those e.g. allow to disable the `fetchGoals` which reduces the http requests when not intending to perform A/B testing through the LD client with flopflip.

We think it's a good idea to support those options and pass them on to the underlying `ld-client`. 

The current version of the `ConfigureAdapter` in the `react` package already supports this as `adapterArgs` are a rather generic concept.

```jsx
<ConfigureAdapter adapter={ldAdapter} adapterArgs={{ 
   clientSideId: 'foo', 
   user: { id: 'bar' }, 
   clientOptions: { fetchGoals: false } 
}}>
  <App />
</ConfigureAdapter>
```