### PR TITLE
chore: remove prop-types

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -35,7 +35,6 @@ module.exports = {
     '@babel/preset-typescript',
   ],
   plugins: [
-    'babel-plugin-typescript-to-proptypes',
     '@babel/plugin-external-helpers',
     [
       '@babel/plugin-proposal-class-properties',

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "babel-eslint": "10.0.2",
     "babel-jest": "24.8.0",
     "babel-plugin-transform-dynamic-import": "2.1.0",
-    "babel-plugin-typescript-to-proptypes": "0.17.1",
     "bundlesize": "0.18.0",
     "check-node-version": "4.0.1",
     "core-js": "3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,15 +2712,6 @@ babel-plugin-transform-dynamic-import@2.1.0:
   dependencies:
     "@babel/plugin-syntax-dynamic-import" "^7.0.0"
 
-babel-plugin-typescript-to-proptypes@0.17.1:
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-typescript-to-proptypes/-/babel-plugin-typescript-to-proptypes-0.17.1.tgz#9874735be3565ba4d7fc7f3cafb04fec40f55a83"
-  integrity sha512-yREUfvDlmn6QjM0QbywXUkXBQMD/iFfLVTl+jig4X7ZLUg9lq8ZLuex8HIM2SQ4X3vcjGnWPFowodlMcXhwxdQ==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-typescript" "^7.2.0"
-
 babel-polyfill@6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"


### PR DESCRIPTION
#### Summary

This could be considered breaking. However has the have a substitute in TypeScript types and had this remove before we won't release it as breaking again.

Essentially the plugin https://github.com/milesj/babel-plugin-typescript-to-proptypes fails to deduct some complex union types. This yields warnings in apps without any reason.