### PR TITLE
fix(types): do not expose event handlers to adapterArgs props

### DIFF
--- a/packages/react-broadcast/modules/components/configure/configure.tsx
+++ b/packages/react-broadcast/modules/components/configure/configure.tsx
@@ -5,6 +5,7 @@ import {
   Flags,
   Adapter,
   AdapterArgs,
+  AdapterEventHandlers,
   AdapterStatus,
   ConfigureAdapterChildren,
 } from '@flopflip/types';
@@ -23,14 +24,9 @@ type State = {
 };
 
 const createAdapterArgs = memoize(
-  (
-    adapterArgs: AdapterArgs,
-    handleUpdateStatus: (status: AdapterStatus) => void,
-    handleUpdateFlags: (flags: Flags) => void
-  ): AdapterArgs => ({
+  (adapterArgs: AdapterArgs, eventHandlers: AdapterEventHandlers) => ({
     ...adapterArgs,
-    onStatusStateChange: handleUpdateStatus,
-    onFlagsStateChange: handleUpdateFlags,
+    ...eventHandlers,
   })
 );
 
@@ -85,11 +81,10 @@ export default class Configure extends React.PureComponent<Props, State> {
       <FlagsContext.Provider value={this.state.flags}>
         <ConfigureAdapter
           adapter={this.props.adapter}
-          adapterArgs={createAdapterArgs(
-            this.props.adapterArgs,
-            this.handleUpdateStatus,
-            this.handleUpdateFlags
-          )}
+          adapterArgs={createAdapterArgs(this.props.adapterArgs, {
+            onFlagsStateChange: this.handleUpdateFlags,
+            onStatusStateChange: this.handleUpdateStatus,
+          })}
           adapterStatus={this.state.status}
           defaultFlags={this.props.defaultFlags}
           shouldDeferAdapterConfiguration={

--- a/packages/react-redux/modules/components/configure/configure.tsx
+++ b/packages/react-redux/modules/components/configure/configure.tsx
@@ -6,6 +6,7 @@ import {
   Flags,
   Adapter,
   AdapterArgs,
+  AdapterEventHandlers,
   AdapterStatus,
   ConfigureAdapterChildren,
 } from '@flopflip/types';
@@ -28,14 +29,9 @@ type State = {
 };
 
 const createAdapterArgs = memoize(
-  (
-    adapterArgs: AdapterArgs,
-    handleUpdateStatus: (status: AdapterStatus) => UpdateStatusAction,
-    handleUpdateFlags: (flags: Flags) => UpdateFlagsAction
-  ): AdapterArgs => ({
+  (adapterArgs: AdapterArgs, eventHandlers: AdapterEventHandlers) => ({
     ...adapterArgs,
-    onStatusStateChange: handleUpdateStatus,
-    onFlagsStateChange: handleUpdateFlags,
+    ...eventHandlers,
   })
 );
 
@@ -54,11 +50,10 @@ export class Configure extends React.PureComponent<
     return (
       <ConfigureAdapter
         adapter={this.props.adapter}
-        adapterArgs={createAdapterArgs(
-          this.props.adapterArgs,
-          this.props.handleUpdateStatus,
-          this.props.handleUpdateFlags
-        )}
+        adapterArgs={createAdapterArgs(this.props.adapterArgs, {
+          onFlagsStateChange: this.props.handleUpdateFlags,
+          onStatusStateChange: this.props.handleUpdateStatus,
+        })}
         defaultFlags={this.props.defaultFlags}
         shouldDeferAdapterConfiguration={
           this.props.shouldDeferAdapterConfiguration
@@ -75,4 +70,7 @@ const mapDispatchToProps: ConnectedProps = {
   handleUpdateFlags: updateFlags,
 };
 
-export default connect(null, mapDispatchToProps)(Configure);
+export default connect(
+  null,
+  mapDispatchToProps
+)(Configure);

--- a/packages/react/modules/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.tsx
@@ -3,7 +3,7 @@ import merge from 'deepmerge';
 import {
   Flags,
   Adapter,
-  AdapterArgs,
+  AdapterArgsWithEventHandlers,
   AdapterStatus,
   AdapterReconfiguration,
   AdapterReconfigurationOptions,
@@ -28,14 +28,14 @@ export const AdapterStates: AdapterStates = {
 type Props = {
   shouldDeferAdapterConfiguration?: boolean;
   adapter: Adapter;
-  adapterArgs: AdapterArgs;
+  adapterArgs: AdapterArgsWithEventHandlers;
   adapterStatus?: AdapterStatus;
   defaultFlags?: Flags;
   render?: () => React.ReactNode;
   children?: ConfigureAdapterChildren;
 };
 type State = {
-  appliedAdapterArgs: AdapterArgs;
+  appliedAdapterArgs: AdapterArgsWithEventHandlers;
 };
 type AdapterState = valueof<AdapterStates>;
 
@@ -47,9 +47,9 @@ const isEmptyChildren = (children: ConfigureAdapterChildren): boolean =>
   !isFunctionChildren(children) && React.Children.count(children) === 0;
 
 export const mergeAdapterArgs = (
-  previousAdapterArgs: AdapterArgs,
+  previousAdapterArgs: AdapterArgsWithEventHandlers,
   { adapterArgs: nextAdapterArgs, options = {} }: AdapterReconfiguration
-): AdapterArgs =>
+): AdapterArgsWithEventHandlers =>
   options.shouldOverwrite
     ? nextAdapterArgs
     : merge(previousAdapterArgs, nextAdapterArgs);
@@ -65,16 +65,16 @@ export default class ConfigureAdapter extends React.PureComponent<
     render: null,
   };
   adapterState: AdapterState = AdapterStates.UNCONFIGURED;
-  pendingAdapterArgs?: AdapterArgs | null = null;
+  pendingAdapterArgs?: AdapterArgsWithEventHandlers | null = null;
 
-  state: { appliedAdapterArgs: AdapterArgs } = {
+  state: { appliedAdapterArgs: AdapterArgsWithEventHandlers } = {
     appliedAdapterArgs: this.props.adapterArgs,
   };
 
   setAdapterState = (nextAdapterState: AdapterState): void => {
     this.adapterState = nextAdapterState;
   };
-  applyAdapterArgs = (nextAdapterArgs: AdapterArgs): void =>
+  applyAdapterArgs = (nextAdapterArgs: AdapterArgsWithEventHandlers): void =>
     /**
      * NOTE:
      *   We can only unset `pendingAdapterArgs` after be actually perform
@@ -98,7 +98,7 @@ export default class ConfigureAdapter extends React.PureComponent<
    *   this function has two arguments for clarify.
    */
   reconfigureOrQueue = (
-    nextAdapterArgs: AdapterArgs,
+    nextAdapterArgs: AdapterArgsWithEventHandlers,
     options: AdapterReconfigurationOptions
   ): void =>
     this.adapterState === AdapterStates.CONFIGURED &&
@@ -138,7 +138,7 @@ export default class ConfigureAdapter extends React.PureComponent<
    *    be passed pending or applied adapterArgs.
    *
    */
-  getAdapterArgsForConfiguration = (): AdapterArgs =>
+  getAdapterArgsForConfiguration = (): AdapterArgsWithEventHandlers =>
     this.pendingAdapterArgs || this.state.appliedAdapterArgs;
 
   handleDefaultFlags = (defaultFlags: Flags): void => {

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -5,19 +5,22 @@ export type Flags = { [key: string]: FlagVariation };
 export type User = {
   key?: string;
 };
+export type AdapterStatus = {
+  isReady?: boolean;
+  isConfigured?: boolean;
+};
+export type AdapterEventHandlers = {
+  onFlagsStateChange: (flags: Flags) => void;
+  onStatusStateChange: (status: AdapterStatus) => void;
+};
 export type AdapterArgs = {
   user: User;
   adapterConfiguration: {
     pollingInteral: number;
   };
   flags: Flags;
-  onFlagsStateChange(flags: Flags): void;
-  onStatusStateChange(status: AdapterStatus): void;
 };
-export type AdapterStatus = {
-  isReady?: boolean;
-  isConfigured?: boolean;
-};
+export type AdapterArgsWithEventHandlers = AdapterArgs & AdapterEventHandlers;
 export type Adapter = {
   configure(adapterArgs: AdapterArgs): Promise<any>;
   reconfigure(adapterArgs: AdapterArgs): Promise<any>;
@@ -33,7 +36,7 @@ export type AdapterReconfigurationOptions = {
   shouldOverwrite?: boolean;
 };
 export type AdapterReconfiguration = {
-  adapterArgs: AdapterArgs;
+  adapterArgs: AdapterArgsWithEventHandlers;
   options: AdapterReconfigurationOptions;
 };
 export type ConfigureAdapterChildrenFnArgs = {
@@ -46,7 +49,7 @@ export type ConfigureAdapterChildren =
   | ConfigureAdapterChildrenFn
   | React.ReactNode;
 export type ReconfigureAdapter = (
-  adapterArgs: AdapterArgs,
+  adapterArgs: AdapterArgsWithEventHandlers,
   options: AdapterReconfigurationOptions
 ) => void;
 export type AdapterContext = {


### PR DESCRIPTION
#### Summary

According to the types of `adapterArgs` prop, the `ConfigureFlopFlip` component currently requires the user to pass props such as `onStatusStateChange` and `onFlagsStateChange`.

As far as I understand, those props are only used internally and therefore do no need to be exposed to the `ConfigureFlopFlip` component.