### PR TITLE
feat(react): add `useAdapterReconfiguration`

### DIFF
--- a/packages/react-broadcast/modules/hooks/index.ts
+++ b/packages/react-broadcast/modules/hooks/index.ts
@@ -1,3 +1,5 @@
 export { default as useFeatureToggle } from './use-feature-toggle';
 export { default as useAdapterStatus } from './use-adapter-status';
-export { useAdapterReconfiguration } from '@flopflip/react';
+export {
+  default as useAdapterReconfiguration,
+} from './use-adapter-reconfiguration';

--- a/packages/react-broadcast/modules/hooks/index.ts
+++ b/packages/react-broadcast/modules/hooks/index.ts
@@ -1,2 +1,3 @@
 export { default as useFeatureToggle } from './use-feature-toggle';
 export { default as useAdapterStatus } from './use-adapter-status';
+export { useAdapterReconfiguration } from '@flopflip/react';

--- a/packages/react-broadcast/modules/hooks/use-adapter-reconfiguration/index.ts
+++ b/packages/react-broadcast/modules/hooks/use-adapter-reconfiguration/index.ts
@@ -1,0 +1,1 @@
+export { useAdapterReconfiguration as default } from '@flopflip/react';

--- a/packages/react-broadcast/modules/index.ts
+++ b/packages/react-broadcast/modules/index.ts
@@ -7,5 +7,9 @@ export {
   ConfigureFlopFlip,
   ReconfigureFlopFlip,
 } from './components';
-export { useFeatureToggle, useAdapterStatus } from './hooks';
+export {
+  useFeatureToggle,
+  useAdapterStatus,
+  useAdapterReconfiguration,
+} from './hooks';
 export { version };

--- a/packages/react-redux/modules/hooks/index.ts
+++ b/packages/react-redux/modules/hooks/index.ts
@@ -1,1 +1,3 @@
-export { useAdapterReconfiguration } from '@flopflip/react';
+export {
+  default as useAdapterReconfiguration,
+} from './use-adapter-reconfiguration';

--- a/packages/react-redux/modules/hooks/index.ts
+++ b/packages/react-redux/modules/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useAdapterReconfiguration } from '@flopflip/react';

--- a/packages/react-redux/modules/hooks/use-adapter-reconfiguration/index.ts
+++ b/packages/react-redux/modules/hooks/use-adapter-reconfiguration/index.ts
@@ -1,0 +1,1 @@
+export { useAdapterReconfiguration as default } from '@flopflip/react';

--- a/packages/react-redux/modules/index.ts
+++ b/packages/react-redux/modules/index.ts
@@ -20,5 +20,6 @@ export {
   ConfigureFlopFlip,
   ReconfigureFlopFlip,
 } from './components';
+export { useAdapterReconfiguration } from './hooks';
 
 export { version };

--- a/packages/react/modules/hooks/index.ts
+++ b/packages/react/modules/hooks/index.ts
@@ -1,0 +1,3 @@
+export {
+  default as useAdapterReconfiguration,
+} from './use-adapter-reconfiguration';

--- a/packages/react/modules/hooks/use-adapter-reconfiguration/index.ts
+++ b/packages/react/modules/hooks/use-adapter-reconfiguration/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-adapter-reconfiguration';

--- a/packages/react/modules/hooks/use-adapter-reconfiguration/use-adapter-reconfiguration.spec.js
+++ b/packages/react/modules/hooks/use-adapter-reconfiguration/use-adapter-reconfiguration.spec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import useAdapterReconfiguration from './use-adapter-reconfiguration';
+
+jest.mock('tiny-warning');
+const reconfigure = jest.fn();
+
+describe('when React hooks (`useContext`) is available', () => {
+  beforeEach(() => {
+    React.useContext = jest.fn(() => ({ reconfigure }));
+  });
+
+  it('should return a function', async () => {
+    expect(useAdapterReconfiguration()).toBe(reconfigure);
+  });
+});
+
+describe('when React hooks (`useContext`) are not available', () => {
+  describe('when flag is enabled', () => {
+    beforeEach(() => {
+      React.useContext = jest.fn(() => undefined);
+    });
+
+    it('should throw', () => {
+      expect(() => useAdapterReconfiguration()).toThrow();
+    });
+  });
+});

--- a/packages/react/modules/hooks/use-adapter-reconfiguration/use-adapter-reconfiguration.ts
+++ b/packages/react/modules/hooks/use-adapter-reconfiguration/use-adapter-reconfiguration.ts
@@ -1,0 +1,27 @@
+import React from 'react';
+import { AdapterContext } from '@flopflip/react';
+import {
+  AdapterContext as AdapterContextType,
+  ReconfigureAdapter as ReconfigureAdapterType,
+} from '@flopflip/types';
+
+export default function useAdapterReconfiguration():
+  | Error
+  | ReconfigureAdapterType {
+  if (typeof React.useContext === 'function') {
+    /**
+     * NODE: `createReactContext` and `React.Context` return incomptaible types which
+     * can not be interchanged. Until `createReactContext` is in use this
+     * has to remain.
+     */
+    const adapterContext: AdapterContextType = React.useContext(
+      AdapterContext as any
+    );
+
+    return adapterContext.reconfigure;
+  }
+
+  throw new Error(
+    'React hooks are not available in your currently installed version of React.'
+  );
+}

--- a/packages/react/modules/index.ts
+++ b/packages/react/modules/index.ts
@@ -12,11 +12,15 @@ export {
 } from './components';
 
 export { default as isFeatureEnabled } from './helpers/is-feature-enabled';
+
 export {
   DEFAULT_FLAG_PROP_KEY,
   DEFAULT_FLAGS_PROP_KEY,
   ALL_FLAGS_PROP_KEY,
 } from './constants';
+
 export { omitProps, setDisplayName, wrapDisplayName, withProps } from './hocs';
+
+export { useAdapterReconfiguration } from './hooks';
 
 export { version };

--- a/readme.md
+++ b/readme.md
@@ -224,6 +224,8 @@ without Redux.
   (alternative to the store enhancer)
 - `ReconfigureFlopFlip` a component to reconfigure flopflip with new user properties
   either merged or overwritting old properties (`shouldOverwrite` prop)
+  - `useAdapterReconfiguration` a hook to reconfigure flopflip with new user properties
+    either merged or overwritting old properties (`shouldOverwrite` prop)
 - `branchOnFeatureToggle` a Higher-Order Component (HoC) to conditionally render
   components depending on feature toggle state
 - `injectFeatureToggle` a HoC to inject a feature toggle onto the `props` of a
@@ -763,13 +765,13 @@ A forward compatible implementation [React hook](https://reactjs.org/docs/hooks-
 import { useAdapterStatus } from '@flopflip/react-broadcast';
 
 const ComponentWithFeatureToggle = () => {
-   const isFeatureEnabled = useFeatureToggle('myFeatureToggle');
-   const { isReady } = useAdapterStatus();
+  const isFeatureEnabled = useFeatureToggle('myFeatureToggle');
+  const { isReady } = useAdapterStatus();
 
-   if (!isReady) return <LoadingSpinner />
-   else if (!isFeatureEnabled) <PageNotFound />
-   else return <FeatureComponent />
-}
+  if (!isReady) return <LoadingSpinner />;
+  else if (!isFeatureEnabled) <PageNotFound />;
+  else return <FeatureComponent />;
+};
 ```
 
 Please note that given the React version _does not_ support hooks using `useFeatureToggle` will throw an error.


### PR DESCRIPTION
#### Summary

This pull request allows pulling the `reconfiguration` function from the context. This works on both the redux and broadcast variation of the library.