### PR TITLE
refactor(react-redux): to remove the mock store

### DIFF
--- a/packages/react-broadcast/package.json
+++ b/packages/react-broadcast/package.json
@@ -38,8 +38,7 @@
     "@types/react": "16.8.2",
     "@types/react-dom": "16.8.0",
     "react": "16.8.3",
-    "react-dom": "16.8.3",
-    "redux-mock-store": "1.5.3"
+    "react-dom": "16.8.3"
   },
   "peerDependencies": {
     "react": "^15.6 || ^16.0 || ^17.0",

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderWithAdapter, components } from '@flopflip/test-utils';
 import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
+import { createStore } from '../../../test-utils';
 import { STATE_SLICE } from '../../store';
 import branchOnFeatureToggle from './branch-on-feature-toggle';
 import Configure from '../configure';
@@ -13,7 +13,6 @@ const render = (store, TestComponent) =>
       Wrapper: <Provider store={store} />,
     },
   });
-const createMockStore = configureStore();
 
 describe('without `untoggledComponent', () => {
   describe('when feature is disabled', () => {
@@ -22,7 +21,7 @@ describe('without `untoggledComponent', () => {
       components.ToggledComponent
     );
     beforeEach(() => {
-      store = createMockStore({
+      store = createStore({
         [STATE_SLICE]: { flags: { disabledFeature: false } },
       });
     });
@@ -32,6 +31,21 @@ describe('without `untoggledComponent', () => {
 
       expect(queryByFlagName('isFeatureEnabled')).not.toBeInTheDocument();
     });
+
+    describe('when enabling feature', () => {
+      it('should render the component representing a enabled feature', async () => {
+        const { queryByFlagName, waitUntilReady, changeFlagVariation } = render(
+          store,
+          <TestComponent />
+        );
+
+        await waitUntilReady();
+
+        changeFlagVariation('disabledFeature', true);
+
+        expect(queryByFlagName('isFeatureEnabled')).toBeInTheDocument();
+      });
+    });
   });
 
   describe('when feature is enabled', () => {
@@ -40,7 +54,7 @@ describe('without `untoggledComponent', () => {
       components.ToggledComponent
     );
     beforeEach(() => {
-      store = createMockStore({
+      store = createStore({
         [STATE_SLICE]: { flags: { enabledFeature: true } },
       });
     });
@@ -65,7 +79,7 @@ describe('with `untoggledComponent', () => {
     )(components.ToggledComponent);
 
     beforeEach(() => {
-      store = createMockStore({
+      store = createStore({
         [STATE_SLICE]: { flags: { disabledFeature: false } },
       });
     });
@@ -97,7 +111,7 @@ describe('with `untoggledComponent', () => {
     )(components.ToggledComponent);
 
     beforeEach(() => {
-      store = createMockStore({
+      store = createStore({
         [STATE_SLICE]: { flags: { enabledFeature: true } },
       });
     });

--- a/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
+++ b/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderWithAdapter, components } from '@flopflip/test-utils';
 import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
+import { createStore } from '../../../test-utils';
 import { STATE_SLICE } from '../../store';
 import injectFeatureToggle from './inject-feature-toggle';
 import Configure from '../configure';
@@ -14,8 +14,6 @@ const render = (store, TestComponent) =>
     },
   });
 
-const createMockStore = configureStore();
-
 describe('without `propKey`', () => {
   describe('when feature is disabled', () => {
     let store;
@@ -24,7 +22,7 @@ describe('without `propKey`', () => {
     );
 
     beforeEach(() => {
-      store = createMockStore({
+      store = createStore({
         [STATE_SLICE]: { flags: { disabledFeature: false } },
       });
     });
@@ -33,6 +31,21 @@ describe('without `propKey`', () => {
       const { queryByFlagName } = render(store, <TestComponent />);
 
       expect(queryByFlagName('isFeatureEnabled')).toHaveTextContent('false');
+    });
+
+    describe('when enabling feature', () => {
+      it('should render the component representing a enabled feature', async () => {
+        const { queryByFlagName, waitUntilReady, changeFlagVariation } = render(
+          store,
+          <TestComponent />
+        );
+
+        await waitUntilReady();
+
+        changeFlagVariation('disabledFeature', true);
+
+        expect(queryByFlagName('isFeatureEnabled')).toHaveTextContent('true');
+      });
     });
   });
 
@@ -43,7 +56,7 @@ describe('without `propKey`', () => {
     );
 
     beforeEach(() => {
-      store = createMockStore({
+      store = createStore({
         [STATE_SLICE]: { flags: { enabledFeature: true } },
       });
     });
@@ -65,7 +78,7 @@ describe('with `propKey`', () => {
     )(components.FlagsToComponent);
 
     beforeEach(() => {
-      store = createMockStore({
+      store = createStore({
         [STATE_SLICE]: { flags: { disabledFeature: false } },
       });
     });

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
@@ -2,7 +2,7 @@ import { Provider } from 'react-redux';
 import React from 'react';
 import { renderWithAdapter, components } from '@flopflip/test-utils';
 import { ALL_FLAGS_PROP_KEY } from '@flopflip/react';
-import configureStore from 'redux-mock-store';
+import { createStore } from '../../../test-utils';
 import Configure from '../configure';
 import { STATE_SLICE } from './../../store';
 import { mapStateToProps } from './inject-feature-toggles';
@@ -40,7 +40,6 @@ describe('mapStateToProps', () => {
   });
 });
 
-const createMockStore = configureStore();
 const render = (store, TestComponent) =>
   renderWithAdapter(TestComponent, {
     components: {
@@ -61,7 +60,7 @@ describe('injectFeatureToggles', () => {
     ])(FlagsToComponent);
 
     beforeEach(() => {
-      store = createMockStore({
+      store = createStore({
         [STATE_SLICE]: {
           flags: { enabledFeature: true, disabledFeature: false },
         },
@@ -79,6 +78,21 @@ describe('injectFeatureToggles', () => {
 
       expect(queryByFlagName('disabledFeature')).toHaveTextContent('false');
     });
+
+    describe('when enabling feature', () => {
+      it('should render the component representing a enabled feature', async () => {
+        const { queryByFlagName, waitUntilReady, changeFlagVariation } = render(
+          store,
+          <TestComponent />
+        );
+
+        await waitUntilReady();
+
+        changeFlagVariation('disabledFeature', true);
+
+        expect(queryByFlagName('disabledFeature')).toHaveTextContent('true');
+      });
+    });
   });
 
   describe('with `propKey`', () => {
@@ -92,7 +106,7 @@ describe('injectFeatureToggles', () => {
     )(FlagsToComponent);
 
     beforeEach(() => {
-      store = createMockStore({
+      store = createStore({
         [STATE_SLICE]: {
           flags: { enabledFeature: true, disabledFeature: false },
         },

--- a/packages/react-redux/modules/components/toggle-feature/toggle-feature.spec.js
+++ b/packages/react-redux/modules/components/toggle-feature/toggle-feature.spec.js
@@ -1,7 +1,7 @@
 import { Provider } from 'react-redux';
 import { renderWithAdapter, components } from '@flopflip/test-utils';
 import React from 'react';
-import configureStore from 'redux-mock-store';
+import { createStore } from '../../../test-utils';
 import Configure from '../configure';
 import { STATE_SLICE } from './../../store';
 import ToggleFeature, { mapStateToProps } from './toggle-feature';
@@ -78,7 +78,6 @@ describe('mapStateToProps', () => {
   });
 });
 
-const createMockStore = configureStore();
 const render = (store, TestComponent) =>
   renderWithAdapter(TestComponent, {
     components: {
@@ -97,7 +96,7 @@ describe('<ToggleFeature>', () => {
     );
 
     beforeEach(() => {
-      store = createMockStore({
+      store = createStore({
         [STATE_SLICE]: { flags: { disabledFeature: false } },
       });
     });
@@ -106,6 +105,21 @@ describe('<ToggleFeature>', () => {
       const { queryByFlagName } = render(store, <TestComponent />);
 
       expect(queryByFlagName('disabledFeature')).not.toBeInTheDocument();
+    });
+
+    describe('when enabling feature', () => {
+      it('should render the component representing a enabled feature', async () => {
+        const { queryByFlagName, waitUntilReady, changeFlagVariation } = render(
+          store,
+          <TestComponent />
+        );
+
+        await waitUntilReady();
+
+        changeFlagVariation('disabledFeature', true);
+
+        expect(queryByFlagName('disabledFeature')).toBeInTheDocument();
+      });
     });
   });
 
@@ -118,7 +132,7 @@ describe('<ToggleFeature>', () => {
     );
 
     beforeEach(() => {
-      store = createMockStore({
+      store = createStore({
         [STATE_SLICE]: { flags: { enabledFeature: true } },
       });
     });

--- a/packages/react-redux/test-utils/index.js
+++ b/packages/react-redux/test-utils/index.js
@@ -1,0 +1,16 @@
+import { createStore as createReduxStore } from 'redux';
+import { combineReducers } from 'redux';
+import {
+  createFlopflipReducer,
+  FLOPFLIP_STATE_SLICE,
+} from '@flopflip/react-redux';
+
+const defaultInitialState = {};
+
+const reducer = combineReducers({
+  [FLOPFLIP_STATE_SLICE]: createFlopflipReducer(),
+});
+const createStore = (initialState = defaultInitialState) =>
+  createReduxStore(reducer, initialState);
+
+export { createStore };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6885,11 +6885,6 @@ lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
-  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
-
 lodash.istypedarray@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz#c9a477498607501d8e8494d283b87c39281cef62"
@@ -8951,13 +8946,6 @@ redis-parser@^2.4.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
   integrity sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=
-
-redux-mock-store@1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.3.tgz#1f10528949b7ce8056c2532624f7cafa98576c6d"
-  integrity sha512-ryhkkb/4D4CUGpAV2ln1GOY/uh51aczjcRz9k2L2bPx/Xja3c5pSGJJPyR25GNVRXtKIExScdAgFdiXp68GmJA==
-  dependencies:
-    lodash.isplainobject "^4.0.6"
 
 redux@4.0.1, redux@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
#### Summary

This is a follow up from #613 to avoid such things in the past. The store is not tested in integration and not mocked anymore.