### PR TITLE
feat(react-broadcast): add useFeatureToggles

### DIFF
--- a/packages/react-broadcast/modules/hooks/index.ts
+++ b/packages/react-broadcast/modules/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useFeatureToggle } from './use-feature-toggle';
+export { default as useFeatureToggles } from './use-feature-toggles';
 export { default as useAdapterStatus } from './use-adapter-status';
 export { default as useAdapterReconfiguration } from './use-adapter-reconfiguration';

--- a/packages/react-broadcast/modules/hooks/use-feature-toggles/index.ts
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggles/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-feature-toggles';

--- a/packages/react-broadcast/modules/hooks/use-feature-toggles/use-feature-toggles.spec.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggles/use-feature-toggles.spec.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import useFeatureToggles from './use-feature-toggles';
+import { renderWithAdapter } from '@flopflip/test-utils';
+import Configure from '../../components/configure';
+
+jest.mock('tiny-warning');
+
+const render = TestComponent =>
+  renderWithAdapter(TestComponent, {
+    components: { ConfigureFlopFlip: Configure },
+  });
+
+const TestComponent = () => {
+  const [
+    isEnabledFeatureEnabled,
+    isDisabledFeatureDisabled,
+  ] = useFeatureToggles({
+    enabledFeature: true,
+    disabledFeature: true,
+  });
+
+  return (
+    <ul>
+      <li>Is enabled: {isEnabledFeatureEnabled ? 'Yes' : 'No'}</li>
+      <li>Is disabled: {isDisabledFeatureDisabled ? 'No' : 'Yes'}</li>
+    </ul>
+  );
+};
+
+describe('when React hooks (`useContext`) is available', () => {
+  it('should indicate a feature being disabled', async () => {
+    const { getByText, waitUntilReady } = render(<TestComponent />);
+
+    await waitUntilReady();
+
+    expect(getByText('Is disabled: Yes')).toBeInTheDocument();
+  });
+
+  it('should indicate a feature being enabled', async () => {
+    const { getByText, waitUntilReady } = render(<TestComponent />);
+
+    await waitUntilReady();
+
+    expect(getByText('Is enabled: Yes')).toBeInTheDocument();
+  });
+});
+
+describe('when React hooks (`useContext`) are not available', () => {
+  describe('when flag is enabled', () => {
+    beforeEach(() => {
+      React.useContext = jest.fn(() => undefined);
+    });
+
+    it('should throw', () => {
+      expect(() => useFeatureToggles('foo')).toThrow();
+    });
+  });
+});

--- a/packages/react-broadcast/modules/hooks/use-feature-toggles/use-feature-toggles.ts
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggles/use-feature-toggles.ts
@@ -1,0 +1,28 @@
+import React from 'react';
+import { getIsFeatureEnabled } from '@flopflip/react';
+import { FlagName, Flags, FlagVariation } from '@flopflip/types';
+import { FlagsContext } from '../../components/flags-context';
+
+export default function useFeatureToggles(flags: Flags): Error | boolean[] {
+  if (typeof React.useContext === 'function') {
+    const allFlags: Flags = React.useContext(FlagsContext);
+
+    const requestedFlags: boolean[] = Object.entries(flags).reduce<boolean[]>(
+      (previousFlags, [flagName, flagVariation]: [FlagName, FlagVariation]) => {
+        const isFeatureEnabled: boolean = getIsFeatureEnabled(
+          flagName,
+          flagVariation
+        )(allFlags);
+
+        return [...previousFlags, isFeatureEnabled];
+      },
+      []
+    );
+
+    return requestedFlags;
+  }
+
+  throw new Error(
+    'React hooks are not available in your currently installed version of React.'
+  );
+}

--- a/packages/react-broadcast/modules/index.ts
+++ b/packages/react-broadcast/modules/index.ts
@@ -10,6 +10,7 @@ export {
 } from './components';
 export {
   useFeatureToggle,
+  useFeatureToggles,
   useAdapterStatus,
   useAdapterReconfiguration,
 } from './hooks';

--- a/readme.md
+++ b/readme.md
@@ -764,6 +764,31 @@ const ComponentWithFeatureToggle = props => {
 }
 ```
 
+#### `useFeatureToggles({ [ flagName: string ]: FlagVariation } ): boolean[]`
+
+A forward compatible implementation [React hook](https://reactjs.org/docs/hooks-reference.html). Given the installed version of React supports hooks you can use a functional component and toggle as follows:
+
+```js
+import { useFeatureToggles } from '@flopflip/react-broadcast';
+
+const ComponentWithFeatureToggles = props => {
+   const [isFirstFeatureEnabled, isV2SignUpEnabled] = useFeatureToggles({
+     'myFeatureToggle': true,
+     'mySignUpVariation': 'signUpV2',
+   });
+
+   return (
+     <h3>{props.title}<h3>
+     <p>
+       The first feature is {isFirstFeatureEnabled ? 'enabled' : 'disabled'}
+     </p>
+     <p>
+       The v2 signup feature is {isV2SignUpEnabled ? 'enabled' : 'disabled'}
+     </p>
+   );
+}
+```
+
 #### `useAdapterStatus(): AdapterStatus`
 
 A forward compatible implementation [React hook](https://reactjs.org/docs/hooks-reference.html). Given the installed version of React supports hooks you can use a functional component and toggle as follows:


### PR DESCRIPTION
#### Summary

Adds a `useFeatureToggles` to `react-broadcast` returning an `boolean[]` when passed `{ [flagName: FlagName]: FlagVariation }`.

An alternative API would have been nested touples in `[ [FlagName, FlagVariation] ]`. This however felt a bit against the existing types where they guided to a hopefully consistent API over all.