### PR TITLE
refactor: remove `create-react-context`

### DIFF
--- a/packages/react-broadcast/modules/components/flags-context/flags-context.ts
+++ b/packages/react-broadcast/modules/components/flags-context/flags-context.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Flags } from '@flopflip/types';
 
-const FlagsContext: React.createContext<Flags>({});
+const intialFlagsContext = {};
+const FlagsContext = React.createContext<Flags>(intialFlagsContext);
 
 export default FlagsContext;

--- a/packages/react-broadcast/modules/components/flags-context/flags-context.ts
+++ b/packages/react-broadcast/modules/components/flags-context/flags-context.ts
@@ -1,6 +1,6 @@
-import createReactContext, { Context } from 'create-react-context';
+import React from 'react';
 import { Flags } from '@flopflip/types';
 
-const FlagsContext: Context<Flags> = createReactContext({});
+const FlagsContext: React.createContext<Flags>({});
 
 export default FlagsContext;

--- a/packages/react-broadcast/modules/hooks/use-adapter-status/use-adapter-status.ts
+++ b/packages/react-broadcast/modules/hooks/use-adapter-status/use-adapter-status.ts
@@ -7,14 +7,7 @@ import {
 
 export default function useAdapterStatus(): Error | AdapterStatusType {
   if (typeof React.useContext === 'function') {
-    /**
-     * NODE: `createReactContext` and `React.Context` return incomptaible types which
-     * can not be interchanged. Until `createReactContext` is in use this
-     * has to remain.
-     */
-    const adapterContext: AdapterContextType = React.useContext(
-      AdapterContext as any
-    );
+    const adapterContext: AdapterContextType = React.useContext(AdapterContext);
 
     React.useDebugValue(adapterContext.status);
 

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.ts
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.ts
@@ -15,12 +15,7 @@ export default function useFeatureToggle(
   );
 
   if (typeof React.useContext === 'function') {
-    /**
-     * NODE: `createReactContext` and `React.Context` return incomptaible types which
-     * can not be interchanged. Until `createReactContext` is in use this
-     * has to remain.
-     */
-    const flags: Flags = React.useContext(FlagsContext as any);
+    const flags: Flags = React.useContext(FlagsContext);
     const isFeatureEnabled: boolean = getIsFeatureEnabled(
       flagName,
       flagVariation

--- a/packages/react-broadcast/package.json
+++ b/packages/react-broadcast/package.json
@@ -49,7 +49,6 @@
     "@babel/runtime": "7.5.5",
     "@flopflip/react": "^8.0.1",
     "@flopflip/types": "^2.1.1",
-    "create-react-context": "0.3.0",
     "lodash": "4.17.15"
   },
   "keywords": [

--- a/packages/react/modules/components/adapter-context/adapter-context.ts
+++ b/packages/react/modules/components/adapter-context/adapter-context.ts
@@ -18,9 +18,8 @@ const createAdapterContext = (
   status: status || initialAdapterStatus,
 });
 
-const AdapterContext:  React.createContext<AdapterContextType>(
-  createAdapterContext()
-);
+const initialAdapterContext = createAdapterContext();
+const AdapterContext = React.createContext(initialAdapterContext);
 
 export default AdapterContext;
 export { createAdapterContext };

--- a/packages/react/modules/components/adapter-context/adapter-context.ts
+++ b/packages/react/modules/components/adapter-context/adapter-context.ts
@@ -1,4 +1,4 @@
-import createReactContext, { Context } from 'create-react-context';
+import React from 'react';
 import {
   AdapterContext as AdapterContextType,
   AdapterStatus as AdapterStatusType,
@@ -18,7 +18,7 @@ const createAdapterContext = (
   status: status || initialAdapterStatus,
 });
 
-const AdapterContext: Context<AdapterContextType> = createReactContext(
+const AdapterContext:  React.createContext<AdapterContextType>(
   createAdapterContext()
 );
 

--- a/packages/react/modules/hooks/use-adapter-reconfiguration/use-adapter-reconfiguration.ts
+++ b/packages/react/modules/hooks/use-adapter-reconfiguration/use-adapter-reconfiguration.ts
@@ -9,14 +9,7 @@ export default function useAdapterReconfiguration():
   | Error
   | ReconfigureAdapterType {
   if (typeof React.useContext === 'function') {
-    /**
-     * NODE: `createReactContext` and `React.Context` return incomptaible types which
-     * can not be interchanged. Until `createReactContext` is in use this
-     * has to remain.
-     */
-    const adapterContext: AdapterContextType = React.useContext(
-      AdapterContext as any
-    );
+    const adapterContext: AdapterContextType = React.useContext(AdapterContext);
 
     return adapterContext.reconfigure;
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "@babel/runtime": "7.5.5",
-    "create-react-context": "0.3.0",
     "deepmerge": "4.0.0",
     "lodash": "4.17.15",
     "react-fast-compare": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3821,14 +3821,6 @@ create-jest-runner@^0.5.3:
     jest-worker "^24.0.0"
     throat "^4.1.0"
 
-create-react-context@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
-  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
-  dependencies:
-    gud "^1.0.0"
-    warning "^4.0.3"
-
 cross-env@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
@@ -5437,11 +5429,6 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
-
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
-  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
 gzip-size@^4.0.0:
   version "4.1.0"
@@ -11056,13 +11043,6 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
-
-warning@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  dependencies:
-    loose-envify "^1.0.0"
 
 wcwidth@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
#### Summary

This pull request removes `create-react-context` possible now as we support only 16.3.

/cc @emmenko thanks!