### PR TITLE
refactor to use tiny-warning over warning

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.js
@@ -8,7 +8,7 @@ import type {
   OnFlagsStateChangeCallback,
   OnStatusStateChangeCallback,
 } from '@flopflip/types';
-import warning from 'warning';
+import warning from 'tiny-warning';
 import isEqual from 'lodash.isequal';
 import { initialize as initializeLaunchDarklyClient } from 'ldclient-js';
 import camelCase from 'lodash.camelcase';

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -1,11 +1,11 @@
 import ldClient from 'ldclient-js';
-import warning from 'warning';
+import warning from 'tiny-warning';
 import adapter, { camelCaseFlags, createAnonymousUserKey } from './adapter';
 
 jest.mock('ldclient-js', () => ({
   initialize: jest.fn(),
 }));
-jest.mock('warning');
+jest.mock('tiny-warning');
 
 const clientSideId = '123-abc';
 const userWithKey = { key: 'foo-user' };
@@ -87,8 +87,7 @@ describe('when configuring', () => {
         user: userWithoutKey,
         onStatusStateChange,
         onFlagsStateChange,
-      })
-    );
+      }));
 
     it('should initialize the `ld-client` with `clientSideId` and random `user` `key`', () => {
       expect(ldClient.initialize).toHaveBeenCalledWith(clientSideId, {

--- a/packages/launchdarkly-adapter/package.json
+++ b/packages/launchdarkly-adapter/package.json
@@ -37,7 +37,7 @@
     "ldclient-js": "2.7.2",
     "lodash.camelcase": "4.3.0",
     "lodash.isequal": "4.5.0",
-    "warning": "4.0.2"
+    "tiny-warning": "1.0.0"
   },
   "keywords": [
     "feature-flags",

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.js
@@ -4,7 +4,7 @@ import type { FlagName, FlagVariation } from '@flopflip/types';
 
 import React from 'react';
 import camelCase from 'lodash.camelcase';
-import warning from 'warning';
+import warning from 'tiny-warning';
 import { isFeatureEnabled } from '@flopflip/react';
 import { FlagsContext } from '../../components/configure';
 

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
@@ -1,7 +1,7 @@
 import useFeatureToggle from './use-feature-toggle';
 import React from 'react';
 
-jest.mock('warning');
+jest.mock('tiny-warning');
 
 const flagName = 'testFlagName';
 

--- a/packages/react/modules/helpers/is-feature-enabled/is-feature-enabled.js
+++ b/packages/react/modules/helpers/is-feature-enabled/is-feature-enabled.js
@@ -2,7 +2,7 @@
 
 import type { FlagName, FlagVariation, Flags } from '@flopflip/types';
 import camelCase from 'lodash.camelcase';
-import warning from 'warning';
+import warning from 'tiny-warning';
 import { DEFAULT_FLAG_PROP_KEY } from '../../constants';
 
 /**

--- a/packages/react/modules/helpers/is-feature-enabled/is-feature-enabled.spec.js
+++ b/packages/react/modules/helpers/is-feature-enabled/is-feature-enabled.spec.js
@@ -1,7 +1,7 @@
-import warning from 'warning';
+import warning from 'tiny-warning';
 import isFeatureEnabled from './is-feature-enabled';
 
-jest.mock('warning');
+jest.mock('tiny-warning');
 
 describe('with existing flag', () => {
   describe('with flag variation', () => {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,8 +37,7 @@
     "enzyme-adapter-react-16": "1.7.0",
     "enzyme-to-json": "3.3.4",
     "react": "16.6.1",
-    "react-dom": "16.6.1",
-    "warning": "4.0.2"
+    "react-dom": "16.6.1"
   },
   "peerDependencies": {
     "react": "^15.6 || ^16.0",
@@ -53,7 +52,7 @@
     "lodash.isnil": "4.0.0",
     "lodash.omit": "4.5.0",
     "react-fast-compare": "2.0.3",
-    "warning": "4.0.2"
+    "tiny-warning": "1.0.0"
   },
   "keywords": [
     "react",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9954,6 +9954,11 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
+tiny-warning@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.0.tgz#70fba262ea3645e10506fe8673aeb133d959fc93"
+  integrity sha512-6CrF/DMLSoYakJ7f6+1bz6nHJY6Tj6sEj8/9hjTzGi94MeuAZprPE+3jykGMUgoswnmuPA9NlKlYLNJaFVYHIw==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -10255,13 +10260,6 @@ walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
-
-warning@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
-  integrity sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==
-  dependencies:
-    loose-envify "^1.0.0"
 
 watch@~0.18.0:
   version "0.18.0"


### PR DESCRIPTION
#### Summary

After `tiny-invariant` comes `tiny-warning`.