### PR TITLE
chore(ci): add throwing logger on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Test
         if: startsWith(matrix.node-version, '12')
         run: yarn test:ci
+        env:
+          CI: true
       - name: Test (with coverage)
         if: startsWith(matrix.node-version, '13')
         run: yarn test:ci:coverage

--- a/jest.test.config.js
+++ b/jest.test.config.js
@@ -12,7 +12,11 @@ module.exports = {
       isolatedModules: true,
     },
   },
-  setupFiles: ['raf/polyfill', 'jest-localstorage-mock'],
+  setupFiles: [
+    'raf/polyfill',
+    'jest-localstorage-mock',
+    './throwing-console-patch.js',
+  ],
   setupFilesAfterEnv: ['./jest-runner-test.config.js'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
   testEnvironment: 'jsdom',

--- a/throwing-console-patch.js
+++ b/throwing-console-patch.js
@@ -1,0 +1,48 @@
+const colors = require('colors/safe');
+
+const shouldSilenceWarnings = (...messages) =>
+  [].some(msgRegex => messages.some(msg => msgRegex.test(msg)));
+
+const shouldNotThrowWarnings = (...messages) =>
+  [].some(msgRegex => messages.some(msg => msgRegex.test(msg)));
+
+const logOrThrow = (log, method, messages) => {
+  const warning = `console.${method} calls not allowed in tests`;
+  if (process.env.CI) {
+    if (shouldSilenceWarnings(messages)) return;
+
+    log(warning, '\n', ...messages);
+
+    // NOTE: That some warnings should be logged allowing us to refactor graceully
+    // without having to introduce a breaking change.
+    if (shouldNotThrowWarnings(messages)) return;
+
+    throw new Error(...messages);
+  } else {
+    log(colors.bgYellow.black(' WARN '), warning, '\n', ...messages);
+  }
+};
+
+// eslint-disable-next-line no-console
+const logMessage = console.log;
+global.console.log = (...messages) => {
+  logOrThrow(logMessage, 'log', messages);
+};
+
+// eslint-disable-next-line no-console
+const logInfo = console.info;
+global.console.info = (...messages) => {
+  logOrThrow(logInfo, 'info', messages);
+};
+
+// eslint-disable-next-line no-console
+const logWarning = console.warn;
+global.console.warn = (...messages) => {
+  logOrThrow(logWarning, 'warn', messages);
+};
+
+// eslint-disable-next-line no-console
+const logError = console.error;
+global.console.error = (...messages) => {
+  logOrThrow(logError, 'error', messages);
+};


### PR DESCRIPTION
#### Summary

Wraps the console to throw when logging on CI while setting the env variable. This helps to found act warnings among other things.