### PR TITLE
feat(react-broadcast): add useFeatureToggle react hook

### DIFF
--- a/packages/react-broadcast/modules/hooks/index.js
+++ b/packages/react-broadcast/modules/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as useFeatureToggle } from './use-feature-toggle';

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/index.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/index.js
@@ -1,0 +1,1 @@
+export default from './use-feature-toggle';

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.js
@@ -1,0 +1,23 @@
+// @flow
+
+import type { FlagName, FlagVariation } from '@flopflip/types';
+
+import { useContext } from 'react';
+import camelCase from 'lodash.camelcase';
+import warning from 'warning';
+import { isFeatureEnabled } from '@flopflip/react';
+import { FlagsContext } from '../../components/configure';
+
+export default function useFeatureToggle(
+  flagName: FlagName,
+  flagVariation: FlagVariation = true
+) {
+  warning(
+    flagName === camelCase(flagName),
+    '@flopflip/react-broadcast: passed flag name does not seem to be normalized which may result in unexpected toggling. Please refer to our readme for more information: https://github.com/tdeekens/flopflip#flag-normalization'
+  );
+
+  const flags = useContext(FlagsContext);
+
+  return isFeatureEnabled(flagName, flagVariation)(flags);
+}

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
@@ -1,0 +1,71 @@
+import useFeatureToggle from './use-feature-toggle';
+import { useContext } from 'react';
+
+jest.mock('warning');
+jest.mock('react');
+
+const flagName = 'testFlagName';
+
+describe('with default variation', () => {
+  describe('when flag is enabled', () => {
+    let flagValue;
+    beforeEach(() => {
+      useContext.mockReturnValue({
+        [flagName]: true,
+      });
+
+      flagValue = useFeatureToggle(flagName);
+    });
+
+    it('should return true', () => {
+      expect(flagValue).toBe(true);
+    });
+  });
+
+  describe('when flag is disabled', () => {
+    let flagValue;
+    beforeEach(() => {
+      useContext.mockReturnValue({
+        [flagName]: false,
+      });
+
+      flagValue = useFeatureToggle(flagName);
+    });
+
+    it('should return false', () => {
+      expect(flagValue).toBe(false);
+    });
+  });
+});
+
+describe('with custom variation', () => {
+  describe('when variation matches', () => {
+    let flagValue;
+    beforeEach(() => {
+      useContext.mockReturnValue({
+        [flagName]: 'variation-a',
+      });
+
+      flagValue = useFeatureToggle(flagName, 'variation-a');
+    });
+
+    it('should return true', () => {
+      expect(flagValue).toBe(true);
+    });
+  });
+
+  describe('when variation does not match', () => {
+    let flagValue;
+    beforeEach(() => {
+      useContext.mockReturnValue({
+        [flagName]: 'variation-b',
+      });
+
+      flagValue = useFeatureToggle(flagName, 'variation-a');
+    });
+
+    it('should return false', () => {
+      expect(flagValue).toBe(false);
+    });
+  });
+});

--- a/packages/react-broadcast/modules/index.js
+++ b/packages/react-broadcast/modules/index.js
@@ -6,5 +6,6 @@ export {
   ConfigureFlopFlip,
   ReconfigureFlopFlip,
 } from './components';
+export { useFeatureToggle } from './hooks';
 
 export { version } from '../package.json';

--- a/packages/react-broadcast/package.json
+++ b/packages/react-broadcast/package.json
@@ -37,8 +37,8 @@
     "enzyme": "3.7.0",
     "enzyme-adapter-react-16": "1.6.0",
     "enzyme-to-json": "3.3.4",
-    "react": "16.6.0",
-    "react-dom": "16.6.0",
+    "react": "16.7.0-alpha.0",
+    "react-dom": "16.7.0-alpha.0",
     "redux-mock-store": "1.5.3"
   },
   "peerDependencies": {

--- a/packages/react/modules/helpers/is-feature-enabled/is-feature-enabled.js
+++ b/packages/react/modules/helpers/is-feature-enabled/is-feature-enabled.js
@@ -1,3 +1,6 @@
+// @flow
+
+import type { FlagName, FlagVariation, Flags } from '@flopflip/types';
 import camelCase from 'lodash.camelcase';
 import warning from 'warning';
 import { DEFAULT_FLAG_PROP_KEY } from '../../constants';
@@ -12,15 +15,15 @@ import { DEFAULT_FLAG_PROP_KEY } from '../../constants';
  * @return {Boolean}                              Indicator if the flag should be toggled
  */
 const isFeatureEnabled = (
-  flagName = DEFAULT_FLAG_PROP_KEY,
-  flagVariation = true
+  flagName: FlagName = DEFAULT_FLAG_PROP_KEY,
+  flagVariation: FlagVariation = true
 ) => {
   warning(
     flagName === camelCase(flagName),
     '@flopflip/react: passed flag name does not seem to be normalized which may result in unexpected toggling. Please refer to our readme for more information: https://github.com/tdeekens/flopflip#flag-normalization'
   );
 
-  return props => props[flagName] === flagVariation;
+  return (flags: Flags) => flags[flagName] === flagVariation;
 };
 
 export default isFeatureEnabled;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8507,6 +8507,16 @@ react-dom@16.6.0:
     prop-types "^15.6.2"
     scheduler "^0.10.0"
 
+react-dom@16.7.0-alpha.0:
+  version "16.7.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0-alpha.0.tgz#8379158d4c76d63c989f325f45dfa5762582584f"
+  integrity sha512-/XUn1ldxmoV2B7ov0rWT5LMZaaHMlF9GGLkUsmPRxmWTJwRDOuAPXidSaSlmR/VOhDSI1s+v3+KzFqhhDFJxYA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.11.0-alpha.0"
+
 react-is@^16.3.2, react-is@^16.6.0:
   version "16.6.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.6.0.tgz#456645144581a6e99f6816ae2bd24ee94bdd0c01"
@@ -8554,6 +8564,16 @@ react@16.6.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.10.0"
+
+react@16.7.0-alpha.0:
+  version "16.7.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0-alpha.0.tgz#e2ed4abe6f268c9b092a1d1e572953684d1783a9"
+  integrity sha512-V0za4H01aoAF0SdzahHepvfvzTQ1xxkgMX4z8uKzn+wzZAlVk0IVpleqyxZWluqmdftNedj6fIIZRO/rVYVFvQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.11.0-alpha.0"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"
@@ -9244,6 +9264,14 @@ scheduler@^0.10.0:
   version "0.10.0"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.10.0.tgz#7988de90fe7edccc774ea175a783e69c40c521e1"
   integrity sha512-+TSTVTCBAA3h8Anei3haDc1IRwMeDmtI/y/o3iBe3Mjl2vwYF9DtPDt929HyRmV/e7au7CLu8sc4C4W0VOs29w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.11.0-alpha.0:
+  version "0.11.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.0-alpha.0.tgz#7b132c726608993471db07866f2d59a52b9e190b"
+  integrity sha512-0tUDHYSyni/EHkMMBysVXVwfanCWWbLsulnDB1tGrQiWWrVuRVoclWCPHCYC/1iR5Rj34EQhxh3/F36V+F+ZpA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
#### Summary

This pull request adds a `useFeatureToggle(flagName: FlagName, flagVariation: FlagVariation)` React hook.

#### Description

```js
import { useFeatureToggle } from '@flopflip/react-broadcast';

function ComponentWithFeatureToggle(props) {
   const isFeatureEnabled = useFeatureToggle('myFeatureToggle');

   return (
     <h3>{props.title}<h3>
     <p>
       The feature is {isFeatureEnabled ? 'enabled' : 'disabled'}
     </p>
   );
}
```

This is just a small experiment how we flopflip's architecture could support a React hook. It is unclear to me how this could also be supported for `@flopflip/react-redux` without redux having a `useRedux` hook to use.