### PR TITLE
feat(launchdarkly-adapter): to allow passing flags

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -16,6 +16,7 @@ const createClient = jest.fn(apiOverwrites => ({
   waitForInitialization: jest.fn(() => Promise.resolve()),
   on: jest.fn((_, cb) => cb()),
   allFlags: jest.fn(() => ({})),
+  variation: jest.fn(() => true),
 
   ...apiOverwrites,
 }));
@@ -132,6 +133,7 @@ describe('when configuring', () => {
       onFlagsStateChange = jest.fn();
       client = createClient({
         allFlags: jest.fn(() => flags),
+        variation: jest.fn(() => true),
       });
 
       ldClient.initialize.mockReturnValue(client);
@@ -271,6 +273,7 @@ describe('when configuring', () => {
           onFlagsStateChange = jest.fn();
           client = createClient({
             allFlags: jest.fn(() => flags),
+            variation: jest.fn(() => true),
           });
 
           ldClient.initialize.mockReturnValue(client);
@@ -307,6 +310,7 @@ describe('when configuring', () => {
           onFlagsStateChange = jest.fn();
           client = createClient({
             allFlags: jest.fn(() => flags),
+            variation: jest.fn(() => true),
           });
 
           ldClient.initialize.mockReturnValue(client);

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -234,6 +234,48 @@ describe('when configuring', () => {
           ).resolves.toEqual(expect.anything());
         });
       });
+
+      describe('when `requestFlags` is passed', () => {
+        beforeEach(() => {
+          onStatusStateChange = jest.fn();
+          onFlagsStateChange = jest.fn();
+          client = createClient({
+            allFlags: jest.fn(),
+            variation: jest.fn(
+              (flagName, defaultFlagValue) => defaultFlagValue
+            ),
+          });
+
+          ldClient.initialize.mockReturnValue(client);
+
+          return adapter.configure({
+            clientSideId,
+            user: userWithKey,
+            onStatusStateChange,
+            requestFlags: flags,
+            onFlagsStateChange,
+          });
+        });
+
+        it('should `dispatch` `onUpdateStatus` action with `isReady`', () => {
+          expect(onStatusStateChange).toHaveBeenCalledWith({
+            isReady: true,
+          });
+        });
+
+        it('should `dispatch` `onStatusStateChange`', () => {
+          expect(onFlagsStateChange).toHaveBeenCalledWith({
+            someFlag1: true,
+            someFlag2: false,
+          });
+        });
+
+        it('should load flags not from `allFlags` but `variation`', () => {
+          expect(client.allFlags).not.toHaveBeenCalled();
+          expect(client.variation).toHaveBeenCalledWith('some-flag-1', true);
+          expect(client.variation).toHaveBeenCalledWith('some-flag-2', false);
+        });
+      });
     });
 
     describe('with flag updates', () => {

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.ts
@@ -17,6 +17,7 @@ import {
   LDClient,
 } from 'launchdarkly-js-client-sdk';
 import camelCase from 'lodash/camelCase';
+import kebabCase from 'lodash/kebabCase';
 
 type ClientOptions = {
   fetchGoals?: boolean;
@@ -166,12 +167,12 @@ export const camelCaseFlags = (rawFlags: Flags): Flags =>
 const getInitialFlags = ({
   onFlagsStateChange,
   onStatusStateChange,
-  requestedFlags,
+  requestFlags,
   throwOnInitializationFailure,
 }: {
   onFlagsStateChange: OnFlagsStateChangeCallback;
   onStatusStateChange: OnStatusStateChangeCallback;
-  requestedFlags: Flags;
+  requestFlags: Flags;
   throwOnInitializationFailure: boolean;
 }): Promise<{ flagsFromSdk: Flags | null }> => {
   if (adapterState.client) {
@@ -180,15 +181,15 @@ const getInitialFlags = ({
       .then(() => {
         let flagsFromSdk: null | Flags = null;
 
-        if (adapterState.client && !requestedFlags) {
+        if (adapterState.client && !requestFlags) {
           flagsFromSdk = adapterState.client.allFlags();
-        } else if (adapterState.client && requestedFlags) {
+        } else if (adapterState.client && requestFlags) {
           flagsFromSdk = {};
           for (let [requestedFlagName, defaultFlagValue] of Object.entries(
-            requestedFlags
+            requestFlags
           )) {
             flagsFromSdk[requestedFlagName] = adapterState.client.variation(
-              requestedFlagName,
+              kebabCase(requestedFlagName),
               defaultFlagValue
             );
           }
@@ -232,7 +233,7 @@ const configure = ({
   clientOptions = {},
   onFlagsStateChange,
   onStatusStateChange,
-  requestedFlags,
+  requestFlags,
   subscribeToFlagChanges = true,
   throwOnInitializationFailure = false,
   flagsUpdateDelayMs,
@@ -242,7 +243,7 @@ const configure = ({
   clientOptions: ClientOptions;
   onFlagsStateChange: OnFlagsStateChangeCallback;
   onStatusStateChange: OnStatusStateChangeCallback;
-  requestedFlags: Flags;
+  requestFlags: Flags;
   subscribeToFlagChanges: boolean;
   throwOnInitializationFailure: boolean;
   flagsUpdateDelayMs?: number;
@@ -258,7 +259,7 @@ const configure = ({
   return getInitialFlags({
     onFlagsStateChange,
     onStatusStateChange,
-    requestedFlags,
+    requestFlags,
     throwOnInitializationFailure,
   }).then(({ flagsFromSdk }) => {
     if (subscribeToFlagChanges && flagsFromSdk)

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -10,6 +10,7 @@ export type AdapterArgs = {
   adapterConfiguration: {
     pollingInteral: number;
   };
+  requestedFlags: Flags;
   onFlagsStateChange(flags: Flags): void;
   onStatusStateChange(status: AdapterStatus): void;
 };

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -10,7 +10,7 @@ export type AdapterArgs = {
   adapterConfiguration: {
     pollingInteral: number;
   };
-  requestedFlags: Flags;
+  requestFlags: Flags;
   onFlagsStateChange(flags: Flags): void;
   onStatusStateChange(status: AdapterStatus): void;
 };


### PR DESCRIPTION
#### Summary

This pull request allows passing `requestedFlags` to the `launchdarkly-adpter`.

#### Description

Passing `requestedFlags` will change the flag setup so that `variation` is called over `allFlags` which allow using LDs long running flag detection.