### PR TITLE
refactor: to always avait to avoid act warnings

### DIFF
--- a/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
@@ -16,14 +16,17 @@ const render = (store, TestComponent) =>
 
 describe('without `untoggledComponent', () => {
   describe('when feature is disabled', () => {
-    it('should render neither the component representing an disabled or enabled feature', () => {
+    it('should render neither the component representing an disabled or enabled feature', async () => {
       const store = createStore({
         [STATE_SLICE]: { flags: { disabledFeature: false } },
       });
       const TestComponent = branchOnFeatureToggle({ flag: 'disabledFeature' })(
         components.ToggledComponent
       );
+
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(
         rendered.queryByFlagName('isFeatureEnabled')
@@ -53,7 +56,7 @@ describe('without `untoggledComponent', () => {
   });
 
   describe('when feature is enabled', () => {
-    it('should render the component representing an enabled feature', () => {
+    it('should render the component representing an enabled feature', async () => {
       const store = createStore({
         [STATE_SLICE]: { flags: { enabledFeature: true } },
       });
@@ -62,6 +65,8 @@ describe('without `untoggledComponent', () => {
       );
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveAttribute(
         'data-flag-status',
@@ -73,7 +78,7 @@ describe('without `untoggledComponent', () => {
 
 describe('with `untoggledComponent', () => {
   describe('when feature is disabled', () => {
-    it('should not render the component representing a enabled feature', () => {
+    it('should not render the component representing a enabled feature', async () => {
       const store = createStore({
         [STATE_SLICE]: { flags: { disabledFeature: false } },
       });
@@ -83,6 +88,8 @@ describe('with `untoggledComponent', () => {
       )(components.ToggledComponent);
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).not.toHaveAttribute(
         'data-flag-status',
@@ -90,7 +97,7 @@ describe('with `untoggledComponent', () => {
       );
     });
 
-    it('should render the component representing a disabled feature', () => {
+    it('should render the component representing a disabled feature', async () => {
       const store = createStore({
         [STATE_SLICE]: { flags: { disabledFeature: false } },
       });
@@ -100,6 +107,8 @@ describe('with `untoggledComponent', () => {
       )(components.ToggledComponent);
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveAttribute(
         'data-flag-status',
@@ -109,16 +118,17 @@ describe('with `untoggledComponent', () => {
   });
 
   describe('when feature is enabled', () => {
-    it('should render the component representing a enabled feature', () => {
+    it('should render the component representing a enabled feature', async () => {
       const store = createStore({
         [STATE_SLICE]: { flags: { enabledFeature: true } },
       });
-      const TestComponent = branchOnFeatureToggle(
-        { flag: 'enabledFeature' },
-        components.UntoggledComponent
-      )(components.ToggledComponent);
+      const TestComponent = branchOnFeatureToggle({ flag: 'enabledFeature' })(
+        components.ToggledComponent
+      );
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveAttribute(
         'data-flag-status',
@@ -126,16 +136,17 @@ describe('with `untoggledComponent', () => {
       );
     });
 
-    it('should not render the component representing a disabled feature', () => {
+    it('should not render the component representing a disabled feature', async () => {
       const store = createStore({
         [STATE_SLICE]: { flags: { enabledFeature: true } },
       });
-      const TestComponent = branchOnFeatureToggle(
-        { flag: 'enabledFeature' },
-        components.UntoggledComponent
-      )(components.ToggledComponent);
+      const TestComponent = branchOnFeatureToggle({ flag: 'enabledFeature' })(
+        components.ToggledComponent
+      );
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).not.toHaveAttribute(
         'data-flag-status',

--- a/packages/react-redux/modules/components/configure/configure.spec.js
+++ b/packages/react-redux/modules/components/configure/configure.spec.js
@@ -27,13 +27,17 @@ const render = () => {
     [STATE_SLICE]: { flags: { disabledFeature: false } },
   });
 
-  return rtlRender(
+  const rtlRendered = rtlRender(
     <Provider store={store}>
       <Configure {...props}>
         <TestComponent />
       </Configure>
     </Provider>
   );
+
+  const waitUntilReady = () => rtlRendered.findByText(`Is ready: Yes`);
+
+  return { ...rtlRendered, waitUntilReady };
 };
 
 const createTestProps = custom => ({
@@ -46,8 +50,10 @@ const createTestProps = custom => ({
 });
 
 describe('when feature is disabled', () => {
-  it('should indicate the feature being disabled', () => {
+  it('should indicate the feature being disabled', async () => {
     const rendered = render();
+
+    await rendered.waitUntilReady();
 
     expect(rendered.queryByText(/Feature enabled: No/i)).toBeInTheDocument();
   });
@@ -63,16 +69,20 @@ describe('when enabling feature is', () => {
       [testFlagName]: true,
     });
 
+    await rendered.waitUntilReady();
+
     expect(rendered.queryByText(/Feature enabled: Yes/i)).toBeInTheDocument();
   });
 });
 
 describe('when not configured and not ready', () => {
-  it('should indicate through the adapter state', () => {
+  it('should indicate through the adapter state', async () => {
     const rendered = render();
 
     expect(rendered.queryByText(/Is ready: No/i)).toBeInTheDocument();
     expect(rendered.queryByText(/Is configured: No/i)).toBeInTheDocument();
+
+    await rendered.waitUntilReady();
   });
 });
 
@@ -80,6 +90,7 @@ describe('when configured and ready', () => {
   it('should indicate through the adapter state', async () => {
     const rendered = render();
 
+    await rendered.waitUntilReady();
     await adapter.waitUntilConfigured();
 
     expect(rendered.queryByText(/Is ready: Yes/i)).toBeInTheDocument();

--- a/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
+++ b/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
@@ -16,7 +16,7 @@ const render = (store, TestComponent) =>
 
 describe('without `propKey`', () => {
   describe('when feature is disabled', () => {
-    it('should render receive the flag value as `false`', () => {
+    it('should render receive the flag value as `false`', async () => {
       const store = createStore({
         [STATE_SLICE]: { flags: { disabledFeature: false } },
       });
@@ -25,6 +25,8 @@ describe('without `propKey`', () => {
       );
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveTextContent(
         'false'
@@ -54,7 +56,7 @@ describe('without `propKey`', () => {
   });
 
   describe('when feature is enabled', () => {
-    it('should render receive the flag value as `true`', () => {
+    it('should render receive the flag value as `true`', async () => {
       const store = createStore({
         [STATE_SLICE]: { flags: { enabledFeature: true } },
       });
@@ -63,6 +65,8 @@ describe('without `propKey`', () => {
       );
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveTextContent(
         'true'
@@ -73,7 +77,7 @@ describe('without `propKey`', () => {
 
 describe('with `propKey`', () => {
   describe('when feature is disabled', () => {
-    it('should render receive the flag value as `false`', () => {
+    it('should render receive the flag value as `false`', async () => {
       const store = createStore({
         [STATE_SLICE]: { flags: { disabledFeature: false } },
       });
@@ -83,6 +87,8 @@ describe('with `propKey`', () => {
       )(components.FlagsToComponent);
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('customPropKey')).toHaveTextContent(
         'false'

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
@@ -22,7 +22,7 @@ const FlagsToComponentWithPropKey = props => (
 
 describe('injectFeatureToggles', () => {
   describe('without `propKey`', () => {
-    it('should have feature enabling prop for `enabledFeature`', () => {
+    it('should have feature enabling prop for `enabledFeature`', async () => {
       const store = createStore({
         [STATE_SLICE]: {
           flags: { enabledFeature: true, disabledFeature: false },
@@ -34,13 +34,15 @@ describe('injectFeatureToggles', () => {
       ])(FlagsToComponent);
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('enabledFeature')).toHaveTextContent(
         'true'
       );
     });
 
-    it('should have feature disabling prop for `disabledFeature`', () => {
+    it('should have feature disabling prop for `disabledFeature`', async () => {
       const store = createStore({
         [STATE_SLICE]: {
           flags: { enabledFeature: true, disabledFeature: false },
@@ -52,6 +54,8 @@ describe('injectFeatureToggles', () => {
       ])(FlagsToComponent);
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('disabledFeature')).toHaveTextContent(
         'false'
@@ -84,7 +88,7 @@ describe('injectFeatureToggles', () => {
   });
 
   describe('with `propKey`', () => {
-    it('should have feature enabling prop for `enabledFeature`', () => {
+    it('should have feature enabling prop for `enabledFeature`', async () => {
       const store = createStore({
         [STATE_SLICE]: {
           flags: { enabledFeature: true, disabledFeature: false },
@@ -96,13 +100,15 @@ describe('injectFeatureToggles', () => {
       )(FlagsToComponentWithPropKey);
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('enabledFeature')).toHaveTextContent(
         'true'
       );
     });
 
-    it('should have feature disabling prop for `disabledFeature`', () => {
+    it('should have feature disabling prop for `disabledFeature`', async () => {
       const store = createStore({
         [STATE_SLICE]: {
           flags: { enabledFeature: true, disabledFeature: false },
@@ -114,6 +120,8 @@ describe('injectFeatureToggles', () => {
       )(FlagsToComponentWithPropKey);
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('disabledFeature')).toHaveTextContent(
         'false'

--- a/packages/react-redux/modules/components/toggle-feature/toggle-feature.spec.js
+++ b/packages/react-redux/modules/components/toggle-feature/toggle-feature.spec.js
@@ -16,17 +16,19 @@ const render = (store, TestComponent) =>
 
 describe('<ToggleFeature>', () => {
   describe('when feature is disabled', () => {
-    it('should not render the component representing a enabled feature', () => {
-      const store = createStore({
-        [STATE_SLICE]: { flags: { disabledFeature: false } },
-      });
+    it('should not render the component representing a enabled feature', async () => {
       const TestComponent = () => (
         <ToggleFeature flag="disabledFeature">
           <components.ToggledComponent flagName="disabledFeature" />
         </ToggleFeature>
       );
+      const store = createStore({
+        [STATE_SLICE]: { flags: { disabledFeature: false } },
+      });
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(
         rendered.queryByFlagName('disabledFeature')
@@ -35,14 +37,14 @@ describe('<ToggleFeature>', () => {
 
     describe('when enabling feature', () => {
       it('should render the component representing a enabled feature', async () => {
-        const store = createStore({
-          [STATE_SLICE]: { flags: { disabledFeature: false } },
-        });
         const TestComponent = () => (
           <ToggleFeature flag="disabledFeature">
             <components.ToggledComponent flagName="disabledFeature" />
           </ToggleFeature>
         );
+        const store = createStore({
+          [STATE_SLICE]: { flags: { disabledFeature: false } },
+        });
 
         const rendered = render(store, <TestComponent />);
 
@@ -56,7 +58,7 @@ describe('<ToggleFeature>', () => {
   });
 
   describe('when feature is enabled', () => {
-    it('should render the component representing a enabled feature', () => {
+    it('should render the component representing a enabled feature', async () => {
       const store = createStore({
         [STATE_SLICE]: { flags: { enabledFeature: true } },
       });
@@ -67,6 +69,8 @@ describe('<ToggleFeature>', () => {
       );
 
       const rendered = render(store, <TestComponent />);
+
+      await rendered.waitUntilReady();
 
       expect(rendered.queryByFlagName('enabledFeature')).toHaveAttribute(
         'data-flag-status',

--- a/packages/react-redux/modules/hooks/use-adapter-status/use-adapter-status.spec.js
+++ b/packages/react-redux/modules/hooks/use-adapter-status/use-adapter-status.spec.js
@@ -25,7 +25,7 @@ const TestComponent = () => {
   );
 };
 
-it('should indicate the adapter not being ready', () => {
+it('should indicate the adapter not being ready', async () => {
   const store = createStore({
     [STATE_SLICE]: { flags: { disabledFeature: false } },
   });
@@ -33,6 +33,8 @@ it('should indicate the adapter not being ready', () => {
   const rendered = render(store, <TestComponent />);
 
   expect(rendered.queryByText('Is ready: No')).toBeInTheDocument();
+
+  await rendered.waitUntilReady();
 });
 
 it('should indicate the adapter being ready', async () => {


### PR DESCRIPTION
#### Summary

This avoids act warnings in the refactoring to RFCs.