### PR TITLE
refactor: to automatically normalise flags

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -1,5 +1,5 @@
 import ldClient from 'launchdarkly-js-client-sdk';
-import adapter, { camelCaseFlags } from './adapter';
+import adapter, { normalizeFlags } from './adapter';
 
 jest.mock('launchdarkly-js-client-sdk', () => ({
   initialize: jest.fn(),
@@ -493,7 +493,7 @@ describe('when configuring', () => {
   });
 });
 
-describe('`camelCasedFlags`', () => {
+describe('`normalizeFlags`', () => {
   describe('with dashes', () => {
     const rawFlags = {
       'a-flag': true,
@@ -501,7 +501,7 @@ describe('`camelCasedFlags`', () => {
     };
 
     it('should camel case to uppercased flag names', () => {
-      expect(camelCaseFlags(rawFlags)).toEqual({ aFlag: true, flagBC: false });
+      expect(normalizeFlags(rawFlags)).toEqual({ aFlag: true, flagBC: false });
     });
   });
 
@@ -512,7 +512,7 @@ describe('`camelCasedFlags`', () => {
     };
 
     it('should camel case to uppercased flag names', () => {
-      expect(camelCaseFlags(rawFlags)).toEqual({ aFlag: true, flagBC: false });
+      expect(normalizeFlags(rawFlags)).toEqual({ aFlag: true, flagBC: false });
     });
   });
 });

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.ts
@@ -149,17 +149,17 @@ const updateUserContext = (updatedUserProps: User): Promise<any> => {
 };
 
 // NOTE: Exported for testing only
-export const camelCaseFlags = (rawFlags: Flags): Flags =>
+export const normalizeFlags = (rawFlags: Flags): Flags =>
   Object.entries(rawFlags).reduce<Flags>(
-    (camelCasedFlags: Flags, [flagName, flagValue]) => {
+    (normalizedFlags: Flags, [flagName, flagValue]) => {
       const [normalizedFlagName, normalizedFlagValue]: Flag = normalizeFlag(
         flagName,
         flagValue
       );
       // Can't return expression as it is the assigned value
-      camelCasedFlags[normalizedFlagName] = normalizedFlagValue;
+      normalizedFlags[normalizedFlagName] = normalizedFlagValue;
 
-      return camelCasedFlags;
+      return normalizedFlags;
     },
     {}
   );
@@ -196,7 +196,7 @@ const getInitialFlags = ({
         }
 
         if (flagsFromSdk) {
-          const flags: Flags = camelCaseFlags(flagsFromSdk);
+          const flags: Flags = normalizeFlags(flagsFromSdk);
           updateFlagsInAdapterState(flags);
           // ...and flush initial state of flags
           onFlagsStateChange(flags);

--- a/packages/localstorage-adapter/modules/adapter/adapter.spec.js
+++ b/packages/localstorage-adapter/modules/adapter/adapter.spec.js
@@ -77,6 +77,29 @@ describe('when configuring', () => {
           updatedFlags
         );
       });
+
+      describe('when flags are not normalized', () => {
+        const nonNormalizedUpdatedFlags = {
+          'flag-a-1': false,
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          flag_b: null,
+        };
+        beforeEach(() => {
+          // From `configure`
+          adapterArgs.onFlagsStateChange.mockClear();
+
+          updateFlags(nonNormalizedUpdatedFlags);
+        });
+
+        it('should invoke `onFlagsStateChange`', () => {
+          expect(adapterArgs.onFlagsStateChange).toHaveBeenCalledWith(
+            expect.objectContaining({
+              flagA1: false,
+              flagB: false,
+            })
+          );
+        });
+      });
     });
 
     describe('when reconfiguring', () => {

--- a/packages/memory-adapter/modules/adapter/adapter.spec.js
+++ b/packages/memory-adapter/modules/adapter/adapter.spec.js
@@ -90,6 +90,29 @@ describe('when configuring', () => {
           expect.objectContaining(updatedFlags)
         );
       });
+
+      describe('when flags are not normalized', () => {
+        const nonNormalizedUpdatedFlags = {
+          'flag-a-1': false,
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          flag_b: null,
+        };
+        beforeEach(() => {
+          // From `configure`
+          adapterArgs.onFlagsStateChange.mockClear();
+
+          updateFlags(nonNormalizedUpdatedFlags);
+        });
+
+        it('should invoke `onFlagsStateChange`', () => {
+          expect(adapterArgs.onFlagsStateChange).toHaveBeenCalled();
+        });
+
+        it('should normalise all flag names and values', () => {
+          expect(adapter.getFlag('flagA1')).toEqual(false);
+          expect(adapter.getFlag('flagB')).toEqual(false);
+        });
+      });
     });
 
     describe('when reconfiguring', () => {

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -96,15 +96,15 @@ const normalizeFlag = (flagName: FlagName, flagValue?: FlagVariation): Flag => [
 ];
 export const normalizeFlags = (rawFlags: Flags): Flags =>
   Object.entries(rawFlags).reduce<Flags>(
-    (camelCasedFlags: Flags, [flagName, flagValue]) => {
+    (normalizedFlags: Flags, [flagName, flagValue]) => {
       const [normalizedFlagName, normalizedFlagValue]: Flag = normalizeFlag(
         flagName,
         flagValue
       );
       // Can't return expression as it is the assigned value
-      camelCasedFlags[normalizedFlagName] = normalizedFlagValue;
+      normalizedFlags[normalizedFlagName] = normalizedFlagValue;
 
-      return camelCasedFlags;
+      return normalizedFlags;
     },
     {}
   );

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -6,8 +6,10 @@ import {
   AdapterArgs,
   FlagName,
   FlagVariation,
+  Flag,
   Flags,
 } from '@flopflip/types';
+import camelCase from 'lodash/camelCase';
 
 type MemoryAdapterState = {
   flags: Flags;
@@ -87,6 +89,25 @@ const updateUser = (user: User): void => {
   adapterState.user = user;
 };
 
+const normalizeFlag = (flagName: FlagName, flagValue?: FlagVariation): Flag => [
+  camelCase(flagName),
+  // Multi variate flags contain a string or `null` - `false` seems more natural.
+  flagValue === null || flagValue === undefined ? false : flagValue,
+];
+export const normalizeFlags = (rawFlags: Flags): Flags =>
+  Object.entries(rawFlags).reduce<Flags>(
+    (camelCasedFlags: Flags, [flagName, flagValue]) => {
+      const [normalizedFlagName, normalizedFlagValue]: Flag = normalizeFlag(
+        flagName,
+        flagValue
+      );
+      // Can't return expression as it is the assigned value
+      camelCasedFlags[normalizedFlagName] = normalizedFlagValue;
+
+      return camelCasedFlags;
+    },
+    {}
+  );
 export const updateFlags = (flags: Flags): void => {
   const isAdapterReady = Boolean(
     adapterState.isConfigured && adapterState.isReady
@@ -101,7 +122,7 @@ export const updateFlags = (flags: Flags): void => {
 
   adapterState.flags = {
     ...adapterState.flags,
-    ...flags,
+    ...normalizeFlags(flags),
   };
 
   adapterState.emitter.emit('flagsStateChange', adapterState.flags);

--- a/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.ts
+++ b/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.ts
@@ -4,7 +4,7 @@ import { FlagName, FlagVariation } from '@flopflip/types';
 import { withProps } from '../../hocs';
 import isNil from 'lodash/isNil';
 import { omitProps } from '../../hocs';
-import getNormalizedFlagName from '../utils/get-normalized-flag-name';
+import { getNormalizedFlagName } from '../../helpers';
 import { DEFAULT_FLAG_PROP_KEY, ALL_FLAGS_PROP_KEY } from '../../constants';
 
 type InjectedProps = {

--- a/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.ts
+++ b/packages/react/modules/components/inject-feature-toggle/inject-feature-toggle.ts
@@ -4,6 +4,7 @@ import { FlagName, FlagVariation } from '@flopflip/types';
 import { withProps } from '../../hocs';
 import isNil from 'lodash/isNil';
 import { omitProps } from '../../hocs';
+import getNormalizedFlagName from '../utils/get-normalized-flag-name';
 import { DEFAULT_FLAG_PROP_KEY, ALL_FLAGS_PROP_KEY } from '../../constants';
 
 type InjectedProps = {
@@ -20,7 +21,7 @@ const injectFeatureToggle = <Props extends object>(
   flowRight(
     withProps<Props, InjectedProps>((ownProps: Props) => {
       const flagVariation: FlagVariation =
-        ownProps[ALL_FLAGS_PROP_KEY][flagName];
+        ownProps[ALL_FLAGS_PROP_KEY][getNormalizedFlagName(flagName)];
 
       return { [propKey]: isNil(flagVariation) ? false : flagVariation };
     }),

--- a/packages/react/modules/components/inject-feature-toggles/utils.ts
+++ b/packages/react/modules/components/inject-feature-toggles/utils.ts
@@ -2,7 +2,7 @@ import { FlagName, Flags } from '@flopflip/types';
 import omit from 'lodash/omit';
 import intersection from 'lodash/intersection';
 import isEqual from 'react-fast-compare';
-import getNormalizedFlagName from '../utils/get-normalized-flag-name';
+import { getNormalizedFlagName } from '../../helpers';
 
 const defaultAreOwnPropsEqual = <Props extends object>(
   nextOwnProps: Props,

--- a/packages/react/modules/components/inject-feature-toggles/utils.ts
+++ b/packages/react/modules/components/inject-feature-toggles/utils.ts
@@ -2,6 +2,7 @@ import { FlagName, Flags } from '@flopflip/types';
 import omit from 'lodash/omit';
 import intersection from 'lodash/intersection';
 import isEqual from 'react-fast-compare';
+import getNormalizedFlagName from '../utils/get-normalized-flag-name';
 
 const defaultAreOwnPropsEqual = <Props extends object>(
   nextOwnProps: Props,
@@ -21,9 +22,11 @@ const defaultAreOwnPropsEqual = <Props extends object>(
 
 const filterFeatureToggles = (allFlags: Flags, demandedFlags: FlagName[]) =>
   intersection(Object.keys(allFlags), demandedFlags).reduce(
-    (featureToggles: Flags, featureToggle: FlagName) => ({
+    (featureToggles: Flags, flagName: FlagName) => ({
       ...featureToggles,
-      [featureToggle]: allFlags[featureToggle],
+      [getNormalizedFlagName(flagName)]: allFlags[
+        getNormalizedFlagName(flagName)
+      ],
     }),
     {}
   );

--- a/packages/react/modules/helpers/get-is-feature-enabled/get-is-feature-enabled.spec.js
+++ b/packages/react/modules/helpers/get-is-feature-enabled/get-is-feature-enabled.spec.js
@@ -32,9 +32,9 @@ describe('with existing flag', () => {
 });
 
 describe('with non normalized flag', () => {
-  it('should indicate feature being disabled', () => {
+  it('should indicate feature being enabled', () => {
     const args = { fooFlag: true };
-    expect(getIsFeatureEnabled('foo-flag')(args)).toBe(false);
+    expect(getIsFeatureEnabled('foo-flag')(args)).toBe(true);
   });
 
   it('should invoke `warning`', () => {

--- a/packages/react/modules/helpers/get-is-feature-enabled/get-is-feature-enabled.ts
+++ b/packages/react/modules/helpers/get-is-feature-enabled/get-is-feature-enabled.ts
@@ -1,7 +1,7 @@
 import { FlagName, FlagVariation, Flags } from '@flopflip/types';
-import camelCase from 'lodash/camelCase';
 import warning from 'tiny-warning';
 import { DEFAULT_FLAG_PROP_KEY } from '../../constants';
+import getNormalizedFlagName from '../get-normalized-flag-name';
 
 /**
  * Given a `flagName` and a `flagVariation`
@@ -16,8 +16,10 @@ const getIsFeatureEnabled = (
   flagName: FlagName = DEFAULT_FLAG_PROP_KEY,
   flagVariation: FlagVariation = true
 ): ((flags: Flags) => boolean) => {
+  const normalizedFlagName = getNormalizedFlagName(flagName);
+
   warning(
-    flagName === camelCase(flagName),
+    normalizedFlagName === flagName,
     '@flopflip/react: passed flag name does not seem to be normalized which may result in unexpected toggling. Please refer to our readme for more information: https://github.com/tdeekens/flopflip#flag-normalization'
   );
 

--- a/packages/react/modules/helpers/get-is-feature-enabled/get-is-feature-enabled.ts
+++ b/packages/react/modules/helpers/get-is-feature-enabled/get-is-feature-enabled.ts
@@ -23,7 +23,7 @@ const getIsFeatureEnabled = (
     '@flopflip/react: passed flag name does not seem to be normalized which may result in unexpected toggling. Please refer to our readme for more information: https://github.com/tdeekens/flopflip#flag-normalization'
   );
 
-  return flags => flags[flagName] === flagVariation;
+  return flags => flags[normalizedFlagName] === flagVariation;
 };
 
 export default getIsFeatureEnabled;

--- a/packages/react/modules/helpers/get-normalized-flag-name/get-normalized-flag-name.spec.js
+++ b/packages/react/modules/helpers/get-normalized-flag-name/get-normalized-flag-name.spec.js
@@ -1,0 +1,15 @@
+import getNormalizedFlagName from './get-normalized-flag-name';
+
+describe('when not camel caased', () => {
+  it('should normalized the flag name', () => {
+    expect(getNormalizedFlagName('foo-flag')).toEqual('fooFlag');
+    expect(getNormalizedFlagName('foo_flag')).toEqual('fooFlag');
+    expect(getNormalizedFlagName('foo flag')).toEqual('fooFlag');
+  });
+});
+
+describe('when camel caased', () => {
+  it('should normalized the flag name', () => {
+    expect(getNormalizedFlagName('fooFlag')).toEqual('fooFlag');
+  });
+});

--- a/packages/react/modules/helpers/get-normalized-flag-name/get-normalized-flag-name.ts
+++ b/packages/react/modules/helpers/get-normalized-flag-name/get-normalized-flag-name.ts
@@ -1,0 +1,8 @@
+import { FlagName } from '@flopflip/types';
+import camelCase from 'lodash/camelCase';
+
+const getNormalizedFlagName = (flagName: FlagName): FlagName => {
+  return camelCase(flagName);
+};
+
+export default getNormalizedFlagName;

--- a/packages/react/modules/helpers/get-normalized-flag-name/index.ts
+++ b/packages/react/modules/helpers/get-normalized-flag-name/index.ts
@@ -1,0 +1,1 @@
+export { default } from './get-normalized-flag-name';

--- a/packages/react/modules/helpers/index.ts
+++ b/packages/react/modules/helpers/index.ts
@@ -1,4 +1,2 @@
 export { default as getIsFeatureEnabled } from './get-is-feature-enabled';
-export {
-  default as getNormalizedFlagName,
-} from './get-get-normalized-flag-name';
+export { default as getNormalizedFlagName } from './get-normalized-flag-name';

--- a/packages/react/modules/helpers/index.ts
+++ b/packages/react/modules/helpers/index.ts
@@ -1,1 +1,4 @@
 export { default as getIsFeatureEnabled } from './get-is-feature-enabled';
+export {
+  default as getNormalizedFlagName,
+} from './get-get-normalized-flag-name';

--- a/packages/splitio-adapter/modules/adapter/adapter.spec.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.spec.js
@@ -1,6 +1,6 @@
 import { SplitFactory } from '@splitsoftware/splitio';
 import adapter, {
-  camelCaseFlags,
+  normalizeFlags,
   createAnonymousUserKey,
   normalizeFlag,
 } from './adapter';
@@ -257,7 +257,7 @@ describe('when configuring', () => {
   });
 });
 
-describe('camelCasedFlags', () => {
+describe('normalizeFlags', () => {
   describe('with dashes', () => {
     const rawFlags = {
       'a-flag': true,
@@ -265,7 +265,7 @@ describe('camelCasedFlags', () => {
     };
 
     it('should camel case to uppercased flag names', () => {
-      expect(camelCaseFlags(rawFlags)).toEqual({ aFlag: true, flagBC: false });
+      expect(normalizeFlags(rawFlags)).toEqual({ aFlag: true, flagBC: false });
     });
   });
 
@@ -276,7 +276,7 @@ describe('camelCasedFlags', () => {
     };
 
     it('should camel case to uppercased flag names', () => {
-      expect(camelCaseFlags(rawFlags)).toEqual({ aFlag: true, flagBC: false });
+      expect(normalizeFlags(rawFlags)).toEqual({ aFlag: true, flagBC: false });
     });
   });
 });

--- a/packages/splitio-adapter/modules/adapter/adapter.ts
+++ b/packages/splitio-adapter/modules/adapter/adapter.ts
@@ -64,17 +64,17 @@ export const normalizeFlag = (
   return [camelCase(flagName), normalizeFlagValue];
 };
 
-export const camelCaseFlags = (flags: Flags): Flags =>
+export const normalizeFlags = (flags: Flags): Flags =>
   Object.entries(flags).reduce<Flags>(
-    (camelCasedFlags: Flags, [flagName, flaValue]) => {
+    (normalizedFlags: Flags, [flagName, flaValue]) => {
       const [normalizedFlagName, normalizedFlagValue]: Flag = normalizeFlag(
         flagName,
         flaValue
       );
 
-      camelCasedFlags[normalizedFlagName] = normalizedFlagValue;
+      normalizedFlags[normalizedFlagName] = normalizedFlagValue;
 
-      return camelCasedFlags;
+      return normalizedFlags;
     },
     {}
   );
@@ -94,7 +94,7 @@ const subscribeToFlagsChanges = ({
           adapterState.user as SplitIO.Attributes
         );
 
-        onFlagsStateChange(camelCaseFlags(flags));
+        onFlagsStateChange(normalizeFlags(flags));
       }
     });
   }
@@ -147,7 +147,7 @@ const subscribe = ({
             adapterState.user as SplitIO.Attributes
           );
 
-          onFlagsStateChange(camelCaseFlags(flags));
+          onFlagsStateChange(normalizeFlags(flags));
 
           // First update internal state
           adapterState.isReady = true;

--- a/readme.md
+++ b/readme.md
@@ -494,7 +494,7 @@ share common logic.
 - `ToggleFeature` a component conditionally rendering its `children` based on
   the status of a passed feature flag
 
-[Note:](#flag-normalization) that all passed `flagNames` passed as `flag` are a string. Depending on the adapter used _these are normalized_ to be camel cased. This means that whenever a `foo-flag-name` is configured in e.g. LaunchDarkly or splitio it will have to be specified as `fooFlagName`. The same applies for a `foo_flag_name`. This is meant to help using flags in an adapter agnostic way. Whenever a flag is otherwise passed in the non-normalized form it is likely to default to `false` which is unintended in most cases. Lastly, `flopflip` will show a warning message in the console in development mode whenever a non normalized flag name is passed.
+[Note:](#flag-normalization) that all passed `flagNames` passed as `flag` are a string. Depending on the adapter used _these are normalized_ to be camel cased. This means that whenever a `foo-flag-name` is received in e.g. LaunchDarkly or splitio it will be converted to `fooFlagName`. The same applies for a `foo_flag_name`. This is meant to help using flags in an adapter agnostic way. Whenever a flag is passed in the non-normalized form it is also normalized again. Lastly, `flopflip` will show a warning message in the console in development mode whenever a non normalized flag name is passed.
 
 #### `ToggleFeature`
 


### PR DESCRIPTION
#### Summary

This pull request takes on #841 to normalise flags by default. 

I still have to reflect on the consequences of this and how to make adapters backwards compatible.

E.g. if you have non normalised flags in local storage we need to normalise to forward their value correctly.

I like this change but it's a bit more risky than it seems ;)