### PR TITLE
feat(react-redux): to add support for use-adpater-status

### DIFF
--- a/packages/react-redux/modules/ducks/status/index.ts
+++ b/packages/react-redux/modules/ducks/status/index.ts
@@ -1,2 +1,2 @@
 export { default as statusReducer } from './status';
-export { UPDATE_STATUS, updateStatus } from './status';
+export { UPDATE_STATUS, updateStatus, selectStatus } from './status';

--- a/packages/react-redux/modules/ducks/status/status.spec.js
+++ b/packages/react-redux/modules/ducks/status/status.spec.js
@@ -1,4 +1,5 @@
-import reducer, { UPDATE_STATUS, updateStatus } from './status';
+import { STATE_SLICE } from '../../store/constants';
+import reducer, { UPDATE_STATUS, updateStatus, selectStatus } from './status';
 
 describe('constants', () => {
   it('should contain `UPDATE_STATUS`', () => {
@@ -56,6 +57,33 @@ describe('reducers', () => {
           isReady: payload.status.isReady,
         });
       });
+    });
+  });
+});
+
+describe('selectors', () => {
+  let status;
+  let state;
+
+  beforeEach(() => {
+    status = {
+      isReady: true,
+      isConfigured: false,
+    };
+    state = {
+      [STATE_SLICE]: {
+        status,
+      },
+    };
+  });
+
+  describe('selecting status', () => {
+    it('should return configuration and ready status', () => {
+      expect(selectStatus(state)).toEqual(
+        expect.objectContaining({
+          isReady: true,
+        })
+      );
     });
   });
 });

--- a/packages/react-redux/modules/ducks/status/status.ts
+++ b/packages/react-redux/modules/ducks/status/status.ts
@@ -1,4 +1,6 @@
 import { AdapterStatus } from '@flopflip/types';
+import { State } from '../../types';
+import { STATE_SLICE } from '../../store/constants';
 import { UpdateStatusAction } from './types';
 
 // Actions
@@ -30,3 +32,6 @@ export const updateStatus = (status: AdapterStatus): UpdateStatusAction => ({
   type: UPDATE_STATUS,
   payload: { status },
 });
+// Selectors
+export const selectStatus = (state: State): AdapterStatus =>
+  state[STATE_SLICE].status ?? {};

--- a/packages/react-redux/modules/hooks/index.ts
+++ b/packages/react-redux/modules/hooks/index.ts
@@ -1,3 +1,5 @@
-export { default as useAdapterReconfiguration } from './use-adapter-reconfiguration';
 export { default as useUpdateFlags } from './use-update-flags';
 export { default as useUpdateStatus } from './use-update-status';
+
+export { default as useAdapterReconfiguration } from './use-adapter-reconfiguration';
+export { default as useAdapterStatus } from './use-adapter-status';

--- a/packages/react-redux/modules/hooks/use-adapter-status/index.ts
+++ b/packages/react-redux/modules/hooks/use-adapter-status/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-adapter-status';

--- a/packages/react-redux/modules/hooks/use-adapter-status/use-adapter-status.spec.js
+++ b/packages/react-redux/modules/hooks/use-adapter-status/use-adapter-status.spec.js
@@ -1,11 +1,17 @@
 import React from 'react';
 import { renderWithAdapter } from '@flopflip/test-utils';
-import useAdapterStatus from './';
+import { Provider } from 'react-redux';
+import { createStore } from '../../../test-utils';
+import { STATE_SLICE } from '../../store/constants';
+import useAdapterStatus from './use-adapter-status';
 import Configure from '../../components/configure';
 
-const render = TestComponent =>
+const render = (store, TestComponent) =>
   renderWithAdapter(TestComponent, {
-    components: { ConfigureFlopFlip: Configure },
+    components: {
+      ConfigureFlopFlip: Configure,
+      Wrapper: <Provider store={store} />,
+    },
   });
 
 const TestComponent = () => {
@@ -19,14 +25,18 @@ const TestComponent = () => {
   );
 };
 
+const store = createStore({
+  [STATE_SLICE]: { flags: { disabledFeature: false } },
+});
+
 it('should indicate the adapter not being ready', () => {
-  const { getByText } = render(<TestComponent />);
+  const { getByText } = render(store, <TestComponent />);
 
   expect(getByText('Is ready: No')).toBeInTheDocument();
 });
 
 it('should indicate the adapter being ready', async () => {
-  const { getByText, waitUntilReady } = render(<TestComponent />);
+  const { getByText, waitUntilReady } = render(store, <TestComponent />);
 
   await waitUntilReady();
 
@@ -34,7 +44,7 @@ it('should indicate the adapter being ready', async () => {
 });
 
 it('should indicate the adapter being configured', async () => {
-  const { getByText, waitUntilReady } = render(<TestComponent />);
+  const { getByText, waitUntilReady } = render(store, <TestComponent />);
 
   await waitUntilReady();
 

--- a/packages/react-redux/modules/hooks/use-adapter-status/use-adapter-status.ts
+++ b/packages/react-redux/modules/hooks/use-adapter-status/use-adapter-status.ts
@@ -1,0 +1,13 @@
+import { AdapterStatus as AdapterStatusType } from '@flopflip/types';
+
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { selectStatus } from '../../ducks/status';
+
+export default function useAdapterStatus(): AdapterStatusType {
+  const status = useSelector(selectStatus);
+
+  React.useDebugValue(status);
+
+  return status;
+}

--- a/packages/react-redux/modules/index.ts
+++ b/packages/react-redux/modules/index.ts
@@ -3,6 +3,7 @@ const version = '__@FLOPFLIP/VERSION_OF_RELEASE__';
 export { default as createFlopFlipEnhancer } from './store/enhancer';
 // Import this separately to avoid a circular dependency
 export { STATE_SLICE as FLOPFLIP_STATE_SLICE } from './store/constants';
+
 export {
   createFlopflipReducer,
   flopflipReducer,
@@ -11,6 +12,7 @@ export {
   UPDATE_STATUS,
   UPDATE_FLAGS,
 } from './ducks';
+
 export {
   ToggleFeature,
   injectFeatureToggle,
@@ -19,6 +21,7 @@ export {
   ConfigureFlopFlip,
   ReconfigureFlopFlip,
 } from './components';
-export { useAdapterReconfiguration } from './hooks';
+
+export { useAdapterReconfiguration, useAdapterStatus } from './hooks';
 
 export { version };


### PR DESCRIPTION
#### Summary

Pulls useAdapterStatus into react package to expose it through both redux and broadcast variant.