### PR TITLE
feat(splitio): support custom attributes

### DIFF
--- a/packages/splitio-adapter/modules/adapter/adapter.spec.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.spec.js
@@ -165,6 +165,7 @@ describe('when configuring', () => {
     let onStub;
     let onStatusStateChange;
     let onFlagsStateChange;
+    let treatmentStub = jest.fn(() => flags);
 
     beforeEach(() => {
       onStatusStateChange = jest.fn();
@@ -174,7 +175,7 @@ describe('when configuring', () => {
       factory = {
         client: jest.fn(() => ({
           on: onStub,
-          getTreatments: jest.fn(() => flags),
+          getTreatments: treatmentStub,
           Event: {
             SDK_READY: 'SDK_READY',
             SDK_UPDATE: 'SDK_UPDATE',
@@ -191,6 +192,9 @@ describe('when configuring', () => {
         {
           authorizationKey,
           user: userWithKey,
+          treatmentAttributes: {
+            platform: 'iOS',
+          },
         },
         {
           onStatusStateChange,
@@ -200,6 +204,13 @@ describe('when configuring', () => {
     });
 
     describe('when `splitio` is ready', () => {
+      it('should call getTreatments with attributes', () => {
+        expect(treatmentStub).toHaveBeenCalledWith(names, {
+          ...userWithKey,
+          platform: 'iOS',
+        });
+      });
+
       it('should indicate that the adapter is ready', () => {
         expect(adapter.getIsReady()).toBe(true);
       });
@@ -245,6 +256,7 @@ describe('when configuring', () => {
               SDK_READY: 'SDK_READY',
               SDK_UPDATE: 'SDK_UPDATE',
             },
+            destroy: jest.fn(),
           })),
           manager: jest.fn(() => ({
             names: namesStub,
@@ -258,6 +270,9 @@ describe('when configuring', () => {
             {
               authorizationKey,
               user: userWithKey,
+              treatmentAttributes: {
+                platform: 'iOS',
+              },
             },
             {
               onStatusStateChange,
@@ -274,8 +289,18 @@ describe('when configuring', () => {
               user: nextUser,
               onStatusStateChange,
               onFlagsStateChange,
+              treatmentAttributes: {
+                platform: 'android',
+              },
             });
           });
+      });
+
+      it('should call getTreatments with attributes', () => {
+        expect(getTreatmentsStub).toHaveBeenCalledWith(names, {
+          ...nextUser,
+          platform: 'android',
+        });
       });
     });
   });

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -38,6 +38,10 @@ export type SplitioAdapterArgs = BaseAdapterArgs & {
       [key: string]: string;
     };
   };
+  treatmentAttributes?: {
+    // Matches the signature of SplitIO.Attributes
+    [key: string]: string | number | boolean | Array<string | number>;
+  };
 };
 export type AdapterArgs =
   | LaunchDarklyAdapterArgs


### PR DESCRIPTION
#### Summary

Added the ability to pass custom attributes into splitio `getTreatments` function. Solves #942 

#### Description

Add a new object under `options` that is `treatmentAttributes`. It will key spread into `getTreatments` along side the `key` from user.

#### Technical debt & future

I don't love copying the type into `@flopflip/types` for SplitIO.Attributes.. but I think it is better than `any`. Open to suggestions.

On a side note, I couldn't figure out how to get all the tests to pass locally. Received a lot of errors like:
```
packages/react-redux/modules/hooks/use-flag-variations/use-flag-variations.spec.js
  ● Test suite failed to run

    Cannot find module '@flopflip/react' from 'use-flag-variations.ts'

    However, Jest was able to find:
        './use-flag-variations.spec.js'
        './use-flag-variations.ts'
```

but the splitio adapter test passed :)
