### PR TITLE
fix(react): with-adapter-reconfiguration

### DIFF
--- a/packages/react/modules/components/configure-adapter/with-reconfiguration.tsx
+++ b/packages/react/modules/components/configure-adapter/with-reconfiguration.tsx
@@ -18,7 +18,7 @@ const withReconfiguration = <Props extends {}>(
     render(): React.ReactNode {
       return (
         <AdapterContext.Consumer>
-          {reconfigure => (
+          {({ reconfigure }) => (
             <Component {...this.props} {...{ [propKey]: reconfigure }} />
           )}
         </AdapterContext.Consumer>


### PR DESCRIPTION
#### Summary

This fixes a regression introduced by 8.1.0. The AdapterContext now contains two values: `reconfigure` and `status`. Previously only one.