### PR TITLE
refactor(launchdarkly-adapter): to waitForInitialization

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -179,6 +179,57 @@ describe('when configuring', () => {
       });
     });
 
+    describe('when `waitForInitialization` throws', () => {
+      describe('when it should `throwOnInitializationFailure`', () => {
+        beforeEach(() => {
+          onStatusStateChange = jest.fn();
+          onFlagsStateChange = jest.fn();
+          client = createClient({
+            waitForInitialization: jest.fn(() => Promise.reject()),
+          });
+
+          ldClient.initialize.mockReturnValue(client);
+        });
+
+        it('should reject the configuration with an error', async () => {
+          await expect(
+            adapter.configure({
+              clientSideId,
+              user: userWithKey,
+              onStatusStateChange,
+              onFlagsStateChange,
+              throwOnInitializationFailure: true,
+            })
+          ).rejects.toThrow(
+            '@flopflip/launchdarkly-adapter: adapter failed to initialize.'
+          );
+        });
+      });
+      describe('when it should not `throwOnInitializationFailure`', () => {
+        beforeEach(() => {
+          onStatusStateChange = jest.fn();
+          onFlagsStateChange = jest.fn();
+          client = createClient({
+            waitForInitialization: jest.fn(() => Promise.reject()),
+          });
+
+          ldClient.initialize.mockReturnValue(client);
+        });
+
+        it('should resolve the configuration', async () => {
+          await expect(
+            adapter.configure({
+              clientSideId,
+              user: userWithKey,
+              onStatusStateChange,
+              onFlagsStateChange,
+              throwOnInitializationFailure: false,
+            })
+          ).resolves.toEqual(expect.anything());
+        });
+      });
+    });
+
     describe('with flag updates', () => {
       describe('when `subscribeToFlagChanges`', () => {
         beforeEach(() => {

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -13,7 +13,7 @@ const userWithoutKey = {
 };
 const flags = { 'some-flag-1': true, 'some-flag-2': false };
 const createClient = jest.fn(apiOverwrites => ({
-  waitUntilReady: jest.fn(() => Promise.resolve()),
+  waitForInitialization: jest.fn(() => Promise.resolve()),
   on: jest.fn((_, cb) => cb()),
   allFlags: jest.fn(() => ({})),
 


### PR DESCRIPTION
- Closes #679 

#### Summary

This pull request intends to solve the issue with resolving configuration only with ready event when it succeeds.