### PR TITLE
Fix to add sequential id when testing multiple configurations at once

### DIFF
--- a/packages/react/modules/helpers/create-sequential-id/create-sequential-id.spec.js
+++ b/packages/react/modules/helpers/create-sequential-id/create-sequential-id.spec.js
@@ -1,0 +1,31 @@
+import createSequentialId from './create-sequential-id';
+
+it('should return a function', () => {
+  expect(typeof createSequentialId('foo')).toBe('function');
+});
+
+describe('when the factory is created', () => {
+  let sequentialId;
+  beforeEach(() => {
+    sequentialId = createSequentialId('first-');
+  });
+  it('should return sequential ids', () => {
+    expect(sequentialId()).toBe('first-1');
+    expect(sequentialId()).toBe('first-2');
+  });
+});
+
+describe('when two factories are created', () => {
+  let sequentialIdFirst;
+  let sequentialIdSecond;
+  beforeEach(() => {
+    sequentialIdFirst = createSequentialId('first-');
+    sequentialIdSecond = createSequentialId('second-');
+  });
+  it('should have separate counters for each one', () => {
+    expect(sequentialIdFirst()).toBe('first-1');
+    expect(sequentialIdFirst()).toBe('first-2');
+    expect(sequentialIdSecond()).toBe('second-1');
+    expect(sequentialIdFirst()).toBe('first-3');
+  });
+});

--- a/packages/react/modules/helpers/create-sequential-id/create-sequential-id.ts
+++ b/packages/react/modules/helpers/create-sequential-id/create-sequential-id.ts
@@ -1,0 +1,9 @@
+const createSequentialId = (prefix: string) => {
+  let id = 0;
+  return () => {
+    id += 1;
+    return `${prefix}${id}`;
+  };
+};
+
+export default createSequentialId;

--- a/packages/react/modules/helpers/create-sequential-id/index.ts
+++ b/packages/react/modules/helpers/create-sequential-id/index.ts
@@ -1,0 +1,1 @@
+export { default } from './create-sequential-id';

--- a/packages/react/modules/helpers/index.ts
+++ b/packages/react/modules/helpers/index.ts
@@ -1,2 +1,3 @@
 export { default as getIsFeatureEnabled } from './get-is-feature-enabled';
 export { default as getNormalizedFlagName } from './get-normalized-flag-name';
+export { default as createSequentialId } from './create-sequential-id';

--- a/packages/react/modules/index.ts
+++ b/packages/react/modules/index.ts
@@ -11,7 +11,7 @@ export {
   ReconfigureAdapter,
 } from './components';
 
-export { getIsFeatureEnabled } from './helpers';
+export { getIsFeatureEnabled, createSequentialId } from './helpers';
 
 export {
   DEFAULT_FLAG_PROP_KEY,


### PR DESCRIPTION
#### Summary

To strike a balance between Firefox crashing and memoizing adapter args only fo reach instance of configuration.