### PR TITLE
fix(types): adapter children is either a node or a function

### DIFF
--- a/packages/react/modules/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.tsx
@@ -8,6 +8,7 @@ import {
   AdapterReconfiguration,
   AdapterReconfigurationOptions,
   ConfigureAdapterChildren,
+  ConfigureAdapterChildrenFn,
 } from '@flopflip/types';
 import AdapterContext, { createAdapterContext } from '../adapter-context';
 
@@ -38,8 +39,12 @@ type State = {
 };
 type AdapterState = valueof<AdapterStates>;
 
-const isEmptyChildren = (children: React.ReactNode): boolean =>
-  React.Children.count(children) === 0;
+const isFunctionChildren = (
+  children: ConfigureAdapterChildren
+): children is ConfigureAdapterChildrenFn => typeof children === 'function';
+
+const isEmptyChildren = (children: ConfigureAdapterChildren): boolean =>
+  !isFunctionChildren(children) && React.Children.count(children) === 0;
 
 export const mergeAdapterArgs = (
   previousAdapterArgs: AdapterArgs,
@@ -244,20 +249,20 @@ export default class ConfigureAdapter extends React.PureComponent<
         )}
       >
         {(() => {
-          const isAdapterReady: boolean = this.props.adapter.getIsReady();
+          const isAdapterReady = this.props.adapter.getIsReady();
 
           if (isAdapterReady) {
             if (typeof this.props.render === 'function')
               return this.props.render();
           }
 
-          if (typeof this.props.children === 'function')
+          if (isFunctionChildren(this.props.children))
             return this.props.children({
               isAdapterReady,
             });
 
           if (this.props.children && !isEmptyChildren(this.props.children))
-            return React.Children.only(this.props.children);
+            return React.Children.only<React.ReactNode>(this.props.children);
 
           return null;
         })()}

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -36,11 +36,15 @@ export type AdapterReconfiguration = {
   adapterArgs: AdapterArgs;
   options: AdapterReconfigurationOptions;
 };
-export type ConfigureAdapterChildren = ({
-  isAdapterReady,
-}: {
+export type ConfigureAdapterChildrenFnArgs = {
   isAdapterReady: boolean;
-}) => React.ReactNode | React.ReactNode | null;
+};
+export type ConfigureAdapterChildrenFn = (
+  args: ConfigureAdapterChildrenFnArgs
+) => React.ReactNode;
+export type ConfigureAdapterChildren =
+  | ConfigureAdapterChildrenFn
+  | React.ReactNode;
 export type ReconfigureAdapter = (
   adapterArgs: AdapterArgs,
   options: AdapterReconfigurationOptions


### PR DESCRIPTION
#### Summary

The type declaration of `ConfigureAdapterChildren` is not entirely correct.

#### Description

The `ConfigureAdapter` component of the `react` package is typed with `children` being

```tsx
type ConfigureAdapterChildren = ({
  isAdapterReady,
}: {
  isAdapterReady: boolean;
}) => React.ReactNode | React.ReactNode | null;
```

which makes it to always be a function. As a consequence, passing a `ReactNode` as a child, results in a type error.
I think the mistake is in the syntax `=> React.ReactNode | React.ReactNode | null`, which hints that the **return type** of the function is either one of the listed types, instead of the `ConfigureAdapterChildren` type being etiher-or.

To fix that, I split the types so that the union is less ambiguous.
