### PR TITLE
feat(memory-adapter): add setIsReady

### DIFF
--- a/packages/memory-adapter/modules/adapter/adapter.spec.js
+++ b/packages/memory-adapter/modules/adapter/adapter.spec.js
@@ -118,5 +118,23 @@ describe('when configuring', () => {
         expect(adapter.getFlag(updatedFlags.barFlag)).not.toBeDefined();
       });
     });
+
+    describe('when setting ready state', () => {
+      beforeEach(() => {
+        adapterArgs.onStatusStateChange.mockClear();
+
+        adapter.setIsReady({ isReady: false });
+      });
+
+      it('should indicate that the adapter is not ready', () => {
+        expect(adapter.getIsReady()).toBe(false);
+      });
+
+      it('should invoke `onStatusStateChange` with `isReady`', () => {
+        expect(adapterArgs.onStatusStateChange).toHaveBeenCalledWith({
+          isReady: false,
+        });
+      });
+    });
   });
 });

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -65,6 +65,13 @@ const reconfigure = ({ user }: { user: User }): Promise<any> => {
 };
 
 const getIsReady = (): boolean => Boolean(adapterState.isReady);
+const setIsReady = (nextIsReady: { isReady: boolean }): void => {
+  adapterState.isReady = nextIsReady.isReady;
+
+  adapterState.emitter.emit('statusStateChange', {
+    isReady: adapterState.isReady,
+  });
+};
 
 const reset = (): void => {
   adapterState = {
@@ -108,6 +115,7 @@ const getFlag = (flagName: FlagName): FlagVariation | undefined =>
 
 export default {
   getIsReady,
+  setIsReady,
   waitUntilConfigured,
   getFlag,
   reset,

--- a/packages/react-broadcast/modules/components/branch-on-feature-toggle/__snapshots__/branch-on-feature-toggle.spec.js.snap
+++ b/packages/react-broadcast/modules/components/branch-on-feature-toggle/__snapshots__/branch-on-feature-toggle.spec.js.snap
@@ -9,6 +9,7 @@ exports[`with \`untoggledComponent when feature is disabled should match snapsho
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -24,6 +25,7 @@ exports[`with \`untoggledComponent when feature is disabled should match snapsho
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -70,6 +72,7 @@ exports[`with \`untoggledComponent when feature is disabled when enabling featur
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -85,6 +88,7 @@ exports[`with \`untoggledComponent when feature is disabled when enabling featur
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -139,6 +143,7 @@ exports[`without \`untoggledComponent when feature is disabled should match snap
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -154,6 +159,7 @@ exports[`without \`untoggledComponent when feature is disabled should match snap
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -198,6 +204,7 @@ exports[`without \`untoggledComponent when feature is disabled when enabling fea
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -213,6 +220,7 @@ exports[`without \`untoggledComponent when feature is disabled when enabling fea
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }

--- a/packages/react-broadcast/modules/components/inject-feature-toggle/__snapshots__/inject-feature-toggle.spec.js.snap
+++ b/packages/react-broadcast/modules/components/inject-feature-toggle/__snapshots__/inject-feature-toggle.spec.js.snap
@@ -9,6 +9,7 @@ exports[`with \`propKey\` should match snapshot 1`] = `
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -24,6 +25,7 @@ exports[`with \`propKey\` should match snapshot 1`] = `
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -66,6 +68,7 @@ exports[`without \`propKey\` when feature is disabled should match snapshot 1`] 
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -81,6 +84,7 @@ exports[`without \`propKey\` when feature is disabled should match snapshot 1`] 
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -123,6 +127,7 @@ exports[`without \`propKey\` when feature is disabled when enabling feature shou
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -138,6 +143,7 @@ exports[`without \`propKey\` when feature is disabled when enabling feature shou
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }

--- a/packages/react-broadcast/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
+++ b/packages/react-broadcast/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
@@ -9,6 +9,7 @@ exports[`with \`propKey\` should match snapshot 1`] = `
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -24,6 +25,7 @@ exports[`with \`propKey\` should match snapshot 1`] = `
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -70,6 +72,7 @@ exports[`without \`propKey\` when feature is disabled should match snapshot 1`] 
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -90,6 +93,7 @@ exports[`without \`propKey\` when feature is disabled should match snapshot 1`] 
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -166,6 +170,7 @@ exports[`without \`propKey\` when feature is disabled when enabling feature shou
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -186,6 +191,7 @@ exports[`without \`propKey\` when feature is disabled when enabling feature shou
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }

--- a/packages/react-broadcast/modules/components/toggle-feature/__snapshots__/toggle-feature.spec.js.snap
+++ b/packages/react-broadcast/modules/components/toggle-feature/__snapshots__/toggle-feature.spec.js.snap
@@ -9,6 +9,7 @@ exports[`when feature is disabled should match snapshot 1`] = `
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -29,6 +30,7 @@ exports[`when feature is disabled should match snapshot 1`] = `
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -87,6 +89,7 @@ exports[`when feature is disabled when enabling feature should match snapshot 1`
       "getIsReady": [Function],
       "reconfigure": [Function],
       "reset": [Function],
+      "setIsReady": [Function],
       "waitUntilConfigured": [Function],
     }
   }
@@ -107,6 +110,7 @@ exports[`when feature is disabled when enabling feature should match snapshot 1`
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/__snapshots__/branch-on-feature-toggle.spec.js.snap
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/__snapshots__/branch-on-feature-toggle.spec.js.snap
@@ -21,6 +21,7 @@ exports[`with \`untoggledComponent when feature is disabled should match snapsho
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -34,6 +35,7 @@ exports[`with \`untoggledComponent when feature is disabled should match snapsho
           "getIsReady": [Function],
           "reconfigure": [Function],
           "reset": [Function],
+          "setIsReady": [Function],
           "waitUntilConfigured": [Function],
         }
       }
@@ -51,6 +53,7 @@ exports[`with \`untoggledComponent when feature is disabled should match snapsho
             "getIsReady": [Function],
             "reconfigure": [Function],
             "reset": [Function],
+            "setIsReady": [Function],
             "waitUntilConfigured": [Function],
           }
         }
@@ -123,6 +126,7 @@ exports[`with \`untoggledComponent when feature is disabled when enabling featur
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -136,6 +140,7 @@ exports[`with \`untoggledComponent when feature is disabled when enabling featur
           "getIsReady": [Function],
           "reconfigure": [Function],
           "reset": [Function],
+          "setIsReady": [Function],
           "waitUntilConfigured": [Function],
         }
       }
@@ -153,6 +158,7 @@ exports[`with \`untoggledComponent when feature is disabled when enabling featur
             "getIsReady": [Function],
             "reconfigure": [Function],
             "reset": [Function],
+            "setIsReady": [Function],
             "waitUntilConfigured": [Function],
           }
         }
@@ -225,6 +231,7 @@ exports[`without \`untoggledComponent when feature is disabled should match snap
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -238,6 +245,7 @@ exports[`without \`untoggledComponent when feature is disabled should match snap
           "getIsReady": [Function],
           "reconfigure": [Function],
           "reset": [Function],
+          "setIsReady": [Function],
           "waitUntilConfigured": [Function],
         }
       }
@@ -255,6 +263,7 @@ exports[`without \`untoggledComponent when feature is disabled should match snap
             "getIsReady": [Function],
             "reconfigure": [Function],
             "reset": [Function],
+            "setIsReady": [Function],
             "waitUntilConfigured": [Function],
           }
         }
@@ -325,6 +334,7 @@ exports[`without \`untoggledComponent when feature is disabled when enabling fea
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -338,6 +348,7 @@ exports[`without \`untoggledComponent when feature is disabled when enabling fea
           "getIsReady": [Function],
           "reconfigure": [Function],
           "reset": [Function],
+          "setIsReady": [Function],
           "waitUntilConfigured": [Function],
         }
       }
@@ -355,6 +366,7 @@ exports[`without \`untoggledComponent when feature is disabled when enabling fea
             "getIsReady": [Function],
             "reconfigure": [Function],
             "reset": [Function],
+            "setIsReady": [Function],
             "waitUntilConfigured": [Function],
           }
         }

--- a/packages/react-redux/modules/components/inject-feature-toggle/__snapshots__/inject-feature-toggle.spec.js.snap
+++ b/packages/react-redux/modules/components/inject-feature-toggle/__snapshots__/inject-feature-toggle.spec.js.snap
@@ -21,6 +21,7 @@ exports[`without \`propKey\` when feature is disabled should match snapshot 1`] 
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -34,6 +35,7 @@ exports[`without \`propKey\` when feature is disabled should match snapshot 1`] 
           "getIsReady": [Function],
           "reconfigure": [Function],
           "reset": [Function],
+          "setIsReady": [Function],
           "waitUntilConfigured": [Function],
         }
       }
@@ -51,6 +53,7 @@ exports[`without \`propKey\` when feature is disabled should match snapshot 1`] 
             "getIsReady": [Function],
             "reconfigure": [Function],
             "reset": [Function],
+            "setIsReady": [Function],
             "waitUntilConfigured": [Function],
           }
         }
@@ -118,6 +121,7 @@ exports[`without \`propKey\` when feature is disabled when enabling feature shou
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -131,6 +135,7 @@ exports[`without \`propKey\` when feature is disabled when enabling feature shou
           "getIsReady": [Function],
           "reconfigure": [Function],
           "reset": [Function],
+          "setIsReady": [Function],
           "waitUntilConfigured": [Function],
         }
       }
@@ -148,6 +153,7 @@ exports[`without \`propKey\` when feature is disabled when enabling feature shou
             "getIsReady": [Function],
             "reconfigure": [Function],
             "reset": [Function],
+            "setIsReady": [Function],
             "waitUntilConfigured": [Function],
           }
         }

--- a/packages/react-redux/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
+++ b/packages/react-redux/modules/components/inject-feature-toggles/__snapshots__/inject-feature-toggles.spec.js.snap
@@ -21,6 +21,7 @@ exports[`injectFeatureToggles with \`propKey\` should match snapshot 1`] = `
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -34,6 +35,7 @@ exports[`injectFeatureToggles with \`propKey\` should match snapshot 1`] = `
           "getIsReady": [Function],
           "reconfigure": [Function],
           "reset": [Function],
+          "setIsReady": [Function],
           "waitUntilConfigured": [Function],
         }
       }
@@ -51,6 +53,7 @@ exports[`injectFeatureToggles with \`propKey\` should match snapshot 1`] = `
             "getIsReady": [Function],
             "reconfigure": [Function],
             "reset": [Function],
+            "setIsReady": [Function],
             "waitUntilConfigured": [Function],
           }
         }
@@ -135,6 +138,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled shoul
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -148,6 +152,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled shoul
           "getIsReady": [Function],
           "reconfigure": [Function],
           "reset": [Function],
+          "setIsReady": [Function],
           "waitUntilConfigured": [Function],
         }
       }
@@ -165,6 +170,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled shoul
             "getIsReady": [Function],
             "reconfigure": [Function],
             "reset": [Function],
+            "setIsReady": [Function],
             "waitUntilConfigured": [Function],
           }
         }
@@ -254,6 +260,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled when 
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -267,6 +274,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled when 
           "getIsReady": [Function],
           "reconfigure": [Function],
           "reset": [Function],
+          "setIsReady": [Function],
           "waitUntilConfigured": [Function],
         }
       }
@@ -284,6 +292,7 @@ exports[`injectFeatureToggles without \`propKey\` when feature is disabled when 
             "getIsReady": [Function],
             "reconfigure": [Function],
             "reset": [Function],
+            "setIsReady": [Function],
             "waitUntilConfigured": [Function],
           }
         }

--- a/packages/react-redux/modules/components/toggle-feature/__snapshots__/toggle-feature.spec.js.snap
+++ b/packages/react-redux/modules/components/toggle-feature/__snapshots__/toggle-feature.spec.js.snap
@@ -21,6 +21,7 @@ exports[`<ToggleFeature> when feature is disabled should match snapshot 1`] = `
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -34,6 +35,7 @@ exports[`<ToggleFeature> when feature is disabled should match snapshot 1`] = `
           "getIsReady": [Function],
           "reconfigure": [Function],
           "reset": [Function],
+          "setIsReady": [Function],
           "waitUntilConfigured": [Function],
         }
       }
@@ -51,6 +53,7 @@ exports[`<ToggleFeature> when feature is disabled should match snapshot 1`] = `
             "getIsReady": [Function],
             "reconfigure": [Function],
             "reset": [Function],
+            "setIsReady": [Function],
             "waitUntilConfigured": [Function],
           }
         }
@@ -103,6 +106,7 @@ exports[`<ToggleFeature> when feature is disabled when enabling feature should m
         "getIsReady": [Function],
         "reconfigure": [Function],
         "reset": [Function],
+        "setIsReady": [Function],
         "waitUntilConfigured": [Function],
       }
     }
@@ -116,6 +120,7 @@ exports[`<ToggleFeature> when feature is disabled when enabling feature should m
           "getIsReady": [Function],
           "reconfigure": [Function],
           "reset": [Function],
+          "setIsReady": [Function],
           "waitUntilConfigured": [Function],
         }
       }
@@ -133,6 +138,7 @@ exports[`<ToggleFeature> when feature is disabled when enabling feature should m
             "getIsReady": [Function],
             "reconfigure": [Function],
             "reset": [Function],
+            "setIsReady": [Function],
             "waitUntilConfigured": [Function],
           }
         }


### PR DESCRIPTION
#### Summary

Adds a `setIsReady` to the `memory-adapter` which is often helpful when testing. 

```js
adapter.setIsReady({ isReady: false });

adapter.getIsReady() // <- false
```

Additionally the `onStatusStateChange` will be invoked.