### PR TITLE
chore: support only react >=16.3, rename deprecated lifecycle method

### DIFF
--- a/packages/react-broadcast/package.json
+++ b/packages/react-broadcast/package.json
@@ -42,8 +42,8 @@
     "react-dom": "16.8.6"
   },
   "peerDependencies": {
-    "react": "^15.6 || ^16.0 || ^17.0",
-    "react-dom": "^15.6 || ^16.0 || ^17.0"
+    "react": "^16.3 || ^17.0",
+    "react-dom": "^16.3 || ^17.0"
   },
   "dependencies": {
     "@babel/runtime": "7.5.5",

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -49,8 +49,8 @@
     "lodash": "4.17.15"
   },
   "peerDependencies": {
-    "react": "^15.6 || ^16.0",
-    "react-dom": "^15.6 || ^16.0",
+    "react": "^16.3",
+    "react-dom": "^16.3",
     "react-redux": "^5.0 || ^7.0.0",
     "redux": "^3.7 || ^4.0"
   },

--- a/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
@@ -317,7 +317,7 @@ describe('lifecycle', () => {
     });
   });
 
-  describe('componentWillReceiveProps', () => {
+  describe('UNSAFE_componentWillReceiveProps', () => {
     let componentInstance;
     let props;
     let nextProps;
@@ -341,7 +341,8 @@ describe('lifecycle', () => {
 
         jest.spyOn(componentInstance, 'reconfigureOrQueue');
 
-        componentInstance.componentWillReceiveProps(nextProps);
+        // eslint-disable-next-line new-cap
+        componentInstance.UNSAFE_componentWillReceiveProps(nextProps);
       });
 
       it('should invoke `recongiureOrQueue`', () => {
@@ -367,7 +368,8 @@ describe('lifecycle', () => {
       beforeEach(() => {
         jest.spyOn(componentInstance, 'reconfigureOrQueue');
 
-        componentInstance.componentWillReceiveProps(props);
+        // eslint-disable-next-line new-cap
+        componentInstance.UNSAFE_componentWillReceiveProps(props);
       });
 
       it('should invoke not `recongiureOrQueue`', () => {

--- a/packages/react/modules/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.tsx
@@ -126,7 +126,7 @@ export default class ConfigureAdapter extends React.PureComponent<
    * NOTE:
    *    Whenever the adapter delays configuration pending adapterArgs will
    *    be kept on `pendingAdapterArgs`. These can either be populated
-   *    from calls to `componentWillReceiveProps` or through `ReconfigureFlopflip`.
+   *    from calls to `UNSAFE_componentWillReceiveProps` or through `ReconfigureFlopflip`.
    *    Both cases go through `reconfigureOrQueue`.
    *
    *    In any case, when the adapter should be configured it should either
@@ -152,7 +152,7 @@ export default class ConfigureAdapter extends React.PureComponent<
    *   may trigger a `setState` it might have unexpected side-effects (setState-loop).
    *   Maybe some more substancial refactor would be needed.
    */
-  componentWillReceiveProps(nextProps: Props): void {
+  UNSAFE_componentWillReceiveProps(nextProps: Props): void {
     if (nextProps.adapterArgs !== this.props.adapterArgs) {
       /**
        * NOTE:

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,8 +42,8 @@
     "react-dom": "16.8.6"
   },
   "peerDependencies": {
-    "react": "^15.6 || ^16.0",
-    "react-dom": "^15.6 || ^16.0"
+    "react": "^16.3",
+    "react-dom": "^16.3"
   },
   "dependencies": {
     "@babel/runtime": "7.5.5",


### PR DESCRIPTION
Ref #733