### PR TITLE
refactor: let TS infer return types if possible, fix props for ToggleFeature

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -4,7 +4,6 @@ parserOptions:
   ecmaFeatures:
     jsx: true
     modules: true
-  project: './tsconfig.json'
 extends:
   - xo
   - xo-typescript

--- a/packages/launchdarkly-adapter/index.ts
+++ b/packages/launchdarkly-adapter/index.ts
@@ -1,0 +1,5 @@
+// This file exists  because we want jest to use our non-compiled code to run tests
+// if this file is missing, and you have a `module` or `main` that points to a non-existing file
+// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
+// all apps should export all their named exports from their root index.js
+export * from './modules';

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.ts
@@ -54,7 +54,7 @@ const normalizeFlag = (
 ];
 const denormalizeFlagName = (flagName: TFlagName) => kebabCase(flagName);
 
-const getIsAnonymousUser = (user: TUser): boolean => !user?.key;
+const getIsAnonymousUser = (user: TUser) => !user?.key;
 
 const ensureUser = (user: TUser) => {
   const isAnonymousUser = getIsAnonymousUser(user);
@@ -70,10 +70,9 @@ const initializeClient = (
   clientSideId: TLaunchDarklyAdapterArgs['clientSideId'],
   user: TUser,
   clientOptions: TLaunchDarklyAdapterArgs['clientOptions']
-): LDClient =>
-  initializeLaunchDarklyClient(clientSideId, user as LDUser, clientOptions);
+) => initializeLaunchDarklyClient(clientSideId, user as LDUser, clientOptions);
 
-const changeUserContext = (nextUser: TUser): Promise<any> =>
+const changeUserContext = (nextUser: TUser) =>
   adapterState.client && adapterState.client.identify
     ? adapterState.client.identify(nextUser as LDUser)
     : Promise.reject(
@@ -81,7 +80,7 @@ const changeUserContext = (nextUser: TUser): Promise<any> =>
       );
 
 // NOTE: Exported for testing only
-export const normalizeFlags = (rawFlags: TFlags): TFlags =>
+export const normalizeFlags = (rawFlags: TFlags) =>
   Object.entries(rawFlags).reduce<TFlags>(
     (normalizedFlags: TFlags, [flagName, flagValue]) => {
       const [normalizedFlagName, normalizedFlagValue]: TFlag = normalizeFlag(
@@ -171,7 +170,7 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
   configure(
     adapterArgs: TLaunchDarklyAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any> {
+  ) {
     const {
       clientSideId,
       user,
@@ -213,7 +212,7 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
   reconfigure(
     adapterArgs: TLaunchDarklyAdapterArgs,
     _adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any> {
+  ) {
     if (!adapterState.isConfigured)
       return Promise.reject(
         new Error(
@@ -230,19 +229,19 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
     return Promise.resolve();
   }
 
-  getIsReady(): boolean {
+  getIsReady() {
     return adapterState.isReady;
   }
 
-  getClient(): LDClient | undefined {
+  getClient() {
     return adapterState.client;
   }
 
-  getFlag(flagName: TFlagName): TFlagVariation | undefined {
+  getFlag(flagName: TFlagName) {
     return adapterState.flags[flagName];
   }
 
-  updateUserContext(updatedUserProps: TUser): Promise<any> {
+  updateUserContext(updatedUserProps: TUser) {
     const isAdapterReady = adapterState.isConfigured && adapterState.isReady;
 
     warning(
@@ -275,7 +274,7 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
       flagsUpdateDelayMs?: number;
     },
     adapterEventHandlers: TAdapterEventHandlers
-  ): void {
+  ) {
     for (const flagName in flagsFromSdk) {
       // Dispatch whenever a configured flag value changes
       if (

--- a/packages/localstorage-adapter/index.ts
+++ b/packages/localstorage-adapter/index.ts
@@ -1,0 +1,5 @@
+// This file exists  because we want jest to use our non-compiled code to run tests
+// if this file is missing, and you have a `module` or `main` that points to a non-existing file
+// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
+// all apps should export all their named exports from their root index.js
+export * from './modules';

--- a/packages/localstorage-adapter/modules/adapter/adapter.ts
+++ b/packages/localstorage-adapter/modules/adapter/adapter.ts
@@ -49,7 +49,7 @@ const normalizeFlag = (
   // Multi variate flags contain a string or `null` - `false` seems more natural.
   flagValue === null || flagValue === undefined ? false : flagValue,
 ];
-export const normalizeFlags = (rawFlags: TFlags): TFlags => {
+export const normalizeFlags = (rawFlags: TFlags) => {
   if (!rawFlags) return {};
 
   return Object.entries(rawFlags).reduce<TFlags>(
@@ -84,7 +84,7 @@ const storage: Storage = {
   },
   unset: key => localStorage.removeItem(`${STORAGE_SLICE}__${key}`),
 };
-export const updateFlags = (flags: TFlags): void => {
+export const updateFlags = (flags: TFlags) => {
   const isAdapterReady = Boolean(
     adapterState.isConfigured && adapterState.isReady
   );
@@ -111,7 +111,7 @@ const subscribeToFlagsChanges = ({
   pollingInteral = 1000 * 60,
 }: {
   pollingInteral?: number;
-}): void => {
+}) => {
   setInterval(() => {
     adapterState.emitter.emit(
       'flagsStateChange',
@@ -130,7 +130,7 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
   configure(
     adapterArgs: TLocalStorageAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any> {
+  ) {
     const { user, adapterConfiguration } = adapterArgs;
 
     adapterState.user = user;
@@ -167,7 +167,7 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
   reconfigure(
     adapterArgs: TLocalStorageAdapterArgs,
     _adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any> {
+  ) {
     storage.unset('flags');
     const nextUser = adapterArgs.user;
     adapterState.user = nextUser;
@@ -175,14 +175,14 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
     return Promise.resolve();
   }
 
-  waitUntilConfigured(): Promise<any> {
+  waitUntilConfigured() {
     return new Promise(resolve => {
       if (adapterState.isConfigured) resolve();
       else adapterState.emitter.on('readyStateChange', resolve);
     });
   }
 
-  getIsReady(): boolean {
+  getIsReady() {
     return Boolean(adapterState.isReady);
   }
 }

--- a/packages/memory-adapter/index.ts
+++ b/packages/memory-adapter/index.ts
@@ -1,0 +1,5 @@
+// This file exists  because we want jest to use our non-compiled code to run tests
+// if this file is missing, and you have a `module` or `main` that points to a non-existing file
+// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
+// all apps should export all their named exports from their root index.js
+export * from './modules';

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -33,7 +33,7 @@ const intialAdapterState: TAdapterStatus & MemoryAdapterState = {
 let adapterState: TAdapterStatus & MemoryAdapterState = {
   ...intialAdapterState,
 };
-const updateUser = (user: TUser): void => {
+const updateUser = (user: TUser) => {
   adapterState.user = user;
 };
 
@@ -45,7 +45,7 @@ const normalizeFlag = (
   // Multi variate flags contain a string or `null` - `false` seems more natural.
   flagValue === null || flagValue === undefined ? false : flagValue,
 ];
-export const normalizeFlags = (rawFlags: TFlags): TFlags =>
+export const normalizeFlags = (rawFlags: TFlags) =>
   Object.entries(rawFlags).reduce<TFlags>(
     (normalizedFlags: TFlags, [flagName, flagValue]) => {
       const [normalizedFlagName, normalizedFlagValue]: TFlag = normalizeFlag(
@@ -60,7 +60,7 @@ export const normalizeFlags = (rawFlags: TFlags): TFlags =>
     {}
   );
 
-export const getUser = (): TUser | undefined => adapterState.user;
+export const getUser = () => adapterState.user;
 
 export const updateFlags = (flags: TFlags) => {
   const isAdapterReady = Boolean(
@@ -92,7 +92,7 @@ class MemoryAdapter implements TMemoryAdapterInterface {
   configure(
     adapterArgs: TMemoryAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any> {
+  ) {
     const { user } = adapterArgs;
 
     adapterState.user = user;
@@ -126,7 +126,7 @@ class MemoryAdapter implements TMemoryAdapterInterface {
   reconfigure(
     adapterArgs: TMemoryAdapterArgs,
     _adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any> {
+  ) {
     updateUser(adapterArgs.user);
 
     adapterState.flags = {};
@@ -138,11 +138,11 @@ class MemoryAdapter implements TMemoryAdapterInterface {
     return Promise.resolve();
   }
 
-  getIsReady(): boolean {
+  getIsReady() {
     return Boolean(adapterState.isReady);
   }
 
-  setIsReady(nextState: TAdapterStatus): void {
+  setIsReady(nextState: TAdapterStatus) {
     adapterState.isReady = nextState.isReady;
 
     adapterState.emitter.emit('statusStateChange', {
@@ -150,25 +150,25 @@ class MemoryAdapter implements TMemoryAdapterInterface {
     });
   }
 
-  reset = (): void => {
+  reset = () => {
     adapterState = {
       ...intialAdapterState,
     };
   };
 
-  waitUntilConfigured(): Promise<any> {
+  waitUntilConfigured() {
     return new Promise(resolve => {
       if (adapterState.isConfigured) resolve();
       else adapterState.emitter.on('readyStateChange', resolve);
     });
   }
 
-  getFlag(flagName: TFlagName): TFlagVariation | undefined {
+  getFlag(flagName: TFlagName) {
     return adapterState.flags && adapterState.flags[flagName];
   }
 
   // For convenience
-  updateFlags(flags: TFlags): void {
+  updateFlags(flags: TFlags) {
     return updateFlags(flags);
   }
 }

--- a/packages/react-broadcast/index.ts
+++ b/packages/react-broadcast/index.ts
@@ -1,0 +1,5 @@
+// This file exists  because we want jest to use our non-compiled code to run tests
+// if this file is missing, and you have a `module` or `main` that points to a non-existing file
+// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
+// all apps should export all their named exports from their root index.js
+export * from './modules';

--- a/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
+++ b/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
@@ -3,22 +3,22 @@ import { TFlagName, TFlagVariation } from '@flopflip/types';
 import React from 'react';
 import { useFeatureToggle } from '../../hooks';
 
-export default <OwnProps extends object>(
+export default function branchOnFeatureToggle<OwnProps extends object>(
   {
     flag: flagName,
     variation: flagVariation,
   }: { flag: TFlagName; variation?: TFlagVariation },
   UntoggledComponent?: React.ComponentType
-) => (
-  ToggledComponent: React.ComponentType<OwnProps>
-): React.ComponentType<OwnProps> => {
-  const WrappedToggledComponent = (ownProps: OwnProps) => {
-    const isFeatureEnabled = useFeatureToggle(flagName, flagVariation);
+) {
+  return (ToggledComponent: React.ComponentType<OwnProps>) => {
+    const WrappedToggledComponent = (ownProps: OwnProps) => {
+      const isFeatureEnabled = useFeatureToggle(flagName, flagVariation);
 
-    if (isFeatureEnabled) return <ToggledComponent {...ownProps} />;
-    if (UntoggledComponent) return <UntoggledComponent {...ownProps} />;
-    return null;
+      if (isFeatureEnabled) return <ToggledComponent {...ownProps} />;
+      if (UntoggledComponent) return <UntoggledComponent {...ownProps} />;
+      return null;
+    };
+
+    return WrappedToggledComponent;
   };
-
-  return WrappedToggledComponent;
-};
+}

--- a/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.tsx
+++ b/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.tsx
@@ -11,23 +11,25 @@ type InjectedProps = {
   [propKey: string]: TFlagVariation;
 };
 
-export default <OwnProps extends object>(
+export default function injectFeatureToggle<OwnProps extends object>(
   flagName: TFlagName,
   propKey: string = DEFAULT_FLAG_PROP_KEY
-) => (
-  Component: React.ComponentType<any>
-): React.ComponentType<OwnProps & InjectedProps> => {
-  const WrappedComponent = (ownProps: OwnProps) => {
-    const [flagVariation] = useFlagVariations([flagName]);
-    const props = {
-      ...ownProps,
-      [propKey]: flagVariation,
+) {
+  return (
+    Component: React.ComponentType<any>
+  ): React.ComponentType<OwnProps & InjectedProps> => {
+    const WrappedComponent = (ownProps: OwnProps) => {
+      const [flagVariation] = useFlagVariations([flagName]);
+      const props = {
+        ...ownProps,
+        [propKey]: flagVariation,
+      };
+
+      return <Component {...props} />;
     };
 
-    return <Component {...props} />;
+    setDisplayName(wrapDisplayName(Component, 'injectFeatureToggle'));
+
+    return WrappedComponent;
   };
-
-  setDisplayName(wrapDisplayName(Component, 'injectFeatureToggle'));
-
-  return WrappedComponent;
-};
+}

--- a/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.tsx
+++ b/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.tsx
@@ -11,29 +11,31 @@ type InjectedProps = {
   [propKey: string]: TFlags;
 };
 
-export default <OwnProps extends object>(
+export default function injectFeatureToggles<OwnProps extends object>(
   flagNames: TFlagName[],
   propKey: string = DEFAULT_FLAGS_PROP_KEY
-) => (
-  Component: React.ComponentType
-): React.ComponentType<OwnProps & InjectedProps> => {
-  const WrappedComponent = (ownProps: OwnProps) => {
-    const flagVariations = useFlagVariations(flagNames);
-    const flags = Object.fromEntries(
-      flagNames.map((flagName, indexOfFlagName) => [
-        flagName,
-        flagVariations[indexOfFlagName],
-      ])
-    );
-    const props = {
-      ...ownProps,
-      [propKey]: flags,
+) {
+  return (
+    Component: React.ComponentType
+  ): React.ComponentType<OwnProps & InjectedProps> => {
+    const WrappedComponent = (ownProps: OwnProps) => {
+      const flagVariations = useFlagVariations(flagNames);
+      const flags = Object.fromEntries(
+        flagNames.map((flagName, indexOfFlagName) => [
+          flagName,
+          flagVariations[indexOfFlagName],
+        ])
+      );
+      const props = {
+        ...ownProps,
+        [propKey]: flags,
+      };
+
+      return <Component {...props} />;
     };
 
-    return <Component {...props} />;
+    setDisplayName(wrapDisplayName(Component, 'injectFeatureToggles'));
+
+    return WrappedComponent;
   };
-
-  setDisplayName(wrapDisplayName(Component, 'injectFeatureToggles'));
-
-  return WrappedComponent;
-};
+}

--- a/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.tsx
+++ b/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.tsx
@@ -1,20 +1,19 @@
 import { TFlagName, TFlagVariation } from '@flopflip/types';
 
 import React from 'react';
-import { ToggleFeature as SharedToggleFeature } from '@flopflip/react';
+import {
+  ToggleFeature as SharedToggleFeature,
+  TToggleFeatureProps,
+} from '@flopflip/react';
 import { useFeatureToggle } from '../../hooks/';
 
 type Props = {
   flag: TFlagName;
   variation: TFlagVariation;
-};
+} & Exclude<TToggleFeatureProps, 'isFeatureEnabled'>;
 
-const ToggleFeature = <OwnProps extends Props>(
-  props: OwnProps
-): React.ReactNode => {
+const ToggleFeature = <OwnProps extends Props>(props: OwnProps) => {
   const isFeatureEnabled = useFeatureToggle(props.flag, props.variation);
-
-  // @ts-ignore
   return <SharedToggleFeature {...props} isFeatureEnabled={isFeatureEnabled} />;
 };
 

--- a/packages/react-broadcast/modules/hooks/use-adapter-status/use-adapter-status.ts
+++ b/packages/react-broadcast/modules/hooks/use-adapter-status/use-adapter-status.ts
@@ -1,8 +1,8 @@
 import React from 'react';
 import { AdapterContext } from '@flopflip/react';
-import { TAdapterContext, TAdapterStatus } from '@flopflip/types';
+import { TAdapterContext } from '@flopflip/types';
 
-export default function useAdapterStatus(): TAdapterStatus {
+export default function useAdapterStatus() {
   const adapterContext: TAdapterContext = React.useContext(AdapterContext);
 
   React.useDebugValue(adapterContext.status);

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.ts
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.ts
@@ -6,7 +6,7 @@ import { FlagsContext } from '../../components/flags-context';
 export default function useFeatureToggle(
   flagName: TFlagName,
   flagVariation: TFlagVariation = true
-): boolean {
+) {
   const flags: TFlags = React.useContext(FlagsContext);
   const isFeatureEnabled: boolean = getIsFeatureEnabled(
     flagName,

--- a/packages/react-broadcast/modules/hooks/use-feature-toggles/use-feature-toggles.ts
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggles/use-feature-toggles.ts
@@ -3,7 +3,7 @@ import { getIsFeatureEnabled } from '@flopflip/react';
 import { TFlagName, TFlags, TFlagVariation } from '@flopflip/types';
 import { FlagsContext } from '../../components/flags-context';
 
-export default function useFeatureToggles(flags: TFlags): boolean[] {
+export default function useFeatureToggles(flags: TFlags) {
   const allFlags: TFlags = React.useContext(FlagsContext);
 
   const requestedFlags: boolean[] = Object.entries(flags).reduce<boolean[]>(

--- a/packages/react-broadcast/modules/hooks/use-flag-variations/use-flag-variations.ts
+++ b/packages/react-broadcast/modules/hooks/use-flag-variations/use-flag-variations.ts
@@ -3,9 +3,7 @@ import { getFlagVariation } from '@flopflip/react';
 import { TFlagName, TFlags, TFlagVariation } from '@flopflip/types';
 import { FlagsContext } from '../../components/flags-context';
 
-export default function useFlagVariations(
-  flagNames: TFlagName[]
-): TFlagVariation[] {
+export default function useFlagVariations(flagNames: TFlagName[]) {
   const allFlags: TFlags = React.useContext(FlagsContext);
 
   const flagVariations: TFlagVariation[] = flagNames.map(requestedVariation =>

--- a/packages/react-redux/index.ts
+++ b/packages/react-redux/index.ts
@@ -1,0 +1,5 @@
+// This file exists  because we want jest to use our non-compiled code to run tests
+// if this file is missing, and you have a `module` or `main` that points to a non-existing file
+// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
+// all apps should export all their named exports from their root index.js
+export * from './modules';

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
@@ -3,22 +3,22 @@ import { TFlagName, TFlagVariation } from '@flopflip/types';
 import React from 'react';
 import { useFeatureToggle } from '../../hooks';
 
-export default <OwnProps extends object>(
+export default function branchOnFeatureToggle<OwnProps extends object>(
   {
     flag: flagName,
     variation: flagVariation,
   }: { flag: TFlagName; variation?: TFlagVariation },
   UntoggledComponent?: React.ComponentType
-) => (
-  ToggledComponent: React.ComponentType<OwnProps>
-): React.ComponentType<OwnProps> => {
-  const WrappedToggledComponent = (ownProps: OwnProps) => {
-    const isFeatureEnabled = useFeatureToggle(flagName, flagVariation);
+) {
+  return (ToggledComponent: React.ComponentType<OwnProps>) => {
+    const WrappedToggledComponent = (ownProps: OwnProps) => {
+      const isFeatureEnabled = useFeatureToggle(flagName, flagVariation);
 
-    if (isFeatureEnabled) return <ToggledComponent {...ownProps} />;
-    if (UntoggledComponent) return <UntoggledComponent {...ownProps} />;
-    return null;
+      if (isFeatureEnabled) return <ToggledComponent {...ownProps} />;
+      if (UntoggledComponent) return <UntoggledComponent {...ownProps} />;
+      return null;
+    };
+
+    return WrappedToggledComponent;
   };
-
-  return WrappedToggledComponent;
-};
+}

--- a/packages/react-redux/modules/components/toggle-feature/toggle-feature.tsx
+++ b/packages/react-redux/modules/components/toggle-feature/toggle-feature.tsx
@@ -1,20 +1,19 @@
 import { TFlagName, TFlagVariation } from '@flopflip/types';
 
 import React from 'react';
-import { ToggleFeature as SharedToggleFeature } from '@flopflip/react';
+import {
+  ToggleFeature as SharedToggleFeature,
+  TToggleFeatureProps,
+} from '@flopflip/react';
 import { useFeatureToggle } from '../../hooks/';
 
 type Props = {
   flag: TFlagName;
   variation: TFlagVariation;
-};
+} & Exclude<TToggleFeatureProps, 'isFeatureEnabled'>;
 
-const ToggleFeature = <OwnProps extends Props>(
-  props: OwnProps
-): React.ReactNode => {
+const ToggleFeature = <OwnProps extends Props>(props: OwnProps) => {
   const isFeatureEnabled = useFeatureToggle(props.flag, props.variation);
-
-  // @ts-ignore
   return <SharedToggleFeature {...props} isFeatureEnabled={isFeatureEnabled} />;
 };
 

--- a/packages/react-redux/modules/ducks/flags/flags.ts
+++ b/packages/react-redux/modules/ducks/flags/flags.ts
@@ -41,8 +41,7 @@ export const updateFlags = (flags: TFlags): TUpdateFlagsAction => ({
 });
 
 // Selectors
-export const selectFlags = (state: TState): TFlags =>
-  state[STATE_SLICE].flags ?? {};
+export const selectFlags = (state: TState) => state[STATE_SLICE].flags ?? {};
 export const selectFlag = (
   flagName: TFlagName
 ): ((state: TState) => TFlagVariation) => state => {

--- a/packages/react-redux/modules/ducks/index.ts
+++ b/packages/react-redux/modules/ducks/index.ts
@@ -1,4 +1,3 @@
-import { Reducer } from 'redux';
 import { combineReducers } from 'redux';
 import { TFlags } from '@flopflip/types';
 import { TUpdateFlagsAction } from './flags/types';
@@ -15,9 +14,7 @@ export const flopflipReducer = combineReducers<any, Actions>({
   flags: flagsReducer,
   status: statusReducer,
 });
-export const createFlopflipReducer = (
-  preloadedState: TFlags = {}
-): Reducer<any, Actions> =>
+export const createFlopflipReducer = (preloadedState: TFlags = {}) =>
   combineReducers<any, Actions>({
     flags: createFlagsReducer(preloadedState),
     status: statusReducer,

--- a/packages/react-redux/modules/ducks/status/status.ts
+++ b/packages/react-redux/modules/ducks/status/status.ts
@@ -33,5 +33,4 @@ export const updateStatus = (status: TAdapterStatus): TUpdateStatusAction => ({
   payload: { status },
 });
 // Selectors
-export const selectStatus = (state: TState): TAdapterStatus =>
-  state[STATE_SLICE].status ?? {};
+export const selectStatus = (state: TState) => state[STATE_SLICE].status ?? {};

--- a/packages/react-redux/modules/hooks/use-adapter-status/use-adapter-status.ts
+++ b/packages/react-redux/modules/hooks/use-adapter-status/use-adapter-status.ts
@@ -1,10 +1,8 @@
-import { TAdapterStatus } from '@flopflip/types';
-
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { selectStatus } from '../../ducks/status';
 
-export default function useAdapterStatus(): TAdapterStatus {
+export default function useAdapterStatus() {
   const status = useSelector(selectStatus);
 
   React.useDebugValue(status);

--- a/packages/react-redux/modules/hooks/use-feature-toggle/use-feature-toggle.ts
+++ b/packages/react-redux/modules/hooks/use-feature-toggle/use-feature-toggle.ts
@@ -8,7 +8,7 @@ import { selectFlags } from '../../ducks/flags';
 export default function useFeatureToggle(
   flagName: TFlagName,
   flagVariation: TFlagVariation = true
-): boolean {
+) {
   const flags = useSelector(selectFlags);
   const isFeatureEnabled: boolean = getIsFeatureEnabled(
     flagName,

--- a/packages/react-redux/modules/hooks/use-feature-toggles/use-feature-toggles.ts
+++ b/packages/react-redux/modules/hooks/use-feature-toggles/use-feature-toggles.ts
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { getIsFeatureEnabled } from '@flopflip/react';
 import { selectFlags } from '../../ducks/flags';
 
-export default function useFeatureToggles(flags: TFlags): boolean[] {
+export default function useFeatureToggles(flags: TFlags) {
   const allFlags = useSelector(selectFlags);
 
   const requestedFlags: boolean[] = Object.entries(flags).reduce<boolean[]>(

--- a/packages/react-redux/modules/hooks/use-flag-variations/use-flag-variations.ts
+++ b/packages/react-redux/modules/hooks/use-flag-variations/use-flag-variations.ts
@@ -4,9 +4,7 @@ import { getFlagVariation } from '@flopflip/react';
 import { useSelector } from 'react-redux';
 import { selectFlags } from '../../ducks/flags';
 
-export default function useFlagVariations(
-  flagNames: TFlagName[]
-): TFlagVariation[] {
+export default function useFlagVariations(flagNames: TFlagName[]) {
   const allFlags = useSelector(selectFlags);
 
   const flagVariations: TFlagVariation[] = flagNames.map(requestedVariation =>

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -1,0 +1,5 @@
+// This file exists  because we want jest to use our non-compiled code to run tests
+// if this file is missing, and you have a `module` or `main` that points to a non-existing file
+// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
+// all apps should export all their named exports from their root index.js
+export * from './modules';

--- a/packages/react/modules/components/adapter-context/adapter-context.ts
+++ b/packages/react/modules/components/adapter-context/adapter-context.ts
@@ -5,7 +5,7 @@ import {
   TReconfigureAdapter,
 } from '@flopflip/types';
 
-const initialReconfigureAdapter: TReconfigureAdapter = (): void => undefined;
+const initialReconfigureAdapter: TReconfigureAdapter = () => undefined;
 const initialAdapterStatus: TAdapterStatus = {
   isReady: false,
   isConfigured: false,

--- a/packages/react/modules/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.tsx
@@ -64,11 +64,11 @@ export default class ConfigureAdapter extends React.PureComponent<
     appliedAdapterArgs: this.props.adapterArgs,
   };
 
-  setAdapterState = (nextAdapterState: AdapterState): void => {
+  setAdapterState = (nextAdapterState: AdapterState) => {
     this.adapterState = nextAdapterState;
   };
 
-  applyAdapterArgs = (nextAdapterArgs: TAdapterArgs): void =>
+  applyAdapterArgs = (nextAdapterArgs: TAdapterArgs) =>
     /**
      * NOTE:
      *   We can only unset `pendingAdapterArgs` after be actually perform
@@ -101,7 +101,7 @@ export default class ConfigureAdapter extends React.PureComponent<
   reconfigureOrQueue = (
     nextAdapterArgs: TAdapterArgs,
     options: TAdapterReconfigurationOptions
-  ): void =>
+  ) =>
     this.getIsAdapterConfigured()
       ? this.applyAdapterArgs(
           mergeAdapterArgs(this.state.appliedAdapterArgs, {
@@ -111,9 +111,7 @@ export default class ConfigureAdapter extends React.PureComponent<
         )
       : this.setPendingAdapterArgs({ adapterArgs: nextAdapterArgs, options });
 
-  setPendingAdapterArgs = (
-    nextReconfiguration: TAdapterReconfiguration
-  ): void => {
+  setPendingAdapterArgs = (nextReconfiguration: TAdapterReconfiguration) => {
     /**
      * NOTE:
      *    The next reconfiguration is merged into the previous
@@ -142,7 +140,7 @@ export default class ConfigureAdapter extends React.PureComponent<
   getAdapterArgsForConfiguration = (): TAdapterArgs =>
     this.pendingAdapterArgs ?? this.state.appliedAdapterArgs;
 
-  handleDefaultFlags = (defaultFlags: TFlags): void => {
+  handleDefaultFlags = (defaultFlags: TFlags) => {
     if (Object.keys(defaultFlags).length > 0) {
       this.props.onFlagsStateChange(defaultFlags);
     }
@@ -158,7 +156,7 @@ export default class ConfigureAdapter extends React.PureComponent<
    *   may trigger a `setState` it might have unexpected side-effects (setState-loop).
    *   Maybe some more substancial refactor would be needed.
    */
-  UNSAFE_componentWillReceiveProps(nextProps: Props): void {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (nextProps.adapterArgs !== this.props.adapterArgs) {
       /**
        * NOTE:
@@ -177,14 +175,14 @@ export default class ConfigureAdapter extends React.PureComponent<
     }
   }
 
-  componentDidMount(): Promise<any> | void {
+  componentDidMount() {
     if (this.props.defaultFlags)
       this.handleDefaultFlags(this.props.defaultFlags);
 
     if (!this.props.shouldDeferAdapterConfiguration) {
       this.setAdapterState(AdapterStates.CONFIGURING);
 
-      return (this.props.adapter as TAdapterInterface<TAdapterArgs>)
+      (this.props.adapter as TAdapterInterface<TAdapterArgs>)
         .configure(this.getAdapterArgsForConfiguration(), {
           onFlagsStateChange: this.props.onFlagsStateChange,
           onStatusStateChange: this.props.onStatusStateChange,
@@ -198,7 +196,7 @@ export default class ConfigureAdapter extends React.PureComponent<
     }
   }
 
-  componentDidUpdate(): Promise<any> | void {
+  componentDidUpdate() {
     /**
      * NOTE:
      *    Be careful here to not double configure from `componentDidMount`.
@@ -212,7 +210,7 @@ export default class ConfigureAdapter extends React.PureComponent<
     ) {
       this.setAdapterState(AdapterStates.CONFIGURING);
 
-      return (this.props.adapter as TAdapterInterface<TAdapterArgs>)
+      (this.props.adapter as TAdapterInterface<TAdapterArgs>)
         .configure(this.getAdapterArgsForConfiguration(), {
           onFlagsStateChange: this.props.onFlagsStateChange,
           onStatusStateChange: this.props.onStatusStateChange,
@@ -224,12 +222,13 @@ export default class ConfigureAdapter extends React.PureComponent<
             this.applyAdapterArgs(this.pendingAdapterArgs);
           }
         });
+      return;
     }
 
     if (this.getIsAdapterConfigured()) {
       this.setAdapterState(AdapterStates.CONFIGURING);
 
-      return (this.props.adapter as TAdapterInterface<TAdapterArgs>)
+      (this.props.adapter as TAdapterInterface<TAdapterArgs>)
         .reconfigure(this.getAdapterArgsForConfiguration(), {
           onFlagsStateChange: this.props.onFlagsStateChange,
           onStatusStateChange: this.props.onStatusStateChange,
@@ -240,7 +239,7 @@ export default class ConfigureAdapter extends React.PureComponent<
     }
   }
 
-  render(): React.ReactNode {
+  render() {
     return (
       <AdapterContext.Provider
         value={createAdapterContext(

--- a/packages/react/modules/components/configure-adapter/helpers.ts
+++ b/packages/react/modules/components/configure-adapter/helpers.ts
@@ -12,7 +12,7 @@ const isFunctionChildren = (
 ): children is TConfigureAdapterChildrenAsFunction =>
   typeof children === 'function';
 
-const isEmptyChildren = (children: TConfigureAdapterChildren): boolean =>
+const isEmptyChildren = (children: TConfigureAdapterChildren) =>
   !isFunctionChildren(children) && React.Children.count(children) === 0;
 
 const mergeAdapterArgs = (

--- a/packages/react/modules/components/toggle-feature/index.ts
+++ b/packages/react/modules/components/toggle-feature/index.ts
@@ -1,1 +1,5 @@
+import { Props } from './toggle-feature';
+
+export type TProps = Props;
+
 export { default } from './toggle-feature';

--- a/packages/react/modules/components/toggle-feature/toggle-feature.ts
+++ b/packages/react/modules/components/toggle-feature/toggle-feature.ts
@@ -2,20 +2,19 @@ import React from 'react';
 import warning from 'tiny-warning';
 import { isValidElementType } from 'react-is';
 
-type Props = {
+type RenderFnArgs = {
+  isFeatureEnabled: boolean;
+};
+type RenderFn = (args: RenderFnArgs) => React.ReactNode;
+export type Props = {
   untoggledComponent?: React.ComponentType;
   toggledComponent?: React.ComponentType;
   render?: () => React.ReactNode;
-  children?:
-    | (({ isFeatureEnabled: boolean }) => React.ReactNode)
-    | React.ReactNode;
+  children?: RenderFn | React.ReactNode;
   isFeatureEnabled: boolean;
 };
 
-const isEmptyChildren = (children: React.ReactNode): boolean =>
-  React.Children.count(children) === 0;
-
-const ToggleFeature = (props: Props): React.ReactNode => {
+const ToggleFeature = (props: Props) => {
   if (props.untoggledComponent)
     warning(
       isValidElementType(props.untoggledComponent),
@@ -32,8 +31,13 @@ const ToggleFeature = (props: Props): React.ReactNode => {
     if (props.toggledComponent)
       return React.createElement(props.toggledComponent);
 
-    if (props.children && !isEmptyChildren(props.children))
-      return React.Children.only(props.children);
+    if (props.children) {
+      if (typeof props.children === 'function')
+        return props.children({
+          isFeatureEnabled: props.isFeatureEnabled,
+        });
+      return React.Children.only<React.ReactNode>(props.children);
+    }
 
     if (typeof props.render === 'function') return props.render();
   }

--- a/packages/react/modules/helpers/is-nil/is-nil.ts
+++ b/packages/react/modules/helpers/is-nil/is-nil.ts
@@ -1,3 +1,3 @@
-const isNil = (value: any): boolean => value === undefined || value === null;
+const isNil = (value: any) => value === undefined || value === null;
 
 export default isNil;

--- a/packages/react/modules/hocs/wrap-display-name/wrap-display-name.ts
+++ b/packages/react/modules/hocs/wrap-display-name/wrap-display-name.ts
@@ -1,10 +1,10 @@
 import React from 'react';
 
-export default (
+export default function wrapDisplayName(
   BaseComponent: React.ComponentType<any>,
   hocName: string
-): string => {
+) {
   const previousDisplayName = BaseComponent.displayName ?? BaseComponent.name;
 
   return `${hocName}(${previousDisplayName ?? 'Component'})`;
-};
+}

--- a/packages/react/modules/hooks/use-adapter-reconfiguration/use-adapter-reconfiguration.ts
+++ b/packages/react/modules/hooks/use-adapter-reconfiguration/use-adapter-reconfiguration.ts
@@ -1,8 +1,8 @@
 import React from 'react';
 import { AdapterContext } from '@flopflip/react';
-import { TAdapterContext, TReconfigureAdapter } from '@flopflip/types';
+import { TAdapterContext } from '@flopflip/types';
 
-export default function useAdapterReconfiguration(): TReconfigureAdapter {
+export default function useAdapterReconfiguration() {
   const adapterContext: TAdapterContext = React.useContext(AdapterContext);
 
   return adapterContext.reconfigure;

--- a/packages/react/modules/index.ts
+++ b/packages/react/modules/index.ts
@@ -1,3 +1,7 @@
+import { TProps as ToggleFeatureProps } from './components/toggle-feature';
+
+export type TToggleFeatureProps = ToggleFeatureProps;
+
 const version = '__@FLOPFLIP/VERSION_OF_RELEASE__';
 
 export {

--- a/packages/splitio-adapter/index.ts
+++ b/packages/splitio-adapter/index.ts
@@ -1,0 +1,5 @@
+// This file exists  because we want jest to use our non-compiled code to run tests
+// if this file is missing, and you have a `module` or `main` that points to a non-existing file
+// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
+// all apps should export all their named exports from their root index.js
+export * from './modules';

--- a/packages/splitio-adapter/modules/adapter/adapter.ts
+++ b/packages/splitio-adapter/modules/adapter/adapter.ts
@@ -62,7 +62,7 @@ export const normalizeFlag = (
   return [camelCase(flagName), normalizeFlagValue];
 };
 
-export const normalizeFlags = (flags: TFlags): TFlags =>
+export const normalizeFlags = (flags: TFlags) =>
   Object.entries(flags).reduce<TFlags>(
     (normalizedFlags: TFlags, [flagName, flaValue]) => {
       const [normalizedFlagName, normalizedFlagValue]: TFlag = normalizeFlag(
@@ -83,7 +83,7 @@ const subscribeToFlagsChanges = ({
 }: {
   flagNames: TFlagName[];
   onFlagsStateChange: TOnFlagsStateChangeCallback;
-}): void => {
+}) => {
   if (adapterState.client) {
     adapterState.client.on(adapterState.client.Event.SDK_UPDATE, () => {
       if (adapterState.client) {
@@ -98,7 +98,7 @@ const subscribeToFlagsChanges = ({
   }
 };
 
-export const createAnonymousUserKey = (): string =>
+export const createAnonymousUserKey = () =>
   Math.random()
     .toString(36)
     .substring(2);
@@ -106,10 +106,11 @@ export const createAnonymousUserKey = (): string =>
 const ensureUser = (user: TUser): TUser =>
   merge(user, { key: user?.key ?? createAnonymousUserKey() });
 
-const initializeClient = (): {
+type SplitIOClient = {
   client: SplitIO.IClient;
   manager: SplitIO.IManager;
-} => {
+};
+const initializeClient = (): SplitIOClient => {
   if (!adapterState.splitioSettings) {
     throw Error(
       'cannot initialize SplitIo without configured settings, call configure() first'
@@ -130,8 +131,8 @@ const subscribe = ({
 }: {
   onFlagsStateChange: TOnFlagsStateChangeCallback;
   onStatusStateChange: TOnStatusStateChangeCallback;
-}): Promise<any> =>
-  new Promise((resolve, reject) => {
+}) =>
+  new Promise<void>((resolve, reject) => {
     if (adapterState.client) {
       adapterState.client.on(adapterState.client.Event.SDK_READY, () => {
         let flagNames: TFlagName[];
@@ -186,7 +187,7 @@ class SplitioAdapter implements TSplitioAdapterInterface {
   configure(
     adapterArgs: TSplitioAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any> {
+  ) {
     const {
       authorizationKey,
       user,
@@ -215,7 +216,7 @@ class SplitioAdapter implements TSplitioAdapterInterface {
   reconfigure(
     adapterArgs: TSplitioAdapterArgs,
     _adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any> {
+  ) {
     if (
       !adapterState.isReady ||
       !adapterState.isConfigured ||
@@ -255,7 +256,7 @@ class SplitioAdapter implements TSplitioAdapterInterface {
     return Promise.resolve();
   }
 
-  getIsReady(): boolean {
+  getIsReady() {
     return Boolean(adapterState.isReady);
   }
 }

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -63,14 +63,14 @@ export interface TAdapterInterface<Args extends TAdapterArgs> {
   configure(
     adapterArgs: Args,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any>;
+  ): Promise<unknown>;
   reconfigure(
     adapterArgs: Args,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any>;
+  ): Promise<unknown>;
   getIsReady(): boolean;
   setIsReady?(nextStatus: TAdapterStatus): void;
-  waitUntilConfigured?(): Promise<any>;
+  waitUntilConfigured?(): Promise<unknown>;
   reset?(): void;
   getFlag?(flagName: TFlagName): TFlagVariation | undefined;
 }
@@ -80,15 +80,15 @@ export interface TLaunchDarklyAdapterInterface
   configure(
     adapterArgs: TLaunchDarklyAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any>;
+  ): Promise<unknown>;
   reconfigure(
     adapterArgs: TLaunchDarklyAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any>;
+  ): Promise<unknown>;
   getIsReady(): boolean;
   getClient(): TLDClient | undefined;
   getFlag(flagName: TFlagName): TFlagVariation | undefined;
-  updateUserContext(updatedUserProps: TUser): Promise<any>;
+  updateUserContext(updatedUserProps: TUser): Promise<unknown>;
 }
 export interface TLocalStorageAdapterInterface
   extends TAdapterInterface<TLocalStorageAdapterArgs> {
@@ -96,13 +96,13 @@ export interface TLocalStorageAdapterInterface
   configure(
     adapterArgs: TLocalStorageAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any>;
+  ): Promise<unknown>;
   reconfigure(
     adapterArgs: TLocalStorageAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any>;
+  ): Promise<unknown>;
   getIsReady(): boolean;
-  waitUntilConfigured(): Promise<any>;
+  waitUntilConfigured(): Promise<unknown>;
 }
 export interface TMemoryAdapterInterface
   extends TAdapterInterface<TMemoryAdapterArgs> {
@@ -110,14 +110,14 @@ export interface TMemoryAdapterInterface
   configure(
     adapterArgs: TMemoryAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any>;
+  ): Promise<unknown>;
   reconfigure(
     adapterArgs: TMemoryAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any>;
+  ): Promise<unknown>;
   getIsReady(): boolean;
   setIsReady(nextStatus: TAdapterStatus): void;
-  waitUntilConfigured(): Promise<any>;
+  waitUntilConfigured(): Promise<unknown>;
   reset(): void;
   updateFlags(flags: TFlags): void;
 }
@@ -127,11 +127,11 @@ export interface TSplitioAdapterInterface
   configure(
     adapterArgs: TSplitioAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any>;
+  ): Promise<unknown>;
   reconfigure(
     adapterArgs: TSplitioAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<any>;
+  ): Promise<unknown>;
   getIsReady(): boolean;
 }
 export type TAdapter =

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
     "allowJs": false
   },
   "include": [
+    "packages/**/*.ts",
     "packages/**/modules/**/*.ts",
     "packages/**/modules/**/*.tsx",
     "packages/**/modules/**/*.js",


### PR DESCRIPTION
#### Summary

Most of the return types are usually inferred by TypeScript, there is no need to explicitly define them. This is also important to get the "correct" return types for React components.

Additionally, I fixed up a bit the `ToggleFeature` component props.

See inline comments for more detailed info.
