### PR TITLE
feat(launch-darkly): expose launchdarkly client

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -41,6 +41,10 @@ describe('when configuring', () => {
     expect(adapter.getIsReady()).toBe(false);
   });
 
+  it('should not return client', () => {
+    expect(adapter.getClient()).toBe(undefined);
+  });
+
   describe('when reconfiguring before configured', () => {
     it('should reject reconfiguration', () => {
       return expect(adapter.reconfigure({ user: userWithKey })).rejects.toEqual(
@@ -162,6 +166,17 @@ describe('when configuring', () => {
       describe('when determining if adapter is ready', () => {
         it('should indicate that the adapter is ready', () => {
           expect(adapter.getIsReady()).toBe(true);
+        });
+
+        it('should return client', () => {
+          expect(adapter.getClient()).toEqual(
+            expect.objectContaining({
+              allFlags: expect.any(Function),
+              on: expect.any(Function),
+              variation: expect.any(Function),
+              waitForInitialization: expect.any(Function),
+            })
+          );
         });
       });
 

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.ts
@@ -231,6 +231,10 @@ class LaunchDarklyAdapter implements LaunchDarklyAdapterInterface {
     return adapterState.isReady;
   }
 
+  getClient(): LDClient | undefined {
+    return adapterState.client;
+  }
+
   getFlag(flagName: FlagName): FlagVariation | undefined {
     return adapterState.flags[flagName];
   }

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,3 +1,5 @@
+import { LDClient } from 'launchdarkly-js-client-sdk';
+
 export type FlagName = string;
 export type FlagVariation = boolean | string;
 export type Flag = [FlagName, FlagVariation];
@@ -84,6 +86,7 @@ export interface LaunchDarklyAdapterInterface
     adapterEventHandlers: AdapterEventHandlers
   ): Promise<any>;
   getIsReady(): boolean;
+  getClient(): LDClient | undefined;
   getFlag(flagName: FlagName): FlagVariation | undefined;
   updateUserContext(updatedUserProps: User): Promise<any>;
 }


### PR DESCRIPTION
#### Summary

Exposes LaunchDarkly client

#### Description

https://github.com/tdeekens/flopflip/issues/829

This allows us to call LD's `track()` method (as an example).

cc tdeekens

#### Technical debt & future

1. Keeping assumption that FlopFlip will control adapter version for now.
