### PR TITLE
Add useFeatureToggle react hook (forward compatible)

### DIFF
--- a/packages/react-broadcast/modules/hooks/index.js
+++ b/packages/react-broadcast/modules/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as useFeatureToggle } from './use-feature-toggle';

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/index.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/index.js
@@ -1,0 +1,1 @@
+export default from './use-feature-toggle';

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.js
@@ -2,7 +2,7 @@
 
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
-import { useContext } from 'react';
+import React from 'react';
 import camelCase from 'lodash.camelcase';
 import warning from 'warning';
 import { isFeatureEnabled } from '@flopflip/react';
@@ -17,7 +17,17 @@ export default function useFeatureToggle(
     '@flopflip/react-broadcast: passed flag name does not seem to be normalized which may result in unexpected toggling. Please refer to our readme for more information: https://github.com/tdeekens/flopflip#flag-normalization'
   );
 
-  const flags = useContext(FlagsContext);
+  //$FlowFixMe
+  if (typeof React.useContext === 'function') {
+    //$FlowFixMe
+    const flags = React.useContext(FlagsContext);
 
-  return isFeatureEnabled(flagName, flagVariation)(flags);
+    return isFeatureEnabled(flagName, flagVariation)(flags);
+  } else {
+    return () => {
+      throw new Error(
+        'React hooks are not available in your currently installed version of React.'
+      );
+    };
+  }
 }

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.js
@@ -1,0 +1,23 @@
+// @flow
+
+import type { FlagName, FlagVariation } from '@flopflip/types';
+
+import { useContext } from 'react';
+import camelCase from 'lodash.camelcase';
+import warning from 'warning';
+import { isFeatureEnabled } from '@flopflip/react';
+import { FlagsContext } from '../../components/configure';
+
+export default function useFeatureToggle(
+  flagName: FlagName,
+  flagVariation: FlagVariation = true
+) {
+  warning(
+    flagName === camelCase(flagName),
+    '@flopflip/react-broadcast: passed flag name does not seem to be normalized which may result in unexpected toggling. Please refer to our readme for more information: https://github.com/tdeekens/flopflip#flag-normalization'
+  );
+
+  const flags = useContext(FlagsContext);
+
+  return isFeatureEnabled(flagName, flagVariation)(flags);
+}

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
@@ -1,71 +1,84 @@
 import useFeatureToggle from './use-feature-toggle';
-import { useContext } from 'react';
+import React from 'react';
 
 jest.mock('warning');
-jest.mock('react');
 
 const flagName = 'testFlagName';
 
-describe('with default variation', () => {
-  describe('when flag is enabled', () => {
-    let flagValue;
-    beforeEach(() => {
-      useContext.mockReturnValue({
-        [flagName]: true,
+describe('when React hooks (`useContext`) is available', () => {
+  describe('with default variation', () => {
+    describe('when flag is enabled', () => {
+      let flagValue;
+      beforeEach(() => {
+        React.useContext = jest.fn(() => ({
+          [flagName]: true,
+        }));
+
+        flagValue = useFeatureToggle(flagName);
       });
 
-      flagValue = useFeatureToggle(flagName);
+      it('should return true', () => {
+        expect(flagValue).toBe(true);
+      });
     });
 
-    it('should return true', () => {
-      expect(flagValue).toBe(true);
+    describe('when flag is disabled', () => {
+      let flagValue;
+      beforeEach(() => {
+        React.useContext = jest.fn(() => ({
+          [flagName]: false,
+        }));
+
+        flagValue = useFeatureToggle(flagName);
+      });
+
+      it('should return false', () => {
+        expect(flagValue).toBe(false);
+      });
     });
   });
 
-  describe('when flag is disabled', () => {
-    let flagValue;
-    beforeEach(() => {
-      useContext.mockReturnValue({
-        [flagName]: false,
+  describe('with custom variation', () => {
+    describe('when variation matches', () => {
+      let flagValue;
+      beforeEach(() => {
+        React.useContext = jest.fn(() => ({
+          [flagName]: 'variation-a',
+        }));
+
+        flagValue = useFeatureToggle(flagName, 'variation-a');
       });
 
-      flagValue = useFeatureToggle(flagName);
+      it('should return true', () => {
+        expect(flagValue).toBe(true);
+      });
     });
 
-    it('should return false', () => {
-      expect(flagValue).toBe(false);
+    describe('when variation does not match', () => {
+      let flagValue;
+      beforeEach(() => {
+        React.useContext = jest.fn(() => ({
+          [flagName]: 'variation-b',
+        }));
+
+        flagValue = useFeatureToggle(flagName, 'variation-a');
+      });
+
+      it('should return false', () => {
+        expect(flagValue).toBe(false);
+      });
     });
   });
 });
 
-describe('with custom variation', () => {
-  describe('when variation matches', () => {
-    let flagValue;
+describe('when React hooks (`useContext`) are not available', () => {
+  describe('when flag is enabled', () => {
     beforeEach(() => {
-      useContext.mockReturnValue({
-        [flagName]: 'variation-a',
-      });
-
-      flagValue = useFeatureToggle(flagName, 'variation-a');
+      React.useContext = jest.fn(() => undefined);
     });
 
-    it('should return true', () => {
-      expect(flagValue).toBe(true);
-    });
-  });
-
-  describe('when variation does not match', () => {
-    let flagValue;
-    beforeEach(() => {
-      useContext.mockReturnValue({
-        [flagName]: 'variation-b',
-      });
-
-      flagValue = useFeatureToggle(flagName, 'variation-a');
-    });
-
-    it('should return false', () => {
-      expect(flagValue).toBe(false);
+    it('should throw', () => {
+      expect(() => useFeatureToggle(flagName)).toThrow();
     });
   });
 });

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
@@ -1,0 +1,71 @@
+import useFeatureToggle from './use-feature-toggle';
+import { useContext } from 'react';
+
+jest.mock('warning');
+jest.mock('react');
+
+const flagName = 'testFlagName';
+
+describe('with default variation', () => {
+  describe('when flag is enabled', () => {
+    let flagValue;
+    beforeEach(() => {
+      useContext.mockReturnValue({
+        [flagName]: true,
+      });
+
+      flagValue = useFeatureToggle(flagName);
+    });
+
+    it('should return true', () => {
+      expect(flagValue).toBe(true);
+    });
+  });
+
+  describe('when flag is disabled', () => {
+    let flagValue;
+    beforeEach(() => {
+      useContext.mockReturnValue({
+        [flagName]: false,
+      });
+
+      flagValue = useFeatureToggle(flagName);
+    });
+
+    it('should return false', () => {
+      expect(flagValue).toBe(false);
+    });
+  });
+});
+
+describe('with custom variation', () => {
+  describe('when variation matches', () => {
+    let flagValue;
+    beforeEach(() => {
+      useContext.mockReturnValue({
+        [flagName]: 'variation-a',
+      });
+
+      flagValue = useFeatureToggle(flagName, 'variation-a');
+    });
+
+    it('should return true', () => {
+      expect(flagValue).toBe(true);
+    });
+  });
+
+  describe('when variation does not match', () => {
+    let flagValue;
+    beforeEach(() => {
+      useContext.mockReturnValue({
+        [flagName]: 'variation-b',
+      });
+
+      flagValue = useFeatureToggle(flagName, 'variation-a');
+    });
+
+    it('should return false', () => {
+      expect(flagValue).toBe(false);
+    });
+  });
+});

--- a/packages/react-broadcast/modules/index.js
+++ b/packages/react-broadcast/modules/index.js
@@ -6,5 +6,6 @@ export {
   ConfigureFlopFlip,
   ReconfigureFlopFlip,
 } from './components';
+export { useFeatureToggle } from './hooks';
 
 export { version } from '../package.json';


### PR DESCRIPTION
#### Summary

This pull request adds a `useFeatureToggle(flagName: FlagName, flagVariation: FlagVariation)` React hook.

#### Description

```js
import { useFeatureToggle } from '@flopflip/react-broadcast';

function ComponentWithFeatureToggle(props) {
   const isFeatureEnabled = useFeatureToggle('myFeatureToggle');

   return (
     <h3>{props.title}<h3>
     <p>
       The feature is {isFeatureEnabled ? 'enabled' : 'disabled'}
     </p>
   );
}
```

This is just a small experiment how we flopflip's architecture could support a React hook. It is unclear to me how this could also be supported for `@flopflip/react-redux` without redux having a `useRedux` hook to use.