### PR TITLE
Remove `recompose`

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -8,7 +8,7 @@
     "react-dom": "16.5.2",
     "react-redux": "5.0.7",
     "react-scripts": "2.0.0",
-    "recompose": "0.30.0",
+    "lodash.flowright": "3.5.0",
     "redux": "4.0.0",
     "redux-logger": "3.0.6",
     "redux-thunk": "2.3.0",

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { compose } from 'recompose';
+import flowRight from 'lodash.flowright';
 import { Provider, connect } from 'react-redux';
 import classNames from 'classnames';
 //import adapter from '@flopflip/launchdarkly-adapter';
@@ -38,7 +38,7 @@ IncrementAsyncButton.propTypes = {
   incrementAsync: PropTypes.func.isRequired,
   isIncrementing: PropTypes.bool.isRequired,
 };
-const FeatureToggledIncrementAsyncButton = compose(
+const FeatureToggledIncrementAsyncButton = flowRight(
   branchOnFeatureToggle(
     { flag: flags.INCREMENT_ASYNC_BUTTON },
     UntoggledFeature

--- a/packages/react-broadcast/modules/components/branch-on-feature-toggle/__snapshots__/branch-on-feature-toggle.spec.js.snap
+++ b/packages/react-broadcast/modules/components/branch-on-feature-toggle/__snapshots__/branch-on-feature-toggle.spec.js.snap
@@ -38,28 +38,22 @@ exports[`with \`untoggledComponent when feature is disabled should match snapsho
     shouldDeferAdapterConfiguration={false}
   >
     <branchOnFeatureToggle(ToggledComponent)>
-      <withProps(omitProps(branch(ToggledComponent)))
+      <withProps(omitProps(BranchOnFeatureToggle))
         @flopflip/flags={Object {}}
       >
-        <omitProps(branch(ToggledComponent))
+        <omitProps(BranchOnFeatureToggle)
           @flopflip/flags={Object {}}
           isFeatureEnabled={false}
         >
-          <branch(ToggledComponent)
+          <BranchOnFeatureToggle
             isFeatureEnabled={false}
           >
-            <renderComponent(UntoggledComponent)
-              isFeatureEnabled={false}
-            >
-              <UntoggledComponent
-                isFeatureEnabled={false}
-              >
-                <div />
-              </UntoggledComponent>
-            </renderComponent(UntoggledComponent)>
-          </branch(ToggledComponent)>
-        </omitProps(branch(ToggledComponent))>
-      </withProps(omitProps(branch(ToggledComponent)))>
+            <UntoggledComponent>
+              <div />
+            </UntoggledComponent>
+          </BranchOnFeatureToggle>
+        </omitProps(BranchOnFeatureToggle)>
+      </withProps(omitProps(BranchOnFeatureToggle))>
     </branchOnFeatureToggle(ToggledComponent)>
   </ConfigureAdapter>
 </ConfigureFlopflip>
@@ -103,14 +97,14 @@ exports[`with \`untoggledComponent when feature is disabled when enabling featur
     shouldDeferAdapterConfiguration={false}
   >
     <branchOnFeatureToggle(ToggledComponent)>
-      <withProps(omitProps(branch(ToggledComponent)))
+      <withProps(omitProps(BranchOnFeatureToggle))
         @flopflip/flags={
           Object {
             "flag1": true,
           }
         }
       >
-        <omitProps(branch(ToggledComponent))
+        <omitProps(BranchOnFeatureToggle)
           @flopflip/flags={
             Object {
               "flag1": true,
@@ -118,17 +112,15 @@ exports[`with \`untoggledComponent when feature is disabled when enabling featur
           }
           isFeatureEnabled={true}
         >
-          <branch(ToggledComponent)
+          <BranchOnFeatureToggle
             isFeatureEnabled={true}
           >
-            <ToggledComponent
-              isFeatureEnabled={true}
-            >
+            <ToggledComponent>
               <div />
             </ToggledComponent>
-          </branch(ToggledComponent)>
-        </omitProps(branch(ToggledComponent))>
-      </withProps(omitProps(branch(ToggledComponent)))>
+          </BranchOnFeatureToggle>
+        </omitProps(BranchOnFeatureToggle)>
+      </withProps(omitProps(BranchOnFeatureToggle))>
     </branchOnFeatureToggle(ToggledComponent)>
   </ConfigureAdapter>
 </ConfigureFlopflip>
@@ -172,22 +164,20 @@ exports[`without \`untoggledComponent when feature is disabled should match snap
     shouldDeferAdapterConfiguration={false}
   >
     <branchOnFeatureToggle(ToggledComponent)>
-      <withProps(omitProps(branch(ToggledComponent)))
+      <withProps(omitProps(BranchOnFeatureToggle))
         @flopflip/flags={Object {}}
       >
-        <omitProps(branch(ToggledComponent))
+        <omitProps(BranchOnFeatureToggle)
           @flopflip/flags={Object {}}
           isFeatureEnabled={false}
         >
-          <branch(ToggledComponent)
+          <BranchOnFeatureToggle
             isFeatureEnabled={false}
           >
-            <Nothing
-              isFeatureEnabled={false}
-            />
-          </branch(ToggledComponent)>
-        </omitProps(branch(ToggledComponent))>
-      </withProps(omitProps(branch(ToggledComponent)))>
+            <DefaultUntoggledComponent />
+          </BranchOnFeatureToggle>
+        </omitProps(BranchOnFeatureToggle)>
+      </withProps(omitProps(BranchOnFeatureToggle))>
     </branchOnFeatureToggle(ToggledComponent)>
   </ConfigureAdapter>
 </ConfigureFlopflip>
@@ -231,14 +221,14 @@ exports[`without \`untoggledComponent when feature is disabled when enabling fea
     shouldDeferAdapterConfiguration={false}
   >
     <branchOnFeatureToggle(ToggledComponent)>
-      <withProps(omitProps(branch(ToggledComponent)))
+      <withProps(omitProps(BranchOnFeatureToggle))
         @flopflip/flags={
           Object {
             "flag1": true,
           }
         }
       >
-        <omitProps(branch(ToggledComponent))
+        <omitProps(BranchOnFeatureToggle)
           @flopflip/flags={
             Object {
               "flag1": true,
@@ -246,17 +236,15 @@ exports[`without \`untoggledComponent when feature is disabled when enabling fea
           }
           isFeatureEnabled={true}
         >
-          <branch(ToggledComponent)
+          <BranchOnFeatureToggle
             isFeatureEnabled={true}
           >
-            <ToggledComponent
-              isFeatureEnabled={true}
-            >
+            <ToggledComponent>
               <div />
             </ToggledComponent>
-          </branch(ToggledComponent)>
-        </omitProps(branch(ToggledComponent))>
-      </withProps(omitProps(branch(ToggledComponent)))>
+          </BranchOnFeatureToggle>
+        </omitProps(BranchOnFeatureToggle)>
+      </withProps(omitProps(BranchOnFeatureToggle))>
     </branchOnFeatureToggle(ToggledComponent)>
   </ConfigureAdapter>
 </ConfigureFlopflip>

--- a/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -3,7 +3,7 @@
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
-import { compose } from 'recompose';
+import flowRight from 'lodash.flowright';
 import {
   branchOnFeatureToggle,
   DEFAULT_FLAG_PROP_KEY,
@@ -18,7 +18,7 @@ export default <RequiredProps, ProvidedProps>(
   { flag, variation }: { flag: FlagName, variation?: FlagVariation },
   UntoggledComponent?: ComponentType<any>
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
-  compose(
+  flowRight(
     wrapDisplayName('branchOnFeatureToggle'),
     injectFeatureToggle(flag),
     branchOnFeatureToggle(UntoggledComponent, DEFAULT_FLAG_PROP_KEY, variation)

--- a/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -3,8 +3,12 @@
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
-import { compose, setDisplayName, wrapDisplayName } from 'recompose';
-import { branchOnFeatureToggle, DEFAULT_FLAG_PROP_KEY } from '@flopflip/react';
+import { compose } from 'recompose';
+import {
+  branchOnFeatureToggle,
+  DEFAULT_FLAG_PROP_KEY,
+  wrapDisplayName,
+} from '@flopflip/react';
 import injectFeatureToggle from './../inject-feature-toggle';
 
 type RequiredProps = {};
@@ -15,7 +19,7 @@ export default <RequiredProps, ProvidedProps>(
   UntoggledComponent?: ComponentType<any>
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   compose(
-    setDisplayName(wrapDisplayName(WrappedComponent, 'branchOnFeatureToggle')),
+    wrapDisplayName('branchOnFeatureToggle'),
     injectFeatureToggle(flag),
     branchOnFeatureToggle(UntoggledComponent, DEFAULT_FLAG_PROP_KEY, variation)
   )(WrappedComponent);

--- a/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -8,6 +8,7 @@ import {
   branchOnFeatureToggle,
   DEFAULT_FLAG_PROP_KEY,
   wrapDisplayName,
+  setDisplayName,
 } from '@flopflip/react';
 import injectFeatureToggle from './../inject-feature-toggle';
 
@@ -19,7 +20,7 @@ export default <RequiredProps, ProvidedProps>(
   UntoggledComponent?: ComponentType<any>
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   flowRight(
-    wrapDisplayName('branchOnFeatureToggle'),
+    setDisplayName(wrapDisplayName(WrappedComponent, 'branchOnFeatureToggle')),
     injectFeatureToggle(flag),
     branchOnFeatureToggle(UntoggledComponent, DEFAULT_FLAG_PROP_KEY, variation)
   )(WrappedComponent);

--- a/packages/react-broadcast/modules/components/configure/with-flags.js
+++ b/packages/react-broadcast/modules/components/configure/with-flags.js
@@ -3,8 +3,7 @@
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
 import React, { PureComponent, type ComponentType, type Node } from 'react';
-import { wrapDisplayName } from 'recompose';
-import { ALL_FLAGS_PROP_KEY } from '@flopflip/react';
+import { ALL_FLAGS_PROP_KEY, wrapDisplayName } from '@flopflip/react';
 import { FlagsContext } from '../configure';
 
 type RequiredProps = {};
@@ -16,7 +15,7 @@ const withFlags = (propKey: string = ALL_FLAGS_PROP_KEY) => (
   class EnhancedComponent extends PureComponent<
     $Diff<RequiredProps, ProvidedProps>
   > {
-    static displayName = wrapDisplayName(Component, 'withFlags');
+    static displayName = wrapDisplayName('withFlags', Component);
     render(): Node {
       return (
         <FlagsContext.Consumer>

--- a/packages/react-broadcast/modules/components/configure/with-flags.js
+++ b/packages/react-broadcast/modules/components/configure/with-flags.js
@@ -15,7 +15,7 @@ const withFlags = (propKey: string = ALL_FLAGS_PROP_KEY) => (
   class EnhancedComponent extends PureComponent<
     $Diff<RequiredProps, ProvidedProps>
   > {
-    static displayName = wrapDisplayName('withFlags', Component);
+    static displayName = wrapDisplayName(Component, 'withFlags');
     render(): Node {
       return (
         <FlagsContext.Consumer>

--- a/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -3,8 +3,8 @@
 import type { FlagName } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
-import { compose, setDisplayName, wrapDisplayName } from 'recompose';
-import { injectFeatureToggle } from '@flopflip/react';
+import { compose } from 'recompose';
+import { injectFeatureToggle, wrapDisplayName } from '@flopflip/react';
 import { withFlags } from '../configure';
 
 type RequiredProps = {};
@@ -15,7 +15,7 @@ export default <RequiredProps, ProvidedProps>(
   propKey?: string
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   compose(
-    setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggle')),
+    wrapDisplayName('injectFeatureToggle'),
     withFlags(),
     injectFeatureToggle(flagName, propKey)
   )(WrappedComponent);

--- a/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -3,7 +3,7 @@
 import type { FlagName } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
-import { compose } from 'recompose';
+import flowRight from 'lodash.flowright';
 import { injectFeatureToggle, wrapDisplayName } from '@flopflip/react';
 import { withFlags } from '../configure';
 
@@ -14,7 +14,7 @@ export default <RequiredProps, ProvidedProps>(
   flagName: FlagName,
   propKey?: string
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
-  compose(
+  flowRight(
     wrapDisplayName('injectFeatureToggle'),
     withFlags(),
     injectFeatureToggle(flagName, propKey)

--- a/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -4,7 +4,11 @@ import type { FlagName } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
 import flowRight from 'lodash.flowright';
-import { injectFeatureToggle, wrapDisplayName } from '@flopflip/react';
+import {
+  injectFeatureToggle,
+  wrapDisplayName,
+  setDisplayName,
+} from '@flopflip/react';
 import { withFlags } from '../configure';
 
 type RequiredProps = {};
@@ -15,7 +19,7 @@ export default <RequiredProps, ProvidedProps>(
   propKey?: string
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   flowRight(
-    wrapDisplayName('injectFeatureToggle'),
+    setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggle')),
     withFlags(),
     injectFeatureToggle(flagName, propKey)
   )(WrappedComponent);

--- a/packages/react-broadcast/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
+++ b/packages/react-broadcast/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
@@ -38,14 +38,14 @@ exports[`with \`propKey\` should match snapshot 1`] = `
     shouldDeferAdapterConfiguration={false}
   >
     <injectFeatureToggles(FeatureComponent)>
-      <withProps(omitProps(shouldUpdate(FeatureComponent)))
+      <withProps(omitProps(FeatureComponent))
         @flopflip/flags={Object {}}
       >
-        <omitProps(shouldUpdate(FeatureComponent))
+        <omitProps(FeatureComponent)
           @flopflip/flags={Object {}}
           fooBar={Object {}}
         >
-          <shouldUpdate(FeatureComponent)
+          <FeatureComponent
             fooBar={Object {}}
           >
             <FeatureComponent
@@ -53,9 +53,9 @@ exports[`with \`propKey\` should match snapshot 1`] = `
             >
               <div />
             </FeatureComponent>
-          </shouldUpdate(FeatureComponent)>
-        </omitProps(shouldUpdate(FeatureComponent))>
-      </withProps(omitProps(shouldUpdate(FeatureComponent)))>
+          </FeatureComponent>
+        </omitProps(FeatureComponent)>
+      </withProps(omitProps(FeatureComponent))>
     </injectFeatureToggles(FeatureComponent)>
   </ConfigureAdapter>
 </ConfigureFlopflip>
@@ -109,7 +109,7 @@ exports[`without \`propKey\` when feature is disabled should match snapshot 1`] 
     shouldDeferAdapterConfiguration={false}
   >
     <injectFeatureToggles(FeatureComponent)>
-      <withProps(omitProps(shouldUpdate(FeatureComponent)))
+      <withProps(omitProps(FeatureComponent))
         @flopflip/flags={
           Object {
             "flag1": false,
@@ -117,7 +117,7 @@ exports[`without \`propKey\` when feature is disabled should match snapshot 1`] 
           }
         }
       >
-        <omitProps(shouldUpdate(FeatureComponent))
+        <omitProps(FeatureComponent)
           @flopflip/flags={
             Object {
               "flag1": false,
@@ -131,7 +131,7 @@ exports[`without \`propKey\` when feature is disabled should match snapshot 1`] 
             }
           }
         >
-          <shouldUpdate(FeatureComponent)
+          <FeatureComponent
             featureToggles={
               Object {
                 "flag1": false,
@@ -149,9 +149,9 @@ exports[`without \`propKey\` when feature is disabled should match snapshot 1`] 
             >
               <div />
             </FeatureComponent>
-          </shouldUpdate(FeatureComponent)>
-        </omitProps(shouldUpdate(FeatureComponent))>
-      </withProps(omitProps(shouldUpdate(FeatureComponent)))>
+          </FeatureComponent>
+        </omitProps(FeatureComponent)>
+      </withProps(omitProps(FeatureComponent))>
     </injectFeatureToggles(FeatureComponent)>
   </ConfigureAdapter>
 </ConfigureFlopflip>
@@ -205,7 +205,7 @@ exports[`without \`propKey\` when feature is disabled when enabling feature shou
     shouldDeferAdapterConfiguration={false}
   >
     <injectFeatureToggles(FeatureComponent)>
-      <withProps(omitProps(shouldUpdate(FeatureComponent)))
+      <withProps(omitProps(FeatureComponent))
         @flopflip/flags={
           Object {
             "flag1": true,
@@ -213,7 +213,7 @@ exports[`without \`propKey\` when feature is disabled when enabling feature shou
           }
         }
       >
-        <omitProps(shouldUpdate(FeatureComponent))
+        <omitProps(FeatureComponent)
           @flopflip/flags={
             Object {
               "flag1": true,
@@ -227,7 +227,7 @@ exports[`without \`propKey\` when feature is disabled when enabling feature shou
             }
           }
         >
-          <shouldUpdate(FeatureComponent)
+          <FeatureComponent
             featureToggles={
               Object {
                 "flag1": true,
@@ -245,9 +245,9 @@ exports[`without \`propKey\` when feature is disabled when enabling feature shou
             >
               <div />
             </FeatureComponent>
-          </shouldUpdate(FeatureComponent)>
-        </omitProps(shouldUpdate(FeatureComponent))>
-      </withProps(omitProps(shouldUpdate(FeatureComponent)))>
+          </FeatureComponent>
+        </omitProps(FeatureComponent)>
+      </withProps(omitProps(FeatureComponent))>
     </injectFeatureToggles(FeatureComponent)>
   </ConfigureAdapter>
 </ConfigureFlopflip>

--- a/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -3,8 +3,8 @@
 import type { FlagName } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
-import { compose, setDisplayName, wrapDisplayName } from 'recompose';
-import { injectFeatureToggles } from '@flopflip/react';
+import { compose } from 'recompose';
+import { injectFeatureToggles, wrapDisplayName } from '@flopflip/react';
 import { withFlags } from '../configure';
 
 type RequiredProps = {};
@@ -20,7 +20,7 @@ export default <RequiredProps, ProvidedProps>(
   ) => boolean
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   compose(
-    setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggles')),
+    wrapDisplayName('injectFeatureToggles'),
     withFlags(),
     injectFeatureToggles(flagNames, propKey, areOwnPropsEqual)
   )(WrappedComponent);

--- a/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -3,7 +3,7 @@
 import type { FlagName } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
-import { compose } from 'recompose';
+import flowRight from 'lodash.flowright';
 import { injectFeatureToggles, wrapDisplayName } from '@flopflip/react';
 import { withFlags } from '../configure';
 
@@ -19,7 +19,7 @@ export default <RequiredProps, ProvidedProps>(
     propKey: string
   ) => boolean
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
-  compose(
+  flowRight(
     wrapDisplayName('injectFeatureToggles'),
     withFlags(),
     injectFeatureToggles(flagNames, propKey, areOwnPropsEqual)

--- a/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -4,7 +4,11 @@ import type { FlagName } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
 import flowRight from 'lodash.flowright';
-import { injectFeatureToggles, wrapDisplayName } from '@flopflip/react';
+import {
+  injectFeatureToggles,
+  wrapDisplayName,
+  setDisplayName,
+} from '@flopflip/react';
 import { withFlags } from '../configure';
 
 type RequiredProps = {};
@@ -20,7 +24,7 @@ export default <RequiredProps, ProvidedProps>(
   ) => boolean
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   flowRight(
-    wrapDisplayName('injectFeatureToggles'),
+    setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggles')),
     withFlags(),
     injectFeatureToggles(flagNames, propKey, areOwnPropsEqual)
   )(WrappedComponent);

--- a/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.js
+++ b/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.js
@@ -1,6 +1,7 @@
 // @flow
 
-import { compose, withProps } from 'recompose';
+import { withProps } from 'recompose';
+import flowRight from 'lodash.flowright';
 import {
   ToggleFeature,
   isFeatureEnabled,
@@ -9,7 +10,7 @@ import {
 } from '@flopflip/react';
 import { withFlags } from '../configure';
 
-export default compose(
+export default flowRight(
   setDisplayName(ToggleFeature.displayName),
   withFlags(),
   withProps(props => ({

--- a/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.js
+++ b/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.js
@@ -1,11 +1,11 @@
 // @flow
 
-import { withProps } from 'recompose';
 import flowRight from 'lodash.flowright';
 import {
   ToggleFeature,
   isFeatureEnabled,
   setDisplayName,
+  withProps,
   ALL_FLAGS_PROP_KEY,
 } from '@flopflip/react';
 import { withFlags } from '../configure';

--- a/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.js
+++ b/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.js
@@ -1,9 +1,10 @@
 // @flow
 
-import { compose, withProps, setDisplayName } from 'recompose';
+import { compose, withProps } from 'recompose';
 import {
   ToggleFeature,
   isFeatureEnabled,
+  setDisplayName,
   ALL_FLAGS_PROP_KEY,
 } from '@flopflip/react';
 import { withFlags } from '../configure';

--- a/packages/react-broadcast/package.json
+++ b/packages/react-broadcast/package.json
@@ -50,6 +50,7 @@
     "@flopflip/types": "^1.3.0",
     "create-react-context": "0.2.3",
     "lodash.memoize": "4.1.2",
+    "lodash.flowright": "3.5.0",
     "recompose": "0.30.0"
   },
   "keywords": [

--- a/packages/react-broadcast/package.json
+++ b/packages/react-broadcast/package.json
@@ -50,8 +50,7 @@
     "@flopflip/types": "^1.3.0",
     "create-react-context": "0.2.3",
     "lodash.memoize": "4.1.2",
-    "lodash.flowright": "3.5.0",
-    "recompose": "0.30.0"
+    "lodash.flowright": "3.5.0"
   },
   "keywords": [
     "react",

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/__snapshots__/branch-on-feature-toggle.spec.js.snap
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/__snapshots__/branch-on-feature-toggle.spec.js.snap
@@ -65,7 +65,7 @@ exports[`with \`untoggledComponent when feature is disabled should match snapsho
         shouldDeferAdapterConfiguration={false}
       >
         <branchOnFeatureToggle(ToggledComponent)>
-          <withProps(omitProps(branch(ToggledComponent)))
+          <withProps(omitProps(BranchOnFeatureToggle))
             @flopflip/flags={
               Object {
                 "flag1": false,
@@ -73,7 +73,7 @@ exports[`with \`untoggledComponent when feature is disabled should match snapsho
             }
             dispatch={[Function]}
           >
-            <omitProps(branch(ToggledComponent))
+            <omitProps(BranchOnFeatureToggle)
               @flopflip/flags={
                 Object {
                   "flag1": false,
@@ -82,24 +82,16 @@ exports[`with \`untoggledComponent when feature is disabled should match snapsho
               dispatch={[Function]}
               isFeatureEnabled={false}
             >
-              <branch(ToggledComponent)
+              <BranchOnFeatureToggle
                 dispatch={[Function]}
                 isFeatureEnabled={false}
               >
-                <renderComponent(UntoggledComponent)
-                  dispatch={[Function]}
-                  isFeatureEnabled={false}
-                >
-                  <UntoggledComponent
-                    dispatch={[Function]}
-                    isFeatureEnabled={false}
-                  >
-                    <div />
-                  </UntoggledComponent>
-                </renderComponent(UntoggledComponent)>
-              </branch(ToggledComponent)>
-            </omitProps(branch(ToggledComponent))>
-          </withProps(omitProps(branch(ToggledComponent)))>
+                <UntoggledComponent>
+                  <div />
+                </UntoggledComponent>
+              </BranchOnFeatureToggle>
+            </omitProps(BranchOnFeatureToggle)>
+          </withProps(omitProps(BranchOnFeatureToggle))>
         </branchOnFeatureToggle(ToggledComponent)>
       </ConfigureAdapter>
     </ConfigureFlopflip>
@@ -172,7 +164,7 @@ exports[`with \`untoggledComponent when feature is disabled when enabling featur
         shouldDeferAdapterConfiguration={false}
       >
         <branchOnFeatureToggle(ToggledComponent)>
-          <withProps(omitProps(branch(ToggledComponent)))
+          <withProps(omitProps(BranchOnFeatureToggle))
             @flopflip/flags={
               Object {
                 "flag1": true,
@@ -180,7 +172,7 @@ exports[`with \`untoggledComponent when feature is disabled when enabling featur
             }
             dispatch={[Function]}
           >
-            <omitProps(branch(ToggledComponent))
+            <omitProps(BranchOnFeatureToggle)
               @flopflip/flags={
                 Object {
                   "flag1": true,
@@ -189,19 +181,16 @@ exports[`with \`untoggledComponent when feature is disabled when enabling featur
               dispatch={[Function]}
               isFeatureEnabled={true}
             >
-              <branch(ToggledComponent)
+              <BranchOnFeatureToggle
                 dispatch={[Function]}
                 isFeatureEnabled={true}
               >
-                <ToggledComponent
-                  dispatch={[Function]}
-                  isFeatureEnabled={true}
-                >
+                <ToggledComponent>
                   <div />
                 </ToggledComponent>
-              </branch(ToggledComponent)>
-            </omitProps(branch(ToggledComponent))>
-          </withProps(omitProps(branch(ToggledComponent)))>
+              </BranchOnFeatureToggle>
+            </omitProps(BranchOnFeatureToggle)>
+          </withProps(omitProps(BranchOnFeatureToggle))>
         </branchOnFeatureToggle(ToggledComponent)>
       </ConfigureAdapter>
     </ConfigureFlopflip>
@@ -274,7 +263,7 @@ exports[`without \`untoggledComponent when feature is disabled should match snap
         shouldDeferAdapterConfiguration={false}
       >
         <branchOnFeatureToggle(ToggledComponent)>
-          <withProps(omitProps(branch(ToggledComponent)))
+          <withProps(omitProps(BranchOnFeatureToggle))
             @flopflip/flags={
               Object {
                 "flag1": false,
@@ -282,7 +271,7 @@ exports[`without \`untoggledComponent when feature is disabled should match snap
             }
             dispatch={[Function]}
           >
-            <omitProps(branch(ToggledComponent))
+            <omitProps(BranchOnFeatureToggle)
               @flopflip/flags={
                 Object {
                   "flag1": false,
@@ -291,17 +280,14 @@ exports[`without \`untoggledComponent when feature is disabled should match snap
               dispatch={[Function]}
               isFeatureEnabled={false}
             >
-              <branch(ToggledComponent)
+              <BranchOnFeatureToggle
                 dispatch={[Function]}
                 isFeatureEnabled={false}
               >
-                <Nothing
-                  dispatch={[Function]}
-                  isFeatureEnabled={false}
-                />
-              </branch(ToggledComponent)>
-            </omitProps(branch(ToggledComponent))>
-          </withProps(omitProps(branch(ToggledComponent)))>
+                <DefaultUntoggledComponent />
+              </BranchOnFeatureToggle>
+            </omitProps(BranchOnFeatureToggle)>
+          </withProps(omitProps(BranchOnFeatureToggle))>
         </branchOnFeatureToggle(ToggledComponent)>
       </ConfigureAdapter>
     </ConfigureFlopflip>
@@ -374,7 +360,7 @@ exports[`without \`untoggledComponent when feature is disabled when enabling fea
         shouldDeferAdapterConfiguration={false}
       >
         <branchOnFeatureToggle(ToggledComponent)>
-          <withProps(omitProps(branch(ToggledComponent)))
+          <withProps(omitProps(BranchOnFeatureToggle))
             @flopflip/flags={
               Object {
                 "flag1": true,
@@ -382,7 +368,7 @@ exports[`without \`untoggledComponent when feature is disabled when enabling fea
             }
             dispatch={[Function]}
           >
-            <omitProps(branch(ToggledComponent))
+            <omitProps(BranchOnFeatureToggle)
               @flopflip/flags={
                 Object {
                   "flag1": true,
@@ -391,19 +377,16 @@ exports[`without \`untoggledComponent when feature is disabled when enabling fea
               dispatch={[Function]}
               isFeatureEnabled={true}
             >
-              <branch(ToggledComponent)
+              <BranchOnFeatureToggle
                 dispatch={[Function]}
                 isFeatureEnabled={true}
               >
-                <ToggledComponent
-                  dispatch={[Function]}
-                  isFeatureEnabled={true}
-                >
+                <ToggledComponent>
                   <div />
                 </ToggledComponent>
-              </branch(ToggledComponent)>
-            </omitProps(branch(ToggledComponent))>
-          </withProps(omitProps(branch(ToggledComponent)))>
+              </BranchOnFeatureToggle>
+            </omitProps(BranchOnFeatureToggle)>
+          </withProps(omitProps(BranchOnFeatureToggle))>
         </branchOnFeatureToggle(ToggledComponent)>
       </ConfigureAdapter>
     </ConfigureFlopflip>

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -3,7 +3,7 @@
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
-import { compose } from 'recompose';
+import flowRight from 'lodash.flowright';
 import {
   branchOnFeatureToggle,
   wrapDisplayName,
@@ -18,7 +18,7 @@ export default <RequiredProps, ProvidedProps>(
   { flag, variation }: { flag: FlagName, variation: FlagVariation },
   UntoggledComponent: ComponentType<any>
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
-  compose(
+  flowRight(
     wrapDisplayName('branchOnFeatureToggle'),
     injectFeatureToggle(flag),
     branchOnFeatureToggle(UntoggledComponent, DEFAULT_FLAG_PROP_KEY, variation)

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -3,8 +3,12 @@
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
-import { compose, setDisplayName, wrapDisplayName } from 'recompose';
-import { branchOnFeatureToggle, DEFAULT_FLAG_PROP_KEY } from '@flopflip/react';
+import { compose } from 'recompose';
+import {
+  branchOnFeatureToggle,
+  wrapDisplayName,
+  DEFAULT_FLAG_PROP_KEY,
+} from '@flopflip/react';
 import injectFeatureToggle from './../inject-feature-toggle';
 
 type RequiredProps = {};
@@ -15,7 +19,7 @@ export default <RequiredProps, ProvidedProps>(
   UntoggledComponent: ComponentType<any>
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   compose(
-    setDisplayName(wrapDisplayName(WrappedComponent, 'branchOnFeatureToggle')),
+    wrapDisplayName('branchOnFeatureToggle'),
     injectFeatureToggle(flag),
     branchOnFeatureToggle(UntoggledComponent, DEFAULT_FLAG_PROP_KEY, variation)
   )(WrappedComponent);

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -7,6 +7,7 @@ import flowRight from 'lodash.flowright';
 import {
   branchOnFeatureToggle,
   wrapDisplayName,
+  setDisplayName,
   DEFAULT_FLAG_PROP_KEY,
 } from '@flopflip/react';
 import injectFeatureToggle from './../inject-feature-toggle';
@@ -19,7 +20,7 @@ export default <RequiredProps, ProvidedProps>(
   UntoggledComponent: ComponentType<any>
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   flowRight(
-    wrapDisplayName('branchOnFeatureToggle'),
+    setDisplayName(wrapDisplayName(WrappedComponent, 'branchOnFeatureToggle')),
     injectFeatureToggle(flag),
     branchOnFeatureToggle(UntoggledComponent, DEFAULT_FLAG_PROP_KEY, variation)
   )(WrappedComponent);

--- a/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -9,6 +9,7 @@ import { selectFlags } from '../../ducks';
 import {
   injectFeatureToggle,
   wrapDisplayName,
+  setDisplayName,
   ALL_FLAGS_PROP_KEY,
 } from '@flopflip/react';
 import { STATE_SLICE } from './../../store';
@@ -25,7 +26,7 @@ export default (flagName: FlagName, propKey?: string) => (
 ) =>
   /* istanbul ignore next */
   flowRight(
-    wrapDisplayName('injectFeatureToggle'),
+    setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggle')),
     connect(mapStateToProps),
     injectFeatureToggle(flagName, propKey)
   )(WrappedComponent);

--- a/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -4,7 +4,7 @@ import type { FlagName } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
 import { connect } from 'react-redux';
-import { compose } from 'recompose';
+import flowRight from 'lodash.flowright';
 import { selectFlags } from '../../ducks';
 import {
   injectFeatureToggle,
@@ -24,7 +24,7 @@ export default (flagName: FlagName, propKey?: string) => (
   WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>
 ) =>
   /* istanbul ignore next */
-  compose(
+  flowRight(
     wrapDisplayName('injectFeatureToggle'),
     connect(mapStateToProps),
     injectFeatureToggle(flagName, propKey)

--- a/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -4,9 +4,13 @@ import type { FlagName } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
 import { connect } from 'react-redux';
-import { compose, setDisplayName, wrapDisplayName } from 'recompose';
+import { compose } from 'recompose';
 import { selectFlags } from '../../ducks';
-import { injectFeatureToggle, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
+import {
+  injectFeatureToggle,
+  wrapDisplayName,
+  ALL_FLAGS_PROP_KEY,
+} from '@flopflip/react';
 import { STATE_SLICE } from './../../store';
 
 type RequiredProps = {};
@@ -21,7 +25,7 @@ export default (flagName: FlagName, propKey?: string) => (
 ) =>
   /* istanbul ignore next */
   compose(
-    setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggle')),
+    wrapDisplayName('injectFeatureToggle'),
     connect(mapStateToProps),
     injectFeatureToggle(flagName, propKey)
   )(WrappedComponent);

--- a/packages/react-redux/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
+++ b/packages/react-redux/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
@@ -65,7 +65,7 @@ exports[`injectFeatureToggles with \`propKey\` should match snapshot 1`] = `
         shouldDeferAdapterConfiguration={false}
       >
         <injectFeatureToggles(FeatureComponent)>
-          <withProps(omitProps(shouldUpdate(FeatureComponent)))
+          <withProps(omitProps(FeatureComponent))
             @flopflip/flags={
               Object {
                 "flag1": false,
@@ -73,7 +73,7 @@ exports[`injectFeatureToggles with \`propKey\` should match snapshot 1`] = `
             }
             dispatch={[Function]}
           >
-            <omitProps(shouldUpdate(FeatureComponent))
+            <omitProps(FeatureComponent)
               @flopflip/flags={
                 Object {
                   "flag1": false,
@@ -86,7 +86,7 @@ exports[`injectFeatureToggles with \`propKey\` should match snapshot 1`] = `
                 }
               }
             >
-              <shouldUpdate(FeatureComponent)
+              <FeatureComponent
                 dispatch={[Function]}
                 fooBar={
                   Object {
@@ -104,9 +104,9 @@ exports[`injectFeatureToggles with \`propKey\` should match snapshot 1`] = `
                 >
                   <div />
                 </FeatureComponent>
-              </shouldUpdate(FeatureComponent)>
-            </omitProps(shouldUpdate(FeatureComponent))>
-          </withProps(omitProps(shouldUpdate(FeatureComponent)))>
+              </FeatureComponent>
+            </omitProps(FeatureComponent)>
+          </withProps(omitProps(FeatureComponent))>
         </injectFeatureToggles(FeatureComponent)>
       </ConfigureAdapter>
     </ConfigureFlopflip>
@@ -179,7 +179,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled shoul
         shouldDeferAdapterConfiguration={false}
       >
         <injectFeatureToggles(FeatureComponent)>
-          <withProps(omitProps(shouldUpdate(FeatureComponent)))
+          <withProps(omitProps(FeatureComponent))
             @flopflip/flags={
               Object {
                 "flag1": false,
@@ -188,7 +188,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled shoul
             }
             dispatch={[Function]}
           >
-            <omitProps(shouldUpdate(FeatureComponent))
+            <omitProps(FeatureComponent)
               @flopflip/flags={
                 Object {
                   "flag1": false,
@@ -203,7 +203,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled shoul
                 }
               }
             >
-              <shouldUpdate(FeatureComponent)
+              <FeatureComponent
                 dispatch={[Function]}
                 featureToggles={
                   Object {
@@ -223,9 +223,9 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled shoul
                 >
                   <div />
                 </FeatureComponent>
-              </shouldUpdate(FeatureComponent)>
-            </omitProps(shouldUpdate(FeatureComponent))>
-          </withProps(omitProps(shouldUpdate(FeatureComponent)))>
+              </FeatureComponent>
+            </omitProps(FeatureComponent)>
+          </withProps(omitProps(FeatureComponent))>
         </injectFeatureToggles(FeatureComponent)>
       </ConfigureAdapter>
     </ConfigureFlopflip>
@@ -298,7 +298,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled when 
         shouldDeferAdapterConfiguration={false}
       >
         <injectFeatureToggles(FeatureComponent)>
-          <withProps(omitProps(shouldUpdate(FeatureComponent)))
+          <withProps(omitProps(FeatureComponent))
             @flopflip/flags={
               Object {
                 "flag1": true,
@@ -306,7 +306,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled when 
             }
             dispatch={[Function]}
           >
-            <omitProps(shouldUpdate(FeatureComponent))
+            <omitProps(FeatureComponent)
               @flopflip/flags={
                 Object {
                   "flag1": true,
@@ -319,7 +319,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled when 
                 }
               }
             >
-              <shouldUpdate(FeatureComponent)
+              <FeatureComponent
                 dispatch={[Function]}
                 featureToggles={
                   Object {
@@ -337,9 +337,9 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled when 
                 >
                   <div />
                 </FeatureComponent>
-              </shouldUpdate(FeatureComponent)>
-            </omitProps(shouldUpdate(FeatureComponent))>
-          </withProps(omitProps(shouldUpdate(FeatureComponent)))>
+              </FeatureComponent>
+            </omitProps(FeatureComponent)>
+          </withProps(omitProps(FeatureComponent))>
         </injectFeatureToggles(FeatureComponent)>
       </ConfigureAdapter>
     </ConfigureFlopflip>

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -4,9 +4,13 @@ import type { FlagName } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
 import { connect } from 'react-redux';
-import { compose, setDisplayName, wrapDisplayName } from 'recompose';
+import { compose } from 'recompose';
 import { selectFlags } from '../../ducks';
-import { injectFeatureToggles, ALL_FLAGS_PROP_KEY } from '@flopflip/react';
+import {
+  injectFeatureToggles,
+  wrapDisplayName,
+  ALL_FLAGS_PROP_KEY,
+} from '@flopflip/react';
 import { STATE_SLICE } from './../../store';
 
 type RequiredProps = {};
@@ -27,7 +31,7 @@ export default (
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   /* istanbul ignore next */
   compose(
-    setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggles')),
+    wrapDisplayName('injectFeatureToggles'),
     connect(mapStateToProps),
     injectFeatureToggles(flagNames, propKey, areOwnPropsEqual)
   )(WrappedComponent);

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -4,7 +4,7 @@ import type { FlagName } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
 import { connect } from 'react-redux';
-import { compose } from 'recompose';
+import flowRight from 'lodash.flowright';
 import { selectFlags } from '../../ducks';
 import {
   injectFeatureToggles,
@@ -30,7 +30,7 @@ export default (
   ) => boolean
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   /* istanbul ignore next */
-  compose(
+  flowRight(
     wrapDisplayName('injectFeatureToggles'),
     connect(mapStateToProps),
     injectFeatureToggles(flagNames, propKey, areOwnPropsEqual)

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -9,6 +9,7 @@ import { selectFlags } from '../../ducks';
 import {
   injectFeatureToggles,
   wrapDisplayName,
+  setDisplayName,
   ALL_FLAGS_PROP_KEY,
 } from '@flopflip/react';
 import { STATE_SLICE } from './../../store';
@@ -31,7 +32,7 @@ export default (
 ) => (WrappedComponent: ComponentType<$Diff<RequiredProps, ProvidedProps>>) =>
   /* istanbul ignore next */
   flowRight(
-    wrapDisplayName('injectFeatureToggles'),
+    setDisplayName(wrapDisplayName(WrappedComponent, 'injectFeatureToggles')),
     connect(mapStateToProps),
     injectFeatureToggles(flagNames, propKey, areOwnPropsEqual)
   )(WrappedComponent);

--- a/packages/react-redux/modules/components/toggle-feature/toggle-feature.js
+++ b/packages/react-redux/modules/components/toggle-feature/toggle-feature.js
@@ -2,9 +2,13 @@
 
 import type { FlagName, FlagVariation, Flags, State } from '@flopflip/types';
 
-import { compose, setDisplayName } from 'recompose';
+import flowRight from 'lodash.flowright';
 import { connect } from 'react-redux';
-import { ToggleFeature, isFeatureEnabled } from '@flopflip/react';
+import {
+  ToggleFeature,
+  setDisplayName,
+  isFeatureEnabled,
+} from '@flopflip/react';
 import { STATE_SLICE } from './../../store';
 
 type OwnProps = {
@@ -18,7 +22,7 @@ export const mapStateToProps = (state: State, ownProps: OwnProps) => ({
 });
 
 /* istanbul ignore next */
-export default compose(
+export default flowRight(
   setDisplayName(ToggleFeature.displayName),
   connect(mapStateToProps)
 )(ToggleFeature);

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -48,8 +48,7 @@
     "@flopflip/types": "^1.3.0",
     "lodash.isnil": "4.0.0",
     "lodash.memoize": "4.1.2",
-    "lodash.flowright": "3.5.0",
-    "recompose": "0.30.0"
+    "lodash.flowright": "3.5.0"
   },
   "peerDependencies": {
     "react": "^15.6 || ^16.0",

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -48,6 +48,7 @@
     "@flopflip/types": "^1.3.0",
     "lodash.isnil": "4.0.0",
     "lodash.memoize": "4.1.2",
+    "lodash.flowright": "3.5.0",
     "recompose": "0.30.0"
   },
   "peerDependencies": {

--- a/packages/react/modules/components/branch-on-feature-toggle/__snapshots__/branch-on-feature-toggle.spec.js.snap
+++ b/packages/react/modules/components/branch-on-feature-toggle/__snapshots__/branch-on-feature-toggle.spec.js.snap
@@ -1,81 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`with \`flagName\` and \`flagVariation\` when feature is disabled with untoggled component should match snapshot 1`] = `
-<renderComponent(UntoggledComponent)
-  flagName="fooFlagName"
-  fooFlagName="flagVariation2"
-/>
-`;
+exports[`with \`flagName\` and \`flagVariation\` when feature is disabled with untoggled component should match snapshot 1`] = `<UntoggledComponent />`;
 
-exports[`with \`flagName\` and \`flagVariation\` when feature is disabled without untoggled component should match snapshot 1`] = `
-<Nothing
-  flagName="fooFlagName"
-  fooFlagName="flagVariation2"
-/>
-`;
+exports[`with \`flagName\` and \`flagVariation\` when feature is disabled without untoggled component should match snapshot 1`] = `<DefaultUntoggledComponent />`;
 
-exports[`with \`flagName\` and \`flagVariation\` when feature is enabled with untoggled component should match snapshot 1`] = `
-<FeatureComponent
-  flagName="fooFlagName"
-  fooFlagName="fooflagVariation"
-/>
-`;
+exports[`with \`flagName\` and \`flagVariation\` when feature is enabled with untoggled component should match snapshot 1`] = `<FeatureComponent />`;
 
-exports[`with \`flagName\` and \`flagVariation\` when feature is enabled without untoggled component should match snapshot 1`] = `
-<FeatureComponent
-  flagName="fooFlagName"
-  fooFlagName="fooflagVariation"
-/>
-`;
+exports[`with \`flagName\` and \`flagVariation\` when feature is enabled without untoggled component should match snapshot 1`] = `<FeatureComponent />`;
 
-exports[`with \`flagName\` when feature is disabled with untoggled component should match snapshot 1`] = `
-<renderComponent(UntoggledComponent)
-  flagName="fooFlagName"
-  fooFlagName={false}
-/>
-`;
+exports[`with \`flagName\` when feature is disabled with untoggled component should match snapshot 1`] = `<UntoggledComponent />`;
 
-exports[`with \`flagName\` when feature is disabled without untoggled component should match snapshot 1`] = `
-<Nothing
-  flagName="fooFlagName"
-  fooFlagName={false}
-/>
-`;
+exports[`with \`flagName\` when feature is disabled without untoggled component should match snapshot 1`] = `<DefaultUntoggledComponent />`;
 
-exports[`with \`flagName\` when feature is enabled with untoggled component should match snapshot 1`] = `
-<FeatureComponent
-  flagName="fooFlagName"
-  fooFlagName={true}
-/>
-`;
+exports[`with \`flagName\` when feature is enabled with untoggled component should match snapshot 1`] = `<FeatureComponent />`;
 
-exports[`with \`flagName\` when feature is enabled without untoggled component should match snapshot 1`] = `
-<FeatureComponent
-  flagName="fooFlagName"
-  fooFlagName={true}
-/>
-`;
+exports[`with \`flagName\` when feature is enabled without untoggled component should match snapshot 1`] = `<FeatureComponent />`;
 
-exports[`without \`flagName\` when feature is disabled with untoggled component should match snapshot 1`] = `
-<renderComponent(UntoggledComponent)
-  isFeatureEnabled={false}
-/>
-`;
+exports[`without \`flagName\` when feature is disabled with untoggled component should match snapshot 1`] = `<UntoggledComponent />`;
 
-exports[`without \`flagName\` when feature is disabled without untoggled component should match snapshot 1`] = `
-<Nothing
-  isFeatureEnabled={false}
-/>
-`;
+exports[`without \`flagName\` when feature is disabled without untoggled component should match snapshot 1`] = `<DefaultUntoggledComponent />`;
 
-exports[`without \`flagName\` when feature is enabled with untoggled component should match snapshot 1`] = `
-<FeatureComponent
-  isFeatureEnabled={true}
-/>
-`;
+exports[`without \`flagName\` when feature is enabled with untoggled component should match snapshot 1`] = `<FeatureComponent />`;
 
-exports[`without \`flagName\` when feature is enabled without untoggled component should match snapshot 1`] = `
-<FeatureComponent
-  isFeatureEnabled={true}
-/>
-`;
+exports[`without \`flagName\` when feature is enabled without untoggled component should match snapshot 1`] = `<FeatureComponent />`;

--- a/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -2,19 +2,30 @@
 
 import type { FlagName, FlagVariation } from '@flopflip/types';
 
-import React, { type ComponentType } from 'react';
-import { branch, renderNothing, renderComponent } from 'recompose';
+import React, { Component, createElement, type ComponentType } from 'react';
 import isFeatureEnabled from '../../helpers/is-feature-enabled';
 import { DEFAULT_FLAG_PROP_KEY } from '../../constants';
 
+class DefaultUntoggledComponent extends Component<{}> {
+  render() {
+    return null;
+  }
+}
+
 const branchOnFeatureToggle = (
-  UntoggledComponent: ComponentType<any>,
+  UntoggledComponent: ComponentType<any> = DefaultUntoggledComponent,
   flagName: FlagName = DEFAULT_FLAG_PROP_KEY,
   flagVariation: FlagVariation = true
-): ComponentType<any> =>
-  branch(
-    props => !isFeatureEnabled(flagName, flagVariation)(props),
-    UntoggledComponent ? renderComponent(UntoggledComponent) : renderNothing
-  );
+) => (ToggledComponent: ComponentType<any>): ComponentType<any> => {
+  const BranchedComponent: ComponentType<any> = (props: Object) => {
+    if (isFeatureEnabled(flagName, flagVariation)(props)) {
+      return createElement(ToggledComponent);
+    } else {
+      return createElement(UntoggledComponent);
+    }
+  };
+
+  return BranchedComponent;
+};
 
 export default branchOnFeatureToggle;

--- a/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
+++ b/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.js
@@ -17,7 +17,7 @@ const branchOnFeatureToggle = (
   flagName: FlagName = DEFAULT_FLAG_PROP_KEY,
   flagVariation: FlagVariation = true
 ) => (ToggledComponent: ComponentType<any>): ComponentType<any> => {
-  const BranchedComponent: ComponentType<any> = (props: Object) => {
+  const BranchOnFeatureToggle: ComponentType<any> = (props: Object) => {
     if (isFeatureEnabled(flagName, flagVariation)(props)) {
       return createElement(ToggledComponent);
     } else {
@@ -25,7 +25,7 @@ const branchOnFeatureToggle = (
     }
   };
 
-  return BranchedComponent;
+  return BranchOnFeatureToggle;
 };
 
 export default branchOnFeatureToggle;

--- a/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
+++ b/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
@@ -6,9 +6,6 @@ const UntoggledComponent = () => (
   <React.Fragment>UntoggledComponent</React.Fragment>
 );
 UntoggledComponent.displayName = 'UntoggledComponent';
-// This is a shortcut for test expectations on the display name as recompose
-// wraps it for us.
-UntoggledComponent.wrappedDisplayName = 'renderComponent(UntoggledComponent)';
 const FeatureComponent = () => (
   <React.Fragment>FeatureComponent</React.Fragment>
 );
@@ -56,7 +53,7 @@ describe('with `flagName`', () => {
       });
 
       it('should not render the `UntoggledComponent`', () => {
-        expect(wrapper).not.toRender(UntoggledComponent.wrappedDisplayName);
+        expect(wrapper).not.toRender(UntoggledComponent.displayName);
       });
 
       it('should render the `FeatureComponent`', () => {
@@ -83,7 +80,7 @@ describe('with `flagName`', () => {
       });
 
       it('should render the `UntoggledComponent`', () => {
-        expect(wrapper).toRender(UntoggledComponent.wrappedDisplayName);
+        expect(wrapper).toRender(UntoggledComponent.displayName);
       });
     });
 
@@ -154,7 +151,7 @@ describe('with `flagName` and `flagVariation`', () => {
       });
 
       it('should not render the `UntoggledComponent`', () => {
-        expect(wrapper).not.toRender(UntoggledComponent.wrappedDisplayName);
+        expect(wrapper).not.toRender(UntoggledComponent.displayName);
       });
 
       it('should render the `FeatureComponent`', () => {
@@ -184,7 +181,7 @@ describe('with `flagName` and `flagVariation`', () => {
       });
 
       it('should render the `UntoggledComponent`', () => {
-        expect(wrapper).toRender(UntoggledComponent.wrappedDisplayName);
+        expect(wrapper).toRender(UntoggledComponent.displayName);
       });
     });
 
@@ -246,7 +243,7 @@ describe('without `flagName`', () => {
       });
 
       it('should not render the `UntoggledComponent`', () => {
-        expect(wrapper).not.toRender(UntoggledComponent.wrappedDisplayName);
+        expect(wrapper).not.toRender(UntoggledComponent.displayName);
       });
 
       it('should render the `FeatureComponent`', () => {
@@ -271,7 +268,7 @@ describe('without `flagName`', () => {
       });
 
       it('should render the `UntoggledComponent`', () => {
-        expect(wrapper).toRender(UntoggledComponent.wrappedDisplayName);
+        expect(wrapper).toRender(UntoggledComponent.displayName);
       });
     });
 

--- a/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
+++ b/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
@@ -53,7 +53,7 @@ describe('with `flagName`', () => {
       });
 
       it('should not render the `UntoggledComponent`', () => {
-        expect(wrapper).not.toRender(UntoggledComponent.displayName);
+        expect(wrapper).not.toRender(UntoggledComponent);
       });
 
       it('should render the `FeatureComponent`', () => {
@@ -80,7 +80,7 @@ describe('with `flagName`', () => {
       });
 
       it('should render the `UntoggledComponent`', () => {
-        expect(wrapper).toRender(UntoggledComponent.displayName);
+        expect(wrapper).toRender(UntoggledComponent);
       });
     });
 
@@ -151,7 +151,7 @@ describe('with `flagName` and `flagVariation`', () => {
       });
 
       it('should not render the `UntoggledComponent`', () => {
-        expect(wrapper).not.toRender(UntoggledComponent.displayName);
+        expect(wrapper).not.toRender(UntoggledComponent);
       });
 
       it('should render the `FeatureComponent`', () => {
@@ -181,7 +181,7 @@ describe('with `flagName` and `flagVariation`', () => {
       });
 
       it('should render the `UntoggledComponent`', () => {
-        expect(wrapper).toRender(UntoggledComponent.displayName);
+        expect(wrapper).toRender(UntoggledComponent);
       });
     });
 
@@ -243,7 +243,7 @@ describe('without `flagName`', () => {
       });
 
       it('should not render the `UntoggledComponent`', () => {
-        expect(wrapper).not.toRender(UntoggledComponent.displayName);
+        expect(wrapper).not.toRender(UntoggledComponent);
       });
 
       it('should render the `FeatureComponent`', () => {
@@ -268,7 +268,7 @@ describe('without `flagName`', () => {
       });
 
       it('should render the `UntoggledComponent`', () => {
-        expect(wrapper).toRender(UntoggledComponent.displayName);
+        expect(wrapper).toRender(UntoggledComponent);
       });
     });
 

--- a/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
+++ b/packages/react/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
@@ -99,8 +99,8 @@ describe('with `flagName`', () => {
         expect(wrapper).toMatchSnapshot();
       });
 
-      it('should render `Nothing`', () => {
-        expect(wrapper).toRender('Nothing');
+      it('should render `DefaultUntoggledComponent`', () => {
+        expect(wrapper).toRender('DefaultUntoggledComponent');
       });
     });
   });
@@ -200,8 +200,8 @@ describe('with `flagName` and `flagVariation`', () => {
         expect(wrapper).toMatchSnapshot();
       });
 
-      it('should render `Nothing`', () => {
-        expect(wrapper).toRender('Nothing');
+      it('should render `DefaultUntoggledComponent`', () => {
+        expect(wrapper).toRender('DefaultUntoggledComponent');
       });
     });
   });
@@ -285,8 +285,8 @@ describe('without `flagName`', () => {
         expect(wrapper).toMatchSnapshot();
       });
 
-      it('should render `Nothing`', () => {
-        expect(wrapper).toRender('Nothing');
+      it('should render `DefaultUntoggledComponent`', () => {
+        expect(wrapper).toRender('DefaultUntoggledComponent');
       });
     });
   });

--- a/packages/react/modules/components/configure-adapter/with-reconfiguration.js
+++ b/packages/react/modules/components/configure-adapter/with-reconfiguration.js
@@ -3,7 +3,7 @@
 import type { Adapter } from '@flopflip/types';
 
 import React, { PureComponent, type ComponentType, type Node } from 'react';
-import { wrapDisplayName } from 'recompose';
+import { wrapDisplayName } from '../../hocs/wrap-display-name';
 import { AdapterContext } from './configure-adapter';
 
 type RequiredProps = {};
@@ -15,7 +15,7 @@ const withReconfiguration = (propKey: string = 'reconfigure') => (
   class EnhancedComponent extends PureComponent<
     $Diff<RequiredProps, ProvidedProps>
   > {
-    static displayName = wrapDisplayName(Component, 'withReconfiguration');
+    static displayName = wrapDisplayName('withReconfiguration', Component);
     render(): Node {
       return (
         <AdapterContext.Consumer>

--- a/packages/react/modules/components/configure-adapter/with-reconfiguration.js
+++ b/packages/react/modules/components/configure-adapter/with-reconfiguration.js
@@ -3,7 +3,6 @@
 import type { Adapter } from '@flopflip/types';
 
 import React, { PureComponent, type ComponentType, type Node } from 'react';
-import { wrapDisplayName } from '../../hocs/wrap-display-name';
 import { AdapterContext } from './configure-adapter';
 
 type RequiredProps = {};
@@ -15,7 +14,8 @@ const withReconfiguration = (propKey: string = 'reconfigure') => (
   class EnhancedComponent extends PureComponent<
     $Diff<RequiredProps, ProvidedProps>
   > {
-    static displayName = wrapDisplayName('withReconfiguration', Component);
+    static displayName = `withReconfiguration(${Component.displayName ||
+      Component.name})`;
     render(): Node {
       return (
         <AdapterContext.Consumer>

--- a/packages/react/modules/components/inject-feature-toggle/__snapshots__/inject-feature-toggle.spec.js.snap
+++ b/packages/react/modules/components/inject-feature-toggle/__snapshots__/inject-feature-toggle.spec.js.snap
@@ -1,23 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`injecting with \`propKey\` should match snapshot 1`] = `
-<omitProps(TestComponent)
+<withProps(omitProps(TestComponent))
   @flopflip/flags={
     Object {
       "aFeatureToggle": true,
     }
   }
-  fooFlagPropName={true}
-/>
+>
+  <omitProps(TestComponent)
+    @flopflip/flags={
+      Object {
+        "aFeatureToggle": true,
+      }
+    }
+    fooFlagPropName={true}
+  >
+    <TestComponent
+      fooFlagPropName={true}
+    >
+      Test
+    </TestComponent>
+  </omitProps(TestComponent)>
+</withProps(omitProps(TestComponent))>
 `;
 
 exports[`injecting without \`propKey\` should match snapshot 1`] = `
-<omitProps(TestComponent)
+<withProps(omitProps(TestComponent))
   @flopflip/flags={
     Object {
       "aFeatureToggle": true,
     }
   }
-  isFeatureEnabled={true}
-/>
+>
+  <omitProps(TestComponent)
+    @flopflip/flags={
+      Object {
+        "aFeatureToggle": true,
+      }
+    }
+    isFeatureEnabled={true}
+  >
+    <TestComponent
+      isFeatureEnabled={true}
+    >
+      Test
+    </TestComponent>
+  </omitProps(TestComponent)>
+</withProps(omitProps(TestComponent))>
 `;

--- a/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -3,7 +3,8 @@
 import type { FlagName, FlagValue } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
-import { compose, withProps } from 'recompose';
+import flowRight from 'lodash.flowright';
+import { withProps } from 'recompose';
 import isNil from 'lodash.isnil';
 import { omitProps } from '../../hocs';
 import { DEFAULT_FLAG_PROP_KEY, ALL_FLAGS_PROP_KEY } from '../../constants';
@@ -15,7 +16,7 @@ const injectFeatureToggle = (
   flagName: FlagName,
   propKey: string = DEFAULT_FLAG_PROP_KEY
 ): ComponentType<$Diff<RequiredProps, ProvidedProps>> =>
-  compose(
+  flowRight(
     withProps((props: RequiredProps) => {
       const flagValue: FlagValue = props[ALL_FLAGS_PROP_KEY][flagName];
 

--- a/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -4,7 +4,7 @@ import type { FlagName, FlagValue } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
 import flowRight from 'lodash.flowright';
-import { withProps } from 'recompose';
+import { withProps } from '../../hocs';
 import isNil from 'lodash.isnil';
 import { omitProps } from '../../hocs';
 import { DEFAULT_FLAG_PROP_KEY, ALL_FLAGS_PROP_KEY } from '../../constants';

--- a/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.js
+++ b/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.js
@@ -17,8 +17,8 @@ const injectFeatureToggle = (
   propKey: string = DEFAULT_FLAG_PROP_KEY
 ): ComponentType<$Diff<RequiredProps, ProvidedProps>> =>
   flowRight(
-    withProps((props: RequiredProps) => {
-      const flagValue: FlagValue = props[ALL_FLAGS_PROP_KEY][flagName];
+    withProps((ownProps: RequiredProps) => {
+      const flagValue: FlagValue = ownProps[ALL_FLAGS_PROP_KEY][flagName];
 
       return { [propKey]: isNil(flagValue) ? false : flagValue };
     }),

--- a/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
+++ b/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { ALL_FLAGS_PROP_KEY } from '../../constants';
 import injectFeatureToggle from './inject-feature-toggle';
 
@@ -25,7 +25,7 @@ describe('injecting', () => {
       props = createTestProps();
 
       Component = injectFeatureToggle(flagName, propKey)(TestComponent);
-      wrapper = shallow(<Component {...props} />);
+      wrapper = mount(<Component {...props} />);
     });
 
     it('should match snapshot', () => {
@@ -33,7 +33,10 @@ describe('injecting', () => {
     });
 
     it("should pass the feature toggle's state as a `prop` of `propKey`", () => {
-      expect(wrapper).toHaveProp(propKey, props[ALL_FLAGS_PROP_KEY][flagName]);
+      expect(wrapper.find(TestComponent)).toHaveProp(
+        propKey,
+        props[ALL_FLAGS_PROP_KEY][flagName]
+      );
     });
   });
 
@@ -44,7 +47,7 @@ describe('injecting', () => {
       props = createTestProps();
 
       Component = injectFeatureToggle(flagName)(TestComponent);
-      wrapper = shallow(<Component {...props} />);
+      wrapper = mount(<Component {...props} />);
     });
 
     it('should match snapshot', () => {
@@ -52,7 +55,7 @@ describe('injecting', () => {
     });
 
     it("should pass the feature toggle's state as a `prop` of `isFeatureEnabled`", () => {
-      expect(wrapper).toHaveProp('isFeatureEnabled', true);
+      expect(wrapper.find(TestComponent)).toHaveProp('isFeatureEnabled', true);
     });
   });
 
@@ -64,11 +67,11 @@ describe('injecting', () => {
       props = createTestProps();
 
       Component = injectFeatureToggle(anotherFlagName)(TestComponent);
-      wrapper = shallow(<Component {...props} />);
+      wrapper = mount(<Component {...props} />);
     });
 
     it("should pass the feature toggle's state as `false`", () => {
-      expect(wrapper).toHaveProp('isFeatureEnabled', false);
+      expect(wrapper.find(TestComponent)).toHaveProp('isFeatureEnabled', false);
     });
   });
 
@@ -79,11 +82,11 @@ describe('injecting', () => {
       props = createTestProps({ [flagName]: 'blue' });
 
       Component = injectFeatureToggle(flagName)(TestComponent);
-      wrapper = shallow(<Component {...props} />);
+      wrapper = mount(<Component {...props} />);
     });
 
     it("should pass the feature toggle's state as the value", () => {
-      expect(wrapper).toHaveProp(flagName, 'blue');
+      expect(wrapper.find(TestComponent)).toHaveProp(flagName, 'blue');
     });
   });
 });

--- a/packages/react/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
+++ b/packages/react/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
@@ -1,16 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`injecting with single feature toggle should match snapshot 1`] = `
-<omitProps(shouldUpdate(TestComponent))
+<withProps(omitProps(TestComponent))
   @flopflip/flags={
     Object {
       "aFeatureToggle": true,
     }
   }
-  featureToggles={
-    Object {
-      "aFeatureToggle": true,
+>
+  <omitProps(TestComponent)
+    @flopflip/flags={
+      Object {
+        "aFeatureToggle": true,
+      }
     }
-  }
-/>
+    featureToggles={
+      Object {
+        "aFeatureToggle": true,
+      }
+    }
+  >
+    <TestComponent
+      featureToggles={
+        Object {
+          "aFeatureToggle": true,
+        }
+      }
+    >
+      <TestComponent
+        featureToggles={
+          Object {
+            "aFeatureToggle": true,
+          }
+        }
+      >
+        Test
+      </TestComponent>
+    </TestComponent>
+  </omitProps(TestComponent)>
+</withProps(omitProps(TestComponent))>
 `;

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -4,7 +4,8 @@ import type { FlagName, Flags, Flag } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
 
-import { withProps, shouldUpdate, shallowEqual } from 'recompose';
+import { withProps, shouldUpdate } from 'recompose';
+const isEqual = require('react-fast-compare');
 import flowRight from 'lodash.flowright';
 import intersection from 'lodash.intersection';
 import omit from 'lodash.omit';
@@ -36,8 +37,8 @@ export const areOwnPropsEqual = (
   ]);
 
   return (
-    shallowEqual(featureFlagProps, nextFeatureFlagProps) &&
-    shallowEqual(remainingProps, nextRemainingProps)
+    isEqual(featureFlagProps, nextFeatureFlagProps) &&
+    isEqual(remainingProps, nextRemainingProps)
   );
 };
 

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -56,21 +56,20 @@ const injectFeatureToggles = (
       [propKey]: filterFeatureToggles(props[ALL_FLAGS_PROP_KEY], flagNames),
     })),
     omitProps(ALL_FLAGS_PROP_KEY),
-    (props: ProvidedProps) => (BaseComponent: ComponentType<any>) => {
+    (BaseComponent: ComponentType<ProvidedProps>) =>
       class ShouldUpdate extends Component<{}> {
+        static displayName = BaseComponent.displayName;
+
         shouldComponentUpdate(nextProps: ProvidedProps) {
           return typeof areOwnPropsEqual === 'function'
-            ? !areOwnPropsEqual(props, nextProps, propKey)
+            ? !areOwnPropsEqual(this.props, nextProps, propKey)
             : true;
         }
 
         render() {
-          return createElement(BaseComponent, this.props);
+          return <BaseComponent {...this.props} />;
         }
       }
-
-      return ShouldUpdate;
-    }
   );
 
 export default injectFeatureToggles;

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -4,7 +4,8 @@ import type { FlagName, Flags, Flag } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
 
-import { compose, withProps, shouldUpdate, shallowEqual } from 'recompose';
+import { withProps, shouldUpdate, shallowEqual } from 'recompose';
+import flowRight from 'lodash.flowright';
 import intersection from 'lodash.intersection';
 import omit from 'lodash.omit';
 import { omitProps } from '../../hocs';
@@ -49,7 +50,7 @@ const injectFeatureToggles = (
     propKey: string
   ) => boolean = areOwnPropsEqual
 ): ComponentType<$Diff<RequiredProps, ProvidedProps>> =>
-  compose(
+  flowRight(
     withProps((props: RequiredProps) => ({
       [propKey]: filterFeatureToggles(props[ALL_FLAGS_PROP_KEY], flagNames),
     })),

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -4,7 +4,6 @@ import type { FlagName, Flags, Flag } from '@flopflip/types';
 
 import React, { createElement, Component, type ComponentType } from 'react';
 
-import { shouldUpdate } from 'recompose';
 import { withProps } from '../../hocs';
 import isEqual from 'react-fast-compare';
 import flowRight from 'lodash.flowright';

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -4,8 +4,9 @@ import type { FlagName, Flags, Flag } from '@flopflip/types';
 
 import React, { type ComponentType } from 'react';
 
-import { withProps, shouldUpdate } from 'recompose';
-const isEqual = require('react-fast-compare');
+import { shouldUpdate } from 'recompose';
+import { withProps } from '../../hocs';
+import isEqual from 'react-fast-compare';
 import flowRight from 'lodash.flowright';
 import intersection from 'lodash.intersection';
 import omit from 'lodash.omit';

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.js
@@ -2,7 +2,7 @@
 
 import type { FlagName, Flags, Flag } from '@flopflip/types';
 
-import React, { type ComponentType } from 'react';
+import React, { createElement, Component, type ComponentType } from 'react';
 
 import { shouldUpdate } from 'recompose';
 import { withProps } from '../../hocs';
@@ -57,11 +57,21 @@ const injectFeatureToggles = (
       [propKey]: filterFeatureToggles(props[ALL_FLAGS_PROP_KEY], flagNames),
     })),
     omitProps(ALL_FLAGS_PROP_KEY),
-    shouldUpdate((props: ProvidedProps, nextProps: ProvidedProps) =>
-      typeof areOwnPropsEqual === 'function'
-        ? !areOwnPropsEqual(props, nextProps, propKey)
-        : true
-    )
+    (props: ProvidedProps) => (BaseComponent: ComponentType<any>) => {
+      class ShouldUpdate extends Component<{}> {
+        shouldComponentUpdate(nextProps: ProvidedProps) {
+          return typeof areOwnPropsEqual === 'function'
+            ? !areOwnPropsEqual(props, nextProps, propKey)
+            : true;
+        }
+
+        render() {
+          return createElement(BaseComponent, this.props);
+        }
+      }
+
+      return ShouldUpdate;
+    }
   );
 
 export default injectFeatureToggles;

--- a/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
+++ b/packages/react/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { ALL_FLAGS_PROP_KEY, DEFAULT_FLAGS_PROP_KEY } from '../../constants';
 import injectFeatureToggles, {
   areOwnPropsEqual,
@@ -25,7 +25,7 @@ describe('injecting', () => {
       props = createTestProps();
 
       Component = injectFeatureToggles([featureToggle])(TestComponent);
-      wrapper = shallow(<Component {...props} />);
+      wrapper = mount(<Component {...props} />);
     });
 
     it('should match snapshot', () => {
@@ -33,14 +33,14 @@ describe('injecting', () => {
     });
 
     it('should pass all requested feature toggles as a `prop`', () => {
-      expect(wrapper).toHaveProp(
+      expect(wrapper.find(TestComponent)).toHaveProp(
         DEFAULT_FLAGS_PROP_KEY,
         props[ALL_FLAGS_PROP_KEY]
       );
     });
 
     it("should pass the feature toggle's state as a `prop`", () => {
-      expect(wrapper).toHaveProp(DEFAULT_FLAGS_PROP_KEY, {
+      expect(wrapper.find(TestComponent)).toHaveProp(DEFAULT_FLAGS_PROP_KEY, {
         [featureToggle]: props[ALL_FLAGS_PROP_KEY][featureToggle],
       });
     });
@@ -64,11 +64,11 @@ describe('injecting', () => {
         Component = injectFeatureToggles([featureToggle, featureToggle2])(
           TestComponent
         );
-        wrapper = shallow(<Component {...props} />);
+        wrapper = mount(<Component {...props} />);
       });
 
       it('should pass all requested feature toggles as a `prop`', () => {
-        expect(wrapper).toHaveProp(
+        expect(wrapper.find(TestComponent)).toHaveProp(
           DEFAULT_FLAGS_PROP_KEY,
           props[ALL_FLAGS_PROP_KEY]
         );
@@ -87,25 +87,28 @@ describe('injecting', () => {
           featureToggle,
           nonExistingFeatureToggle,
         ])(TestComponent);
-        wrapper = shallow(<Component {...props} />);
+        wrapper = mount(<Component {...props} />);
       });
 
       it('should pass requested feature toggles as a `prop`', () => {
-        expect(wrapper).toHaveProp(DEFAULT_FLAGS_PROP_KEY, {
+        expect(wrapper.find(TestComponent)).toHaveProp(DEFAULT_FLAGS_PROP_KEY, {
           [featureToggle]: expect.any(Boolean),
         });
       });
 
       it("should pass the feature toggle's state as a `prop`", () => {
-        expect(wrapper).toHaveProp(DEFAULT_FLAGS_PROP_KEY, {
+        expect(wrapper.find(TestComponent)).toHaveProp(DEFAULT_FLAGS_PROP_KEY, {
           [featureToggle]: props[ALL_FLAGS_PROP_KEY][featureToggle],
         });
       });
 
       it('should omit requested but non existent feature toggles from `props`', () => {
-        expect(wrapper).not.toHaveProp(DEFAULT_FLAGS_PROP_KEY, {
-          [nonExistingFeatureToggle]: expect.any(Boolean),
-        });
+        expect(wrapper.find(TestComponent)).not.toHaveProp(
+          DEFAULT_FLAGS_PROP_KEY,
+          {
+            [nonExistingFeatureToggle]: expect.any(Boolean),
+          }
+        );
       });
     });
 
@@ -122,11 +125,14 @@ describe('injecting', () => {
           [featureToggle, featureToggle2],
           'fooPropKey'
         )(TestComponent);
-        wrapper = shallow(<Component {...props} />);
+        wrapper = mount(<Component {...props} />);
       });
 
       it('should map all feature toggles', () => {
-        expect(wrapper).toHaveProp('fooPropKey', props[ALL_FLAGS_PROP_KEY]);
+        expect(wrapper.find(TestComponent)).toHaveProp(
+          'fooPropKey',
+          props[ALL_FLAGS_PROP_KEY]
+        );
       });
     });
   });

--- a/packages/react/modules/hocs/index.js
+++ b/packages/react/modules/hocs/index.js
@@ -1,1 +1,3 @@
 export { omitProps } from './omit-props';
+export { setDisplayName } from './set-display-name';
+export { wrapDisplayName } from './wrap-display-name';

--- a/packages/react/modules/hocs/index.js
+++ b/packages/react/modules/hocs/index.js
@@ -1,3 +1,4 @@
 export { omitProps } from './omit-props';
 export { setDisplayName } from './set-display-name';
 export { wrapDisplayName } from './wrap-display-name';
+export { withProps } from './with-props';

--- a/packages/react/modules/hocs/omit-props/omit-props.js
+++ b/packages/react/modules/hocs/omit-props/omit-props.js
@@ -1,5 +1,5 @@
 import { createElement } from 'react';
-import { setDisplayName, wrapDisplayName } from 'recompose';
+import { wrapDisplayName } from '../wrap-display-name';
 import omit from 'lodash.omit';
 
 const omitProps = (...propsToOmit) => WrappedComponent => {
@@ -7,9 +7,7 @@ const omitProps = (...propsToOmit) => WrappedComponent => {
     createElement(WrappedComponent, omit(props, propsToOmit));
 
   if (process.env.NODE_ENV !== 'production') {
-    return setDisplayName(wrapDisplayName(WrappedComponent, 'omitProps'))(
-      WithPropsOmitted
-    );
+    return wrapDisplayName('omitProps', WrappedComponent)(WithPropsOmitted);
   }
 
   return WithPropsOmitted;

--- a/packages/react/modules/hocs/omit-props/omit-props.js
+++ b/packages/react/modules/hocs/omit-props/omit-props.js
@@ -1,9 +1,18 @@
-import { createElement } from 'react';
+// @flow
+
+import { createElement, type ComponentType } from 'react';
 import { wrapDisplayName } from '../wrap-display-name';
 import { setDisplayName } from '../set-display-name';
 import omit from 'lodash.omit';
 
-const omitProps = (...propsToOmit) => BaseComponent => {
+type ProvidedProps = {};
+type OmitProps = {
+  [key: string]: any,
+};
+
+const omitProps = (...propsToOmit: Array<$Keys<OmitProps>>) => (
+  BaseComponent: ComponentType<ProvidedProps>
+): ComponentType<$Diff<ProvidedProps, OmitProps>> => {
   const OmitProps = props =>
     createElement(BaseComponent, omit(props, propsToOmit));
 

--- a/packages/react/modules/hocs/omit-props/omit-props.js
+++ b/packages/react/modules/hocs/omit-props/omit-props.js
@@ -1,16 +1,19 @@
 import { createElement } from 'react';
 import { wrapDisplayName } from '../wrap-display-name';
+import { setDisplayName } from '../set-display-name';
 import omit from 'lodash.omit';
 
 const omitProps = (...propsToOmit) => BaseComponent => {
-  const WithPropsOmitted = props =>
+  const OmitProps = props =>
     createElement(BaseComponent, omit(props, propsToOmit));
 
   if (process.env.NODE_ENV !== 'production') {
-    return wrapDisplayName('omitProps', BaseComponent)(WithPropsOmitted);
+    return setDisplayName(wrapDisplayName(BaseComponent, 'omitProps'))(
+      OmitProps
+    );
   }
 
-  return WithPropsOmitted;
+  return OmitProps;
 };
 
 export default omitProps;

--- a/packages/react/modules/hocs/omit-props/omit-props.js
+++ b/packages/react/modules/hocs/omit-props/omit-props.js
@@ -2,12 +2,12 @@ import { createElement } from 'react';
 import { wrapDisplayName } from '../wrap-display-name';
 import omit from 'lodash.omit';
 
-const omitProps = (...propsToOmit) => WrappedComponent => {
+const omitProps = (...propsToOmit) => BaseComponent => {
   const WithPropsOmitted = props =>
-    createElement(WrappedComponent, omit(props, propsToOmit));
+    createElement(BaseComponent, omit(props, propsToOmit));
 
   if (process.env.NODE_ENV !== 'production') {
-    return wrapDisplayName('omitProps', WrappedComponent)(WithPropsOmitted);
+    return wrapDisplayName('omitProps', BaseComponent)(WithPropsOmitted);
   }
 
   return WithPropsOmitted;

--- a/packages/react/modules/hocs/omit-props/omit-props.spec.js
+++ b/packages/react/modules/hocs/omit-props/omit-props.spec.js
@@ -13,15 +13,16 @@ const createTestProps = (custom = {}) => ({
 });
 
 describe('rendering', () => {
-  let EnhancedTarget;
+  let EnhancedComponent;
   let props;
   let wrapper;
 
   describe('with multiple props', () => {
     beforeEach(() => {
-      EnhancedTarget = omitProps('a', 'b')(WrappedComponent);
+      EnhancedComponent = omitProps('a', 'b')(WrappedComponent);
       props = createTestProps();
-      wrapper = shallow(<EnhancedTarget {...props} />);
+
+      wrapper = shallow(<EnhancedComponent {...props} />);
     });
 
     it('should omit multiple props', () => {
@@ -31,8 +32,8 @@ describe('rendering', () => {
 
   describe('without any props', () => {
     beforeEach(() => {
-      EnhancedTarget = omitProps()(WrappedComponent);
-      wrapper = shallow(<EnhancedTarget {...props} />);
+      EnhancedComponent = omitProps()(WrappedComponent);
+      wrapper = shallow(<EnhancedComponent {...props} />);
     });
 
     it('should do nothing', () => {

--- a/packages/react/modules/hocs/set-display-name/__snapshots__/set-display-name.spec.js.snap
+++ b/packages/react/modules/hocs/set-display-name/__snapshots__/set-display-name.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rendering should match snapshot 1`] = `"BaseComponent"`;

--- a/packages/react/modules/hocs/set-display-name/__snapshots__/set-display-name.spec.js.snap
+++ b/packages/react/modules/hocs/set-display-name/__snapshots__/set-display-name.spec.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`rendering should match snapshot 1`] = `"BaseComponent"`;

--- a/packages/react/modules/hocs/set-display-name/index.js
+++ b/packages/react/modules/hocs/set-display-name/index.js
@@ -1,0 +1,1 @@
+export { default as setDisplayName } from './set-display-name';

--- a/packages/react/modules/hocs/set-display-name/set-display-name.js
+++ b/packages/react/modules/hocs/set-display-name/set-display-name.js
@@ -1,4 +1,12 @@
-export default nextDisplayName => BaseComponent => {
+// @flow
+
+import { type ComponentType } from 'react';
+
+type ProvidedProps = {};
+
+export default (nextDisplayName: string) => (
+  BaseComponent: ComponentType<ProvidedProps>
+): ComponentType<ProvidedProps> => {
   BaseComponent['displayName'] = nextDisplayName;
 
   return BaseComponent;

--- a/packages/react/modules/hocs/set-display-name/set-display-name.js
+++ b/packages/react/modules/hocs/set-display-name/set-display-name.js
@@ -1,0 +1,5 @@
+export default nextDisplayName => BaseComponent => {
+  BaseComponent['displayName'] = nextDisplayName;
+
+  return BaseComponent;
+};

--- a/packages/react/modules/hocs/set-display-name/set-display-name.spec.js
+++ b/packages/react/modules/hocs/set-display-name/set-display-name.spec.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import setDisplayName from './set-display-name';
+
+function BaseComponent() {
+  return 'BaseComponent';
+}
+BaseComponent.displayName = 'BaseComponent';
+
+describe('rendering', () => {
+  const nextDisplayName = 'RenamedBaseComponent';
+  let EnhancedComponent;
+  let wrapper;
+
+  beforeEach(() => {
+    EnhancedComponent = setDisplayName(nextDisplayName)(BaseComponent);
+  });
+
+  it('should overwrite the previous display name', () => {
+    expect(EnhancedComponent.displayName).toEqual(nextDisplayName);
+  });
+});

--- a/packages/react/modules/hocs/with-props/__snapshots__/with-props.spec.js.snap
+++ b/packages/react/modules/hocs/with-props/__snapshots__/with-props.spec.js.snap
@@ -1,6 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`rendering should match snapshot 1`] = `
+exports[`rendering with \`mapProps\` being function should match snapshot 1`] = `
+<withProps(WithProps)
+  a={1}
+>
+  <BaseComponent
+    a={1}
+    b="b"
+  />
+</withProps(WithProps)>
+`;
+
+exports[`rendering with \`mapProps\` being object should match snapshot 1`] = `
 <withProps(WithProps)
   a={1}
 >

--- a/packages/react/modules/hocs/with-props/__snapshots__/with-props.spec.js.snap
+++ b/packages/react/modules/hocs/with-props/__snapshots__/with-props.spec.js.snap
@@ -1,23 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rendering with \`mapProps\` being function should match snapshot 1`] = `
-<withProps(WithProps)
+<withProps(BaseComponent)
   a={1}
 >
   <BaseComponent
     a={1}
     b="b"
   />
-</withProps(WithProps)>
+</withProps(BaseComponent)>
 `;
 
 exports[`rendering with \`mapProps\` being object should match snapshot 1`] = `
-<withProps(WithProps)
+<withProps(BaseComponent)
   a={1}
 >
   <BaseComponent
     a={1}
     b="b"
   />
-</withProps(WithProps)>
+</withProps(BaseComponent)>
 `;

--- a/packages/react/modules/hocs/with-props/__snapshots__/with-props.spec.js.snap
+++ b/packages/react/modules/hocs/with-props/__snapshots__/with-props.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rendering should match snapshot 1`] = `
+<withProps(WithProps)
+  a={1}
+>
+  <BaseComponent
+    a={1}
+    b="b"
+  />
+</withProps(WithProps)>
+`;

--- a/packages/react/modules/hocs/with-props/index.js
+++ b/packages/react/modules/hocs/with-props/index.js
@@ -1,0 +1,1 @@
+export { default as withProps } from './with-props';

--- a/packages/react/modules/hocs/with-props/with-props.js
+++ b/packages/react/modules/hocs/with-props/with-props.js
@@ -1,5 +1,6 @@
 import React, { createElement } from 'react';
 import { wrapDisplayName } from '../wrap-display-name';
+import { setDisplayName } from '../set-display-name';
 
 const withProps = mapProps => BaseComponent => {
   const WithProps = ownProps => {
@@ -12,7 +13,9 @@ const withProps = mapProps => BaseComponent => {
   };
 
   if (process.env.NODE_ENV !== 'production') {
-    return wrapDisplayName('withProps', BaseComponent)(WithProps);
+    return setDisplayName(wrapDisplayName(BaseComponent, 'withProps'))(
+      WithProps
+    );
   }
 
   return WithProps;

--- a/packages/react/modules/hocs/with-props/with-props.js
+++ b/packages/react/modules/hocs/with-props/with-props.js
@@ -1,0 +1,15 @@
+import React, { createElement } from 'react';
+import { wrapDisplayName } from '../wrap-display-name';
+
+const withProps = baseProps => BaseComponent => {
+  const WithProps = enhancedProps =>
+    createElement(BaseComponent, { ...baseProps, ...enhancedProps });
+
+  if (process.env.NODE_ENV !== 'production') {
+    return wrapDisplayName('withProps', BaseComponent)(WithProps);
+  }
+
+  return WithProps;
+};
+
+export default withProps;

--- a/packages/react/modules/hocs/with-props/with-props.js
+++ b/packages/react/modules/hocs/with-props/with-props.js
@@ -1,9 +1,16 @@
-import React, { createElement } from 'react';
+// @flow
+import React, { createElement, type ComponentType } from 'react';
+
 import { wrapDisplayName } from '../wrap-display-name';
 import { setDisplayName } from '../set-display-name';
 
-const withProps = mapProps => BaseComponent => {
-  const WithProps = ownProps => {
+type WithProps = {};
+type ProvidedProps = {};
+
+const withProps = (
+  mapProps: WithProps | ((ownProps: ProvidedProps) => WithProps)
+) => (BaseComponent: ComponentType<ProvidedProps & WithProps>) => {
+  const WithProps = (ownProps: ProvidedProps): ProvidedProps & WithProps => {
     const enhancedProps =
       typeof mapProps === 'function'
         ? { ...ownProps, ...mapProps(ownProps) }

--- a/packages/react/modules/hocs/with-props/with-props.js
+++ b/packages/react/modules/hocs/with-props/with-props.js
@@ -1,9 +1,15 @@
 import React, { createElement } from 'react';
 import { wrapDisplayName } from '../wrap-display-name';
 
-const withProps = baseProps => BaseComponent => {
-  const WithProps = enhancedProps =>
-    createElement(BaseComponent, { ...baseProps, ...enhancedProps });
+const withProps = mapProps => BaseComponent => {
+  const WithProps = ownProps => {
+    const enhancedProps =
+      typeof mapProps === 'function'
+        ? { ...ownProps, ...mapProps(ownProps) }
+        : { ...ownProps, ...mapProps };
+
+    return createElement(BaseComponent, enhancedProps);
+  };
 
   if (process.env.NODE_ENV !== 'production') {
     return wrapDisplayName('withProps', BaseComponent)(WithProps);

--- a/packages/react/modules/hocs/with-props/with-props.spec.js
+++ b/packages/react/modules/hocs/with-props/with-props.spec.js
@@ -10,28 +10,49 @@ const createTestProps = (custom = {}) => ({
 });
 
 describe('rendering', () => {
-  const enhancedProps = {
-    b: 'b',
-  };
   let EnhancedComponent;
   let props;
   let wrapper;
 
-  beforeEach(() => {
-    props = createTestProps();
-    EnhancedComponent = withProps(enhancedProps)(BaseComponent);
-    wrapper = mount(<EnhancedComponent {...props} />);
+  describe('with `mapProps` being object', () => {
+    const enhancedProps = {
+      b: 'b',
+    };
+    beforeEach(() => {
+      props = createTestProps();
+      EnhancedComponent = withProps(enhancedProps)(BaseComponent);
+      wrapper = mount(<EnhancedComponent {...props} />);
+    });
+
+    it('should match snapshot', () => {
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should have base props', () => {
+      expect(wrapper).toHaveProp('a', 1);
+    });
+
+    it('should have enhanced props', () => {
+      expect(wrapper.find(BaseComponent)).toHaveProp('b', 'b');
+    });
   });
 
-  it('should match snapshot', () => {
-    expect(wrapper).toMatchSnapshot();
-  });
+  describe('with `mapProps` being function', () => {
+    const enhancedProps = {
+      b: 'b',
+    };
+    beforeEach(() => {
+      props = createTestProps();
+      EnhancedComponent = withProps(() => enhancedProps)(BaseComponent);
+      wrapper = mount(<EnhancedComponent {...props} />);
+    });
 
-  it('should have base props', () => {
-    expect(wrapper).toHaveProp('a', 1);
-  });
+    it('should match snapshot', () => {
+      expect(wrapper).toMatchSnapshot();
+    });
 
-  it('should have enhanced props', () => {
-    expect(wrapper.find(BaseComponent)).toHaveProp('b', 'b');
+    it('should have enhanced props', () => {
+      expect(wrapper.find(BaseComponent)).toHaveProp('b', 'b');
+    });
   });
 });

--- a/packages/react/modules/hocs/with-props/with-props.spec.js
+++ b/packages/react/modules/hocs/with-props/with-props.spec.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import withProps from './with-props';
+
+const BaseComponent = () => null;
+const createTestProps = (custom = {}) => ({
+  a: 1,
+
+  ...custom,
+});
+
+describe('rendering', () => {
+  const enhancedProps = {
+    b: 'b',
+  };
+  let EnhancedComponent;
+  let props;
+  let wrapper;
+
+  beforeEach(() => {
+    props = createTestProps();
+    EnhancedComponent = withProps(enhancedProps)(BaseComponent);
+    wrapper = mount(<EnhancedComponent {...props} />);
+  });
+
+  it('should match snapshot', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should have base props', () => {
+    expect(wrapper).toHaveProp('a', 1);
+  });
+
+  it('should have enhanced props', () => {
+    expect(wrapper.find(BaseComponent)).toHaveProp('b', 'b');
+  });
+});

--- a/packages/react/modules/hocs/wrap-display-name/__snapshots__/wrap-display-name.spec.js.snap
+++ b/packages/react/modules/hocs/wrap-display-name/__snapshots__/wrap-display-name.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rendering should match snapshot 1`] = `"BaseComponent"`;

--- a/packages/react/modules/hocs/wrap-display-name/__snapshots__/wrap-display-name.spec.js.snap
+++ b/packages/react/modules/hocs/wrap-display-name/__snapshots__/wrap-display-name.spec.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`rendering should match snapshot 1`] = `"BaseComponent"`;

--- a/packages/react/modules/hocs/wrap-display-name/index.js
+++ b/packages/react/modules/hocs/wrap-display-name/index.js
@@ -1,0 +1,1 @@
+export { default as wrapDisplayName } from './wrap-display-name';

--- a/packages/react/modules/hocs/wrap-display-name/wrap-display-name.js
+++ b/packages/react/modules/hocs/wrap-display-name/wrap-display-name.js
@@ -1,4 +1,10 @@
-export default (BaseComponent, hocName) => {
+// @flow
+
+import { type ComponentType } from 'react';
+
+type ProvidedProps = {};
+
+export default (BaseComponent: ComponentType<any>, hocName: string): string => {
   const previousDisplayName = BaseComponent.displayName || BaseComponent.name;
 
   return `${hocName}(${previousDisplayName})`;

--- a/packages/react/modules/hocs/wrap-display-name/wrap-display-name.js
+++ b/packages/react/modules/hocs/wrap-display-name/wrap-display-name.js
@@ -1,0 +1,7 @@
+export default hocName => BaseComponent => {
+  const previousDisplayName = BaseComponent.displayName || BaseComponent.name;
+
+  BaseComponent['displayName'] = `${hocName}(${previousDisplayName})`;
+
+  return BaseComponent;
+};

--- a/packages/react/modules/hocs/wrap-display-name/wrap-display-name.js
+++ b/packages/react/modules/hocs/wrap-display-name/wrap-display-name.js
@@ -1,7 +1,5 @@
-export default hocName => BaseComponent => {
+export default (BaseComponent, hocName) => {
   const previousDisplayName = BaseComponent.displayName || BaseComponent.name;
 
-  BaseComponent['displayName'] = `${hocName}(${previousDisplayName})`;
-
-  return BaseComponent;
+  return `${hocName}(${previousDisplayName})`;
 };

--- a/packages/react/modules/hocs/wrap-display-name/wrap-display-name.spec.js
+++ b/packages/react/modules/hocs/wrap-display-name/wrap-display-name.spec.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import wrapDisplayName from './wrap-display-name';
+
+function BaseComponent() {
+  return 'BaseComponent';
+}
+BaseComponent.displayName = 'BaseComponent';
+
+describe('rendering', () => {
+  const hocName = 'testHoc';
+  let EnhancedComponent;
+  let wrapper;
+
+  beforeEach(() => {
+    EnhancedComponent = wrapDisplayName(hocName)(BaseComponent);
+  });
+
+  it('should include `hocName` in wrapped display name', () => {
+    expect(EnhancedComponent.displayName).toContain(hocName);
+  });
+});

--- a/packages/react/modules/hocs/wrap-display-name/wrap-display-name.spec.js
+++ b/packages/react/modules/hocs/wrap-display-name/wrap-display-name.spec.js
@@ -9,14 +9,14 @@ BaseComponent.displayName = 'BaseComponent';
 
 describe('rendering', () => {
   const hocName = 'testHoc';
-  let EnhancedComponent;
+  let wrappedDisplayName;
   let wrapper;
 
   beforeEach(() => {
-    EnhancedComponent = wrapDisplayName(hocName)(BaseComponent);
+    wrappedDisplayName = wrapDisplayName(BaseComponent, hocName);
   });
 
   it('should include `hocName` in wrapped display name', () => {
-    expect(EnhancedComponent.displayName).toContain(hocName);
+    expect(wrappedDisplayName).toContain(hocName);
   });
 });

--- a/packages/react/modules/index.js
+++ b/packages/react/modules/index.js
@@ -13,5 +13,6 @@ export {
   DEFAULT_FLAGS_PROP_KEY,
   ALL_FLAGS_PROP_KEY,
 } from './constants';
+export { omitProps, setDisplayName, wrapDisplayName, withProps } from './hocs';
 
 export { version } from '../package.json';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,6 +52,7 @@
     "lodash.isnil": "4.0.0",
     "lodash.omit": "4.5.0",
     "lodash.flowright": "3.5.0",
+    "react-fast-compare": "2.0.3",
     "recompose": "0.30.0",
     "warning": "4.0.2"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,6 +51,7 @@
     "lodash.intersection": "4.4.0",
     "lodash.isnil": "4.0.0",
     "lodash.omit": "4.5.0",
+    "lodash.flowright": "3.5.0",
     "recompose": "0.30.0",
     "warning": "4.0.2"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,7 +53,6 @@
     "lodash.omit": "4.5.0",
     "lodash.flowright": "3.5.0",
     "react-fast-compare": "2.0.3",
-    "recompose": "0.30.0",
     "warning": "4.0.2"
   },
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,6 @@
   ❤️
   React
   · Redux
-  · Recompose
   · Jest
   · Prettier
   · Flow

--- a/yarn.lock
+++ b/yarn.lock
@@ -8539,6 +8539,11 @@ react-dom@16.6.1:
     prop-types "^15.6.2"
     scheduler "^0.11.0"
 
+react-fast-compare@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.3.tgz#f7c8f3867986dd6d9ad512299a3fc2231fb60c6f"
+  integrity sha512-zUaPHxoOZZYYf42Jm3tZklY19YVGr7Z7buvKw1MSzy0S1r/DVnuR/EfYPQmwh5UkMrAfAH4gbBz2pcDqec7Bhw==
+
 react-is@^16.3.2, react-is@^16.6.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.0.tgz#456645144581a6e99f6816ae2bd24ee94bdd0c01"

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,7 +753,7 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2":
+"@babel/runtime@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
   integrity sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==
@@ -2598,11 +2598,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-change-emitter@^0.1.2:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
-  integrity sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=
-
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -4243,7 +4238,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.1:
+fbjs@^0.8.0:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -4967,11 +4962,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoist-non-react-statics@^2.3.1:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
 hoist-non-react-statics@^3.0.0:
   version "3.1.0"
@@ -8554,7 +8544,7 @@ react-is@^16.6.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.1.tgz#f77b1c3d901be300abe8d58645b7a59e794e5982"
   integrity sha512-wOKsGtvTMYs7WAscmwwdM8sfRRvE17Ym30zFj3n37Qx5tHRfhenPKEPILHaHob6WoLFADmQm1ZNrE5xMCM6sCw==
 
-react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2:
+react-lifecycles-compat@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
@@ -8747,18 +8737,6 @@ realpath-native@^1.0.0:
   integrity sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==
   dependencies:
     util.promisify "^1.0.0"
-
-recompose@0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
-  integrity sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    change-emitter "^0.1.2"
-    fbjs "^0.8.1"
-    hoist-non-react-statics "^2.3.1"
-    react-lifecycles-compat "^3.0.2"
-    symbol-observable "^1.0.4"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -9825,7 +9803,7 @@ supports-color@^5.2.0, supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
+symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6729,6 +6729,11 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
+lodash.flowright@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flowright/-/lodash.flowright-3.5.0.tgz#2b5fff399716d7e7dc5724fe9349f67065184d67"
+  integrity sha1-K1//OZcW1+fcVyT+k0n2cGUYTWc=
+
 lodash.foreach@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"


### PR DESCRIPTION
#### Summary

This pull request removes recompose and replaces it with small and custom hocs.

#### Description

Recompose will likely be discontinued while flopflip at most used 20% of it. Tree shaking might have helped but those 2-3 hocs can be replaced by custom built ones. 

I really thought this would be easier but it felt somewhat like taking out really essential glue code. I feel that this will be even harder to application level code.