### PR TITLE
update typings

### DIFF
--- a/packages/react-redux/typings/index.d.ts
+++ b/packages/react-redux/typings/index.d.ts
@@ -19,9 +19,9 @@ declare module '@flopflip/react-redux' {
   export class ToggleFeature extends React.Component<
     ToggleComponentProps,
     any
-  > {}
+    > { }
 
-  export function createFlopFlipEnhancer(adapter: any, adapterArgs?: any): (next) => () => void;
+  export function createFlopFlipEnhancer(adapter: any, adapterArgs?: any): (next: any) => () => void;
   export function flopflipReducer(state: {}, action: {}): any;
   export function selectFeatureFlag(flagName: FlagName): (state: {}) => Flags;
   export function selectFeatureFlags(state: {}): Flags;

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -6,7 +6,8 @@ declare module '@flopflip/types' {
 
   export type Diff<T extends string, U extends string> = ({ [P in T]: P } &
     { [P in U]: never } & { [x: string]: never })[T];
-  export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+  export type Omit<T, K extends keyof T> = Pick<T,
+    ({ [P in keyof T]-?: P } & { [P in K]: never })[keyof T]>;
 
   export interface ComponentEnhancerWithProps<ProvidedProps, RerquiredProps> {
     <P extends ProvidedProps>(
@@ -39,8 +40,8 @@ declare module '@flopflip/types' {
     untoggledComponent?: React.ComponentType<any>;
     render?: () => React.ReactNode;
     children?:
-      | (({ isFeatureEnabled: boolean }) => React.ReactNode)
-      | React.ReactNode;
+    | (({ isFeatureEnabled }: { isFeatureEnabled: boolean }) => React.ReactNode)
+    | React.ReactNode;
     isFeatureEnabled: boolean;
   }
   export interface ToggleComponentProps extends ToggleComponentCommonProps {
@@ -84,15 +85,15 @@ declare module '@flopflip/types' {
   export class ToggleFeature extends React.Component<
     ToggleComponentProps,
     any
-  > {}
+    > { }
 
   export class ConfigureFlopFlip extends React.Component<
     ConfigureComponentProps,
     any
-  > {}
+    > { }
 
   export class ReconfigureFlopFlip extends React.Component<
     ReconfigureComponentProps,
     any
-  > {}
+    > { }
 }


### PR DESCRIPTION
#### Summary

Updates some typings that cause build errors on `tsc` in Typescript v3.2.1
#### Description

- new Omit is from https://github.com/Microsoft/TypeScript/issues/25041#issuecomment-418900748
- stops implicity 'any' error on next parameter
- fixes destructuring confusion



