### PR TITLE
refactor: to not use booleans for adapter state

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -1,3 +1,4 @@
+import { TAdapterConfigurationStatus } from '@flopflip/types';
 import ldClient from 'launchdarkly-js-client-sdk';
 import adapter, { normalizeFlags } from './adapter';
 
@@ -20,11 +21,6 @@ const createClient = jest.fn(apiOverwrites => ({
 
   ...apiOverwrites,
 }));
-const AdapterStatus = {
-  Unconfigured: 0,
-  Configuring: 1,
-  Configured: 2,
-};
 
 const triggerFlagValueChange = (client, flagValue = false) =>
   client.on.mock.calls.forEach(([event, cb]) => {
@@ -43,9 +39,9 @@ describe('when configuring', () => {
   });
 
   it('should indicate that the adapter is not configured', () => {
-    expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
-      false
-    );
+    expect(
+      adapter.getIsConfigurationStatus(TAdapterConfigurationStatus.Configured)
+    ).toBe(false);
   });
 
   it('should not return client', () => {
@@ -173,7 +169,9 @@ describe('when configuring', () => {
       describe('when determining if adapter is ready', () => {
         it('should indicate that the adapter is configured', () => {
           expect(
-            adapter.getIsConfigurationStatus(AdapterStatus.Configured)
+            adapter.getIsConfigurationStatus(
+              TAdapterConfigurationStatus.Configured
+            )
           ).toBe(true);
         });
 
@@ -191,7 +189,7 @@ describe('when configuring', () => {
 
       it('should `dispatch` `onUpdateStatus` action with configured', () => {
         expect(onStatusStateChange).toHaveBeenCalledWith({
-          configurationStatus: AdapterStatus.Configured,
+          configurationStatus: TAdapterConfigurationStatus.Configured,
         });
       });
 
@@ -307,7 +305,7 @@ describe('when configuring', () => {
 
         it('should `dispatch` `onUpdateStatus` action with configured', () => {
           expect(onStatusStateChange).toHaveBeenCalledWith({
-            configurationStatus: AdapterStatus.Configured,
+            configurationStatus: TAdapterConfigurationStatus.Configured,
           });
         });
 

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -165,8 +165,8 @@ describe('when configuring', () => {
       );
     });
 
-    describe('when `ldClient` is ready', () => {
-      describe('when determining if adapter is ready', () => {
+    describe('when `ldClient` is configured', () => {
+      describe('when determining if adapter is configured', () => {
         it('should indicate that the adapter is configured', () => {
           expect(
             adapter.getIsConfigurationStatus(

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -20,6 +20,11 @@ const createClient = jest.fn(apiOverwrites => ({
 
   ...apiOverwrites,
 }));
+const AdapterStatus = {
+  Unconfigured: 0,
+  Configuring: 1,
+  Configured: 2,
+};
 
 const triggerFlagValueChange = (client, flagValue = false) =>
   client.on.mock.calls.forEach(([event, cb]) => {
@@ -37,8 +42,10 @@ describe('when configuring', () => {
     ldClient.initialize.mockReturnValue(createClient());
   });
 
-  it('should indicate that the adapter is not ready', () => {
-    expect(adapter.getIsReady()).toBe(false);
+  it('should indicate that the adapter is not configured', () => {
+    expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
+      false
+    );
   });
 
   it('should not return client', () => {
@@ -164,8 +171,10 @@ describe('when configuring', () => {
 
     describe('when `ldClient` is ready', () => {
       describe('when determining if adapter is ready', () => {
-        it('should indicate that the adapter is ready', () => {
-          expect(adapter.getIsReady()).toBe(true);
+        it('should indicate that the adapter is configured', () => {
+          expect(
+            adapter.getIsConfigurationStatus(AdapterStatus.Configured)
+          ).toBe(true);
         });
 
         it('should return client', () => {
@@ -180,9 +189,9 @@ describe('when configuring', () => {
         });
       });
 
-      it('should `dispatch` `onUpdateStatus` action with `isReady`', () => {
+      it('should `dispatch` `onUpdateStatus` action with configured', () => {
         expect(onStatusStateChange).toHaveBeenCalledWith({
-          isReady: true,
+          configurationStatus: AdapterStatus.Configured,
         });
       });
 
@@ -296,9 +305,9 @@ describe('when configuring', () => {
           );
         });
 
-        it('should `dispatch` `onUpdateStatus` action with `isReady`', () => {
+        it('should `dispatch` `onUpdateStatus` action with configured', () => {
           expect(onStatusStateChange).toHaveBeenCalledWith({
-            isReady: true,
+            configurationStatus: AdapterStatus.Configured,
           });
         });
 

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.ts
@@ -9,19 +9,20 @@ import {
   TLaunchDarklyAdapterArgs,
   TAdapterEventHandlers,
   TAdapterSubscriptionStatus,
+  TAdapterConfigurationStatus,
   interfaceIdentifiers,
 } from '@flopflip/types';
 import merge from 'deepmerge';
 import warning from 'tiny-warning';
 import isEqual from 'lodash/isEqual';
+import camelCase from 'lodash/camelCase';
+import kebabCase from 'lodash/kebabCase';
 import debounce from 'debounce-fn';
 import {
   initialize as initializeLaunchDarklyClient,
   LDUser,
   LDClient,
 } from 'launchdarkly-js-client-sdk';
-import camelCase from 'lodash/camelCase';
-import kebabCase from 'lodash/kebabCase';
 
 type LaunchDarklyAdapterState = {
   user?: TUser;
@@ -30,9 +31,8 @@ type LaunchDarklyAdapterState = {
 };
 
 const adapterState: TAdapterStatus & LaunchDarklyAdapterState = {
-  isReady: false,
-  isConfigured: false,
   subscriptionStatus: TAdapterSubscriptionStatus.Subscribed,
+  configurationStatus: TAdapterConfigurationStatus.Unconfigured,
   user: undefined,
   client: undefined,
   flags: {},
@@ -142,10 +142,14 @@ const getInitialFlags = (
         }
 
         // First update internal state
-        adapterState.isReady = true;
+        adapterState.configurationStatus =
+          TAdapterConfigurationStatus.Configured;
+
         // ...to then signal that the adapter is ready
         if (!getIsUnsubscribed()) {
-          adapterEventHandlers.onStatusStateChange({ isReady: true });
+          adapterEventHandlers.onStatusStateChange({
+            configurationStatus: adapterState.configurationStatus,
+          });
         }
 
         return Promise.resolve({ flagsFromSdk });
@@ -179,6 +183,12 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
     adapterArgs: TLaunchDarklyAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
   ) {
+    adapterState.configurationStatus = TAdapterConfigurationStatus.Configuring;
+
+    adapterEventHandlers.onStatusStateChange({
+      configurationStatus: adapterState.configurationStatus,
+    });
+
     const {
       clientSideId,
       user,
@@ -195,7 +205,6 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
       adapterState.user,
       clientOptions
     );
-    adapterState.isConfigured = true;
 
     return getInitialFlags(
       {
@@ -221,7 +230,10 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
     adapterArgs: TLaunchDarklyAdapterArgs,
     _adapterEventHandlers: TAdapterEventHandlers
   ) {
-    if (!adapterState.isConfigured)
+    if (
+      adapterState.configurationStatus !==
+      TAdapterConfigurationStatus.Configured
+    )
       return Promise.reject(
         new Error(
           '@flopflip/launchdarkly-adapter: please configure adapter before reconfiguring.'
@@ -237,8 +249,8 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
     return Promise.resolve();
   }
 
-  getIsReady() {
-    return Boolean(adapterState.isReady);
+  getIsConfigurationStatus(configurationStatus: TAdapterConfigurationStatus) {
+    return adapterState.configurationStatus === configurationStatus;
   }
 
   getClient() {
@@ -250,16 +262,18 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
   }
 
   updateUserContext(updatedUserProps: TUser) {
-    const isAdapterReady = adapterState.isConfigured && adapterState.isReady;
+    const isAdapterConfigured =
+      adapterState.configurationStatus ===
+      TAdapterConfigurationStatus.Configured;
 
     warning(
-      isAdapterReady,
-      '@flopflip/launchdarkly-adapter: adapter not ready and configured. User context can not be updated before.'
+      isAdapterConfigured,
+      '@flopflip/launchdarkly-adapter: adapter not configured. User context can not be updated before.'
     );
 
-    if (!isAdapterReady)
+    if (!isAdapterConfigured)
       return Promise.reject(
-        new Error('Can not update user context: adapter not yet ready.')
+        new Error('Can not update user context: adapter not yet configured.')
       );
 
     return changeUserContext({ ...adapterState.user, ...updatedUserProps });

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.ts
@@ -287,6 +287,18 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
     adapterState.subscriptionStatus = TAdapterSubscriptionStatus.Subscribed;
   }
 
+  // NOTE: This function is deprecated. Please use `getIsConfigurationStatus`.
+  getIsReady() {
+    warning(
+      false,
+      '@flopflip/launchdarkly-adapter: `getIsReady` has been deprecated. Please use `getIsConfigurationStatus` instead.'
+    );
+
+    return this.getIsConfigurationStatus(
+      TAdapterConfigurationStatus.Configured
+    );
+  }
+
   private _didFlagChange(flagName: TFlagName, nextFlagValue: TFlagVariation) {
     const previousFlagValue = this.getFlag(flagName);
 

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.ts
@@ -145,7 +145,7 @@ const getInitialFlags = (
         adapterState.configurationStatus =
           TAdapterConfigurationStatus.Configured;
 
-        // ...to then signal that the adapter is ready
+        // ...to then signal that the adapter is configured
         if (!getIsUnsubscribed()) {
           adapterEventHandlers.onStatusStateChange({
             configurationStatus: adapterState.configurationStatus,

--- a/packages/localstorage-adapter/modules/adapter/adapter.spec.js
+++ b/packages/localstorage-adapter/modules/adapter/adapter.spec.js
@@ -1,3 +1,4 @@
+import { TAdapterConfigurationStatus } from '@flopflip/types';
 import warning from 'tiny-warning';
 import adapter, { updateFlags, STORAGE_SLICE } from './adapter';
 
@@ -8,11 +9,6 @@ const createAdapterEventHandlers = (custom = {}) => ({
   onStatusStateChange: jest.fn(),
   ...custom,
 });
-const AdapterStatus = {
-  Unconfigured: 0,
-  Configuring: 1,
-  Configured: 2,
-};
 
 describe('when configuring', () => {
   let adapterArgs = {};
@@ -20,9 +16,9 @@ describe('when configuring', () => {
 
   describe('when not configured', () => {
     it('should indicate that the adapter is not configured', () => {
-      expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
-        false
-      );
+      expect(
+        adapter.getIsConfigurationStatus(TAdapterConfigurationStatus.Configured)
+      ).toBe(false);
     });
 
     describe('updating flags', () => {
@@ -42,21 +38,21 @@ describe('when configuring', () => {
     it('should invoke `onStatusStateChange` with configuring', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
-          configurationStatus: AdapterStatus.Configuring,
+          configurationStatus: TAdapterConfigurationStatus.Configuring,
         })
       );
     });
 
     it('should indicate that the adapter is configured', () => {
-      expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
-        true
-      );
+      expect(
+        adapter.getIsConfigurationStatus(TAdapterConfigurationStatus.Configured)
+      ).toBe(true);
     });
 
     it('should invoke `onStatusStateChange` with configured', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
-          configurationStatus: AdapterStatus.Configured,
+          configurationStatus: TAdapterConfigurationStatus.Configured,
         })
       );
     });
@@ -72,7 +68,7 @@ describe('when configuring', () => {
     it('should invoke `onStatusStateChange` with configuring', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
-          configurationStatus: AdapterStatus.Configuring,
+          configurationStatus: TAdapterConfigurationStatus.Configuring,
         })
       );
     });
@@ -154,7 +150,7 @@ describe('when configuring', () => {
       it('should invoke `onStatusStateChange` with configuring', () => {
         expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
           expect.objectContaining({
-            configurationStatus: AdapterStatus.Configuring,
+            configurationStatus: TAdapterConfigurationStatus.Configuring,
           })
         );
       });
@@ -162,7 +158,7 @@ describe('when configuring', () => {
       it('should invoke `onStatusStateChange` with configured', () => {
         expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
           expect.objectContaining({
-            configurationStatus: AdapterStatus.Configured,
+            configurationStatus: TAdapterConfigurationStatus.Configured,
           })
         );
       });

--- a/packages/localstorage-adapter/modules/adapter/adapter.spec.js
+++ b/packages/localstorage-adapter/modules/adapter/adapter.spec.js
@@ -65,14 +65,6 @@ describe('when configuring', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalled();
     });
 
-    it('should invoke `onStatusStateChange` with configuring', () => {
-      expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          configurationStatus: TAdapterConfigurationStatus.Configuring,
-        })
-      );
-    });
-
     it('should invoke `onFlagsStateChange`', () => {
       expect(adapterEventHandlers.onFlagsStateChange).toHaveBeenCalled();
     });

--- a/packages/localstorage-adapter/modules/adapter/adapter.spec.js
+++ b/packages/localstorage-adapter/modules/adapter/adapter.spec.js
@@ -8,14 +8,21 @@ const createAdapterEventHandlers = (custom = {}) => ({
   onStatusStateChange: jest.fn(),
   ...custom,
 });
+const AdapterStatus = {
+  Unconfigured: 0,
+  Configuring: 1,
+  Configured: 2,
+};
 
 describe('when configuring', () => {
   let adapterArgs = {};
   let adapterEventHandlers = createAdapterEventHandlers();
 
   describe('when not configured', () => {
-    it('should indicate that the adapter is not ready', () => {
-      expect(adapter.getIsReady()).toBe(false);
+    it('should indicate that the adapter is not configured', () => {
+      expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
+        false
+      );
     });
 
     describe('updating flags', () => {
@@ -32,8 +39,26 @@ describe('when configuring', () => {
   describe('when configured', () => {
     beforeEach(() => adapter.configure(adapterArgs, adapterEventHandlers));
 
-    it('should indicate that the adapter is ready', () => {
-      expect(adapter.getIsReady()).toBe(true);
+    it('should invoke `onStatusStateChange` with configuring', () => {
+      expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          configurationStatus: AdapterStatus.Configuring,
+        })
+      );
+    });
+
+    it('should indicate that the adapter is configured', () => {
+      expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
+        true
+      );
+    });
+
+    it('should invoke `onStatusStateChange` with configured', () => {
+      expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          configurationStatus: AdapterStatus.Configured,
+        })
+      );
     });
 
     it('should resolve `waitUntilConfigured`', async () => {
@@ -44,10 +69,12 @@ describe('when configuring', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalled();
     });
 
-    it('should invoke `onStatusStateChange` with `isReady`', () => {
-      expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith({
-        isReady: true,
-      });
+    it('should invoke `onStatusStateChange` with configuring', () => {
+      expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          configurationStatus: AdapterStatus.Configuring,
+        })
+      );
     });
 
     it('should invoke `onFlagsStateChange`', () => {
@@ -81,7 +108,6 @@ describe('when configuring', () => {
       describe('when flags are not normalized', () => {
         const nonNormalizedUpdatedFlags = {
           'flag-a-1': false,
-          // eslint-disable-next-line @typescript-eslint/camelcase
           flag_b: null,
         };
         beforeEach(() => {
@@ -122,6 +148,22 @@ describe('when configuring', () => {
       it('should invoke `onFlagsStateChange` with empty flags', () => {
         expect(adapterEventHandlers.onFlagsStateChange).toHaveBeenCalledWith(
           {}
+        );
+      });
+
+      it('should invoke `onStatusStateChange` with configuring', () => {
+        expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            configurationStatus: AdapterStatus.Configuring,
+          })
+        );
+      });
+
+      it('should invoke `onStatusStateChange` with configured', () => {
+        expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            configurationStatus: AdapterStatus.Configured,
+          })
         );
       });
     });

--- a/packages/localstorage-adapter/modules/adapter/adapter.ts
+++ b/packages/localstorage-adapter/modules/adapter/adapter.ts
@@ -129,6 +129,8 @@ const subscribeToFlagsChanges = ({
   }, pollingInteral);
 };
 
+const __internalConfiguredStatusChange__ = '__internalConfiguredStatusChange__';
+
 class LocalStorageAdapter implements TLocalStorageAdapterInterface {
   id: typeof interfaceIdentifiers.localstorage;
 
@@ -175,7 +177,7 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
       adapterState.emitter.emit('statusStateChange', {
         configurationStatus: adapterState.configurationStatus,
       });
-      adapterState.emitter.emit('__internalConfiguredStatusChange__');
+      adapterState.emitter.emit(__internalConfiguredStatusChange__);
 
       subscribeToFlagsChanges({
         pollingInteral: adapterConfiguration?.pollingInteral,
@@ -204,8 +206,7 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
         TAdapterConfigurationStatus.Configured
       )
         resolve();
-      else
-        adapterState.emitter.on('__internalConfiguredStatusChange__', resolve);
+      else adapterState.emitter.on(__internalConfiguredStatusChange__, resolve);
     });
   }
 

--- a/packages/localstorage-adapter/modules/adapter/adapter.ts
+++ b/packages/localstorage-adapter/modules/adapter/adapter.ts
@@ -4,6 +4,7 @@ import camelCase from 'lodash/camelCase';
 import {
   TUser,
   TAdapterStatus,
+  TAdapterStatusChange,
   TAdapterEventHandlers,
   TLocalStorageAdapterInterface,
   TLocalStorageAdapterArgs,
@@ -12,6 +13,7 @@ import {
   TFlag,
   TFlags,
   TAdapterSubscriptionStatus,
+  TAdapterConfigurationStatus,
   interfaceIdentifiers,
 } from '@flopflip/types';
 
@@ -28,8 +30,8 @@ type LocalStorageAdapterState = {
 };
 
 const intialAdapterState: TAdapterStatus & LocalStorageAdapterState = {
-  isReady: false,
   subscriptionStatus: TAdapterSubscriptionStatus.Subscribed,
+  configurationStatus: TAdapterConfigurationStatus.Unconfigured,
   flags: {},
   user: {},
   // Typings are incorrect and state that mitt is not callable.
@@ -91,16 +93,15 @@ const storage: Storage = {
   unset: key => localStorage.removeItem(`${STORAGE_SLICE}__${key}`),
 };
 export const updateFlags = (flags: TFlags) => {
-  const isAdapterReady = Boolean(
-    adapterState.isConfigured && adapterState.isReady
-  );
+  const isAdapterConfigured =
+    adapterState.configurationStatus === TAdapterConfigurationStatus.Configured;
 
   warning(
-    isAdapterReady,
-    '@flopflip/localstorage-adapter: adapter not ready and configured. Flags can not be updated before.'
+    isAdapterConfigured,
+    '@flopflip/localstorage-adapter: adapter not configured. Flags can not be updated before.'
   );
 
-  if (!isAdapterReady) return;
+  if (!isAdapterConfigured) return;
 
   const previousFlags: TFlags | null = storage.get('flags') as TFlags;
   const nextFlags: TFlags = normalizeFlags({
@@ -139,37 +140,42 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
     adapterArgs: TLocalStorageAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
   ) {
+    const handleFlagsChange = (nextFlags: TFlags) => {
+      if (getIsUnsubscribed()) return;
+
+      adapterEventHandlers.onFlagsStateChange(nextFlags);
+    };
+
+    const handleStatusChange = (nextStatus: TAdapterStatusChange) => {
+      if (getIsUnsubscribed()) return;
+
+      adapterEventHandlers.onStatusStateChange(nextStatus);
+    };
+
+    adapterState.emitter.on('flagsStateChange', handleFlagsChange);
+    adapterState.emitter.on('statusStateChange', handleStatusChange);
+
+    adapterState.configurationStatus = TAdapterConfigurationStatus.Configuring;
+
+    adapterState.emitter.emit('statusStateChange', {
+      configurationStatus: adapterState.configurationStatus,
+    });
+
     const { user, adapterConfiguration } = adapterArgs;
 
     adapterState.user = user;
 
     return Promise.resolve().then(() => {
-      adapterState.isConfigured = true;
-      adapterState.isReady = true;
-
-      const handleFlagsChange = (nextFlags: TFlags) => {
-        if (getIsUnsubscribed()) return;
-
-        adapterEventHandlers.onFlagsStateChange(nextFlags);
-      };
-
-      const handleStatusChange = (nextStatus: TAdapterStatus) => {
-        if (getIsUnsubscribed()) return;
-
-        adapterEventHandlers.onStatusStateChange(nextStatus);
-      };
-
-      adapterState.emitter.on('flagsStateChange', handleFlagsChange);
-      adapterState.emitter.on('statusStateChange', handleStatusChange);
+      adapterState.configurationStatus = TAdapterConfigurationStatus.Configured;
 
       adapterState.emitter.emit(
         'flagsStateChange',
         normalizeFlags(storage.get('flags'))
       );
       adapterState.emitter.emit('statusStateChange', {
-        isReady: adapterState.isReady,
+        configurationStatus: adapterState.configurationStatus,
       });
-      adapterState.emitter.emit('readyStateChange');
+      adapterState.emitter.emit('__internalConfiguredStatusChange__');
 
       subscribeToFlagsChanges({
         pollingInteral: adapterConfiguration?.pollingInteral,
@@ -193,13 +199,18 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
 
   waitUntilConfigured() {
     return new Promise(resolve => {
-      if (adapterState.isConfigured) resolve();
-      else adapterState.emitter.on('readyStateChange', resolve);
+      if (
+        adapterState.configurationStatus ===
+        TAdapterConfigurationStatus.Configured
+      )
+        resolve();
+      else
+        adapterState.emitter.on('__internalConfiguredStatusChange__', resolve);
     });
   }
 
-  getIsReady() {
-    return Boolean(adapterState.isReady);
+  getIsConfigurationStatus(configurationStatus: TAdapterConfigurationStatus) {
+    return adapterState.configurationStatus === configurationStatus;
   }
 
   unsubscribe() {

--- a/packages/localstorage-adapter/modules/adapter/adapter.ts
+++ b/packages/localstorage-adapter/modules/adapter/adapter.ts
@@ -220,6 +220,18 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
   subscribe() {
     adapterState.subscriptionStatus = TAdapterSubscriptionStatus.Subscribed;
   }
+
+  // NOTE: This function is deprecated. Please use `getIsConfigurationStatus`.
+  getIsReady() {
+    warning(
+      false,
+      '@flopflip/localstorage-adapter: `getIsReady` has been deprecated. Please use `getIsConfigurationStatus` instead.'
+    );
+
+    return this.getIsConfigurationStatus(
+      TAdapterConfigurationStatus.Configured
+    );
+  }
 }
 
 const adapter = new LocalStorageAdapter();

--- a/packages/memory-adapter/modules/adapter/adapter.spec.js
+++ b/packages/memory-adapter/modules/adapter/adapter.spec.js
@@ -37,6 +37,14 @@ describe('when configuring', () => {
     );
   });
 
+  it('should invoke `onStatusStateChange` with configuring', () => {
+    expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configurationStatus: AdapterStatus.Configuring,
+      })
+    );
+  });
+
   describe('updating flags', () => {
     beforeEach(() => {
       updateFlags({ attempted: 'flagUpdate' });
@@ -62,14 +70,6 @@ describe('when configuring', () => {
 
     it('should resolve `waitUntilConfigured`', async () => {
       await expect(adapter.waitUntilConfigured()).resolves.not.toBeDefined();
-    });
-
-    it('should invoke `onStatusStateChange` with configuring', () => {
-      expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          configurationStatus: AdapterStatus.Configuring,
-        })
-      );
     });
 
     it('should invoke `onStatusStateChange` with configured', () => {
@@ -175,16 +175,24 @@ describe('when configuring', () => {
         adapter.setConfigurationStatus(AdapterStatus.Configuring);
       });
 
+      it('should invoke `onStatusStateChange` with configuring', () => {
+        expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            configurationStatus: AdapterStatus.Configuring,
+          })
+        );
+      });
+
       it('should indicate that the adapter is not configured', () => {
         expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
           false
         );
       });
 
-      it('should invoke `onStatusStateChange` with configuring', () => {
+      it('should invoke `onStatusStateChange` with configured', () => {
         expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
           expect.objectContaining({
-            configurationStatus: AdapterStatus.Configuring,
+            configurationStatus: AdapterStatus.Configured,
           })
         );
       });

--- a/packages/memory-adapter/modules/adapter/adapter.spec.js
+++ b/packages/memory-adapter/modules/adapter/adapter.spec.js
@@ -67,7 +67,7 @@ describe('when configuring', () => {
     it('should invoke `onStatusStateChange` with configuring', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: AdapterStatus.Configuring,
+          configurationStatus: AdapterStatus.Configuring,
         })
       );
     });
@@ -75,7 +75,7 @@ describe('when configuring', () => {
     it('should invoke `onStatusStateChange` with configured', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: AdapterStatus.Configured,
+          configurationStatus: AdapterStatus.Configured,
         })
       );
     });
@@ -184,7 +184,7 @@ describe('when configuring', () => {
       it('should invoke `onStatusStateChange` with configuring', () => {
         expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
           expect.objectContaining({
-            status: AdapterStatus.Configuring,
+            configurationStatus: AdapterStatus.Configuring,
           })
         );
       });

--- a/packages/memory-adapter/modules/adapter/adapter.spec.js
+++ b/packages/memory-adapter/modules/adapter/adapter.spec.js
@@ -14,6 +14,11 @@ const createAdapterEventHandlers = (custom = {}) => ({
   onStatusStateChange: jest.fn(),
   ...custom,
 });
+const AdapterStatus = {
+  Unconfigured: 0,
+  Configuring: 1,
+  Configured: 2,
+};
 
 describe('when configuring', () => {
   const updatedFlags = { fooFlag: true, barFlag: false };
@@ -26,8 +31,10 @@ describe('when configuring', () => {
     adapterEventHandlers = createAdapterEventHandlers();
   });
 
-  it('should indicate that the adapter is not ready', () => {
-    expect(adapter.getIsReady()).toBe(false);
+  it('should indicate that the adapter is not configured', () => {
+    expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
+      false
+    );
   });
 
   describe('updating flags', () => {
@@ -43,8 +50,10 @@ describe('when configuring', () => {
   describe('when configured', () => {
     beforeEach(() => adapter.configure(adapterArgs, adapterEventHandlers));
 
-    it('should indicate that the adapter is ready', () => {
-      expect(adapter.getIsReady()).toBe(true);
+    it('should indicate that the adapter is configured', () => {
+      expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
+        true
+      );
     });
 
     it('should invoke `onStatusStateChange`', () => {
@@ -55,18 +64,18 @@ describe('when configuring', () => {
       await expect(adapter.waitUntilConfigured()).resolves.not.toBeDefined();
     });
 
-    it('should invoke `onStatusStateChange` with `isReady`', () => {
+    it('should invoke `onStatusStateChange` with configuring', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
-          isReady: true,
+          status: AdapterStatus.Configuring,
         })
       );
     });
 
-    it('should invoke `onStatusStateChange` with `isConfigured`', () => {
+    it('should invoke `onStatusStateChange` with configured', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
-          isConfigured: true,
+          status: AdapterStatus.Configured,
         })
       );
     });
@@ -100,7 +109,6 @@ describe('when configuring', () => {
       describe('when flags are not normalized', () => {
         const nonNormalizedUpdatedFlags = {
           'flag-a-1': false,
-          // eslint-disable-next-line @typescript-eslint/camelcase
           flag_b: null,
         };
         beforeEach(() => {
@@ -160,21 +168,23 @@ describe('when configuring', () => {
       });
     });
 
-    describe('when setting ready state', () => {
+    describe('when setting configuration status to configuring', () => {
       beforeEach(() => {
         adapterEventHandlers.onStatusStateChange.mockClear();
 
-        adapter.setIsReady({ isReady: false });
+        adapter.setConfigurationStatus(AdapterStatus.Configuring);
       });
 
-      it('should indicate that the adapter is not ready', () => {
-        expect(adapter.getIsReady()).toBe(false);
+      it('should indicate that the adapter is not configured', () => {
+        expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
+          false
+        );
       });
 
-      it('should invoke `onStatusStateChange` with `isReady`', () => {
+      it('should invoke `onStatusStateChange` with configuring', () => {
         expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
           expect.objectContaining({
-            isReady: false,
+            status: AdapterStatus.Configuring,
           })
         );
       });

--- a/packages/memory-adapter/modules/adapter/adapter.spec.js
+++ b/packages/memory-adapter/modules/adapter/adapter.spec.js
@@ -1,3 +1,4 @@
+import { TAdapterConfigurationStatus } from '@flopflip/types';
 import warning from 'tiny-warning';
 import adapter, { getUser, updateFlags } from './adapter';
 
@@ -14,11 +15,6 @@ const createAdapterEventHandlers = (custom = {}) => ({
   onStatusStateChange: jest.fn(),
   ...custom,
 });
-const AdapterStatus = {
-  Unconfigured: 0,
-  Configuring: 1,
-  Configured: 2,
-};
 
 describe('when configuring', () => {
   const updatedFlags = { fooFlag: true, barFlag: false };
@@ -32,17 +28,9 @@ describe('when configuring', () => {
   });
 
   it('should indicate that the adapter is not configured', () => {
-    expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
-      false
-    );
-  });
-
-  it('should invoke `onStatusStateChange` with configuring', () => {
-    expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        configurationStatus: AdapterStatus.Configuring,
-      })
-    );
+    expect(
+      adapter.getIsConfigurationStatus(TAdapterConfigurationStatus.Configured)
+    ).toBe(false);
   });
 
   describe('updating flags', () => {
@@ -58,10 +46,18 @@ describe('when configuring', () => {
   describe('when configured', () => {
     beforeEach(() => adapter.configure(adapterArgs, adapterEventHandlers));
 
-    it('should indicate that the adapter is configured', () => {
-      expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
-        true
+    it('should invoke `onStatusStateChange` with configuring', () => {
+      expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          configurationStatus: TAdapterConfigurationStatus.Configuring,
+        })
       );
+    });
+
+    it('should indicate that the adapter is configured', () => {
+      expect(
+        adapter.getIsConfigurationStatus(TAdapterConfigurationStatus.Configured)
+      ).toBe(true);
     });
 
     it('should invoke `onStatusStateChange`', () => {
@@ -75,7 +71,7 @@ describe('when configuring', () => {
     it('should invoke `onStatusStateChange` with configured', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
         expect.objectContaining({
-          configurationStatus: AdapterStatus.Configured,
+          configurationStatus: TAdapterConfigurationStatus.Configured,
         })
       );
     });
@@ -172,27 +168,29 @@ describe('when configuring', () => {
       beforeEach(() => {
         adapterEventHandlers.onStatusStateChange.mockClear();
 
-        adapter.setConfigurationStatus(AdapterStatus.Configuring);
+        adapter.setConfigurationStatus(TAdapterConfigurationStatus.Configuring);
       });
 
       it('should invoke `onStatusStateChange` with configuring', () => {
         expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
           expect.objectContaining({
-            configurationStatus: AdapterStatus.Configuring,
+            configurationStatus: TAdapterConfigurationStatus.Configuring,
           })
         );
       });
 
       it('should indicate that the adapter is not configured', () => {
-        expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
-          false
-        );
+        expect(
+          adapter.getIsConfigurationStatus(
+            TAdapterConfigurationStatus.Configured
+          )
+        ).toBe(false);
       });
 
       it('should invoke `onStatusStateChange` with configured', () => {
         expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
           expect.objectContaining({
-            configurationStatus: AdapterStatus.Configured,
+            configurationStatus: TAdapterConfigurationStatus.Configuring,
           })
         );
       });

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -10,6 +10,7 @@ import {
   TAdapterEventHandlers,
   TMemoryAdapterInterface,
   TAdapterSubscriptionStatus,
+  TAdapterConfigurationStatus,
   TMemoryAdapterArgs,
   interfaceIdentifiers,
 } from '@flopflip/types';
@@ -22,7 +23,7 @@ type MemoryAdapterState = {
 };
 
 const intialAdapterState: TAdapterStatus & MemoryAdapterState = {
-  isReady: false,
+  configurationStatus: TAdapterConfigurationStatus.Unconfigured,
   subscriptionStatus: TAdapterSubscriptionStatus.Subscribed,
   flags: {},
   user: {},
@@ -68,16 +69,15 @@ export const normalizeFlags = (rawFlags: TFlags) =>
 export const getUser = () => adapterState.user;
 
 export const updateFlags = (flags: TFlags) => {
-  const isAdapterReady = Boolean(
-    adapterState.isConfigured && adapterState.isReady
-  );
+  const isAdapterConfigured =
+    adapterState.configurationStatus === TAdapterConfigurationStatus.Configured;
 
   warning(
-    isAdapterReady,
-    '@flopflip/memory-adapter: adapter not ready and configured. Flags can not be updated before.'
+    isAdapterConfigured,
+    '@flopflip/memory-adapter: adapter is not configured. Flags can not be updated before.'
   );
 
-  if (!isAdapterReady) return;
+  if (!isAdapterConfigured) return;
 
   adapterState.flags = {
     ...adapterState.flags,
@@ -98,39 +98,46 @@ class MemoryAdapter implements TMemoryAdapterInterface {
     adapterArgs: TMemoryAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
   ) {
+    const handleFlagsChange = (nextFlags: TFlags) => {
+      if (getIsUnsubscribed()) return;
+
+      adapterEventHandlers.onFlagsStateChange(nextFlags);
+    };
+
+    const handleStatusChange = (nextStatus: TAdapterStatus) => {
+      if (getIsUnsubscribed()) return;
+
+      adapterEventHandlers.onStatusStateChange(nextStatus);
+    };
+
+    adapterState.emitter.on('flagsStateChange', handleFlagsChange);
+    adapterState.emitter.on('statusStateChange', handleStatusChange);
+
+    adapterState.configurationStatus = TAdapterConfigurationStatus.Configuring;
+
+    adapterState.emitter.emit('statusStateChange', {
+      status: adapterState.configurationStatus,
+    });
+
     const { user } = adapterArgs;
 
     adapterState.user = user;
 
     return Promise.resolve().then(() => {
-      adapterState.isConfigured = true;
-      adapterState.isReady = true;
+      adapterState.configurationStatus =
+        TAdapterConfigurationStatus.Configuring;
       adapterState.flags = {};
 
       updateUser(user);
 
-      const handleFlagsChange = (nextFlags: TFlags) => {
-        if (getIsUnsubscribed()) return;
-
-        adapterEventHandlers.onFlagsStateChange(nextFlags);
-      };
-
-      const handleStatusChange = (nextStatus: TAdapterStatus) => {
-        if (getIsUnsubscribed()) return;
-
-        adapterEventHandlers.onStatusStateChange(nextStatus);
-      };
-
-      adapterState.emitter.on('flagsStateChange', handleFlagsChange);
-      adapterState.emitter.on('statusStateChange', handleStatusChange);
+      adapterState.configurationStatus = TAdapterConfigurationStatus.Configured;
 
       adapterState.emitter.emit('flagsStateChange', adapterState.flags);
       adapterState.emitter.emit('statusStateChange', {
-        isReady: adapterState.isReady,
-        isConfigured: adapterState.isConfigured,
+        status: adapterState.configurationStatus,
       });
 
-      adapterState.emitter.emit('readyStateChange');
+      adapterState.emitter.emit('__internalConfiguredStatusChange__');
     });
   }
 
@@ -138,27 +145,31 @@ class MemoryAdapter implements TMemoryAdapterInterface {
     adapterArgs: TMemoryAdapterArgs,
     _adapterEventHandlers: TAdapterEventHandlers
   ) {
+    adapterState.configurationStatus = TAdapterConfigurationStatus.Configuring;
+
     updateUser(adapterArgs.user);
 
     adapterState.flags = {};
 
+    adapterState.configurationStatus = TAdapterConfigurationStatus.Configured;
+
     adapterState.emitter.emit('flagsStateChange', adapterState.flags);
     adapterState.emitter.emit('statusStateChange', {
-      isConfigured: adapterState.isConfigured,
+      status: adapterState.configurationStatus,
     });
 
     return Promise.resolve();
   }
 
-  getIsReady() {
-    return Boolean(adapterState.isReady);
+  getIsConfigurationStatus(configurationStatus: TAdapterConfigurationStatus) {
+    return adapterState.configurationStatus === configurationStatus;
   }
 
-  setIsReady(nextState: TAdapterStatus) {
-    adapterState.isReady = nextState.isReady;
+  setConfigurationStatus(nextConfigurationStatus: TAdapterConfigurationStatus) {
+    adapterState.configurationStatus = nextConfigurationStatus;
 
     adapterState.emitter.emit('statusStateChange', {
-      isReady: adapterState.isReady,
+      status: adapterState.configurationStatus,
     });
   }
 
@@ -170,8 +181,13 @@ class MemoryAdapter implements TMemoryAdapterInterface {
 
   waitUntilConfigured() {
     return new Promise(resolve => {
-      if (adapterState.isConfigured) resolve();
-      else adapterState.emitter.on('readyStateChange', resolve);
+      if (
+        adapterState.configurationStatus ===
+        TAdapterConfigurationStatus.Configured
+      )
+        resolve();
+      else
+        adapterState.emitter.on('__internalConfiguredStatusChange__', resolve);
     });
   }
 

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -125,8 +125,6 @@ class MemoryAdapter implements TMemoryAdapterInterface {
     adapterState.user = user;
 
     return Promise.resolve().then(() => {
-      adapterState.configurationStatus =
-        TAdapterConfigurationStatus.Configuring;
       adapterState.flags = {};
 
       updateUser(user);

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -206,6 +206,18 @@ class MemoryAdapter implements TMemoryAdapterInterface {
   subscribe() {
     adapterState.subscriptionStatus = TAdapterSubscriptionStatus.Subscribed;
   }
+
+  // NOTE: This function is deprecated. Please use `getIsConfigurationStatus`.
+  getIsReady() {
+    warning(
+      false,
+      '@flopflip/memory-adapter: `getIsReady` has been deprecated. Please use `getIsConfigurationStatus` instead.'
+    );
+
+    return this.getIsConfigurationStatus(
+      TAdapterConfigurationStatus.Configured
+    );
+  }
 }
 
 const adapter = new MemoryAdapter();

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -3,6 +3,7 @@ import mitt, { Emitter } from 'mitt';
 import {
   TUser,
   TAdapterStatus,
+  TAdapterStatusChange,
   TFlagName,
   TFlagVariation,
   TFlag,
@@ -104,7 +105,7 @@ class MemoryAdapter implements TMemoryAdapterInterface {
       adapterEventHandlers.onFlagsStateChange(nextFlags);
     };
 
-    const handleStatusChange = (nextStatus: TAdapterStatus) => {
+    const handleStatusChange = (nextStatus: TAdapterStatusChange) => {
       if (getIsUnsubscribed()) return;
 
       adapterEventHandlers.onStatusStateChange(nextStatus);
@@ -116,7 +117,7 @@ class MemoryAdapter implements TMemoryAdapterInterface {
     adapterState.configurationStatus = TAdapterConfigurationStatus.Configuring;
 
     adapterState.emitter.emit('statusStateChange', {
-      status: adapterState.configurationStatus,
+      configurationStatus: adapterState.configurationStatus,
     });
 
     const { user } = adapterArgs;
@@ -134,7 +135,7 @@ class MemoryAdapter implements TMemoryAdapterInterface {
 
       adapterState.emitter.emit('flagsStateChange', adapterState.flags);
       adapterState.emitter.emit('statusStateChange', {
-        status: adapterState.configurationStatus,
+        configurationStatus: adapterState.configurationStatus,
       });
 
       adapterState.emitter.emit('__internalConfiguredStatusChange__');
@@ -155,7 +156,7 @@ class MemoryAdapter implements TMemoryAdapterInterface {
 
     adapterState.emitter.emit('flagsStateChange', adapterState.flags);
     adapterState.emitter.emit('statusStateChange', {
-      status: adapterState.configurationStatus,
+      configurationStatus: adapterState.configurationStatus,
     });
 
     return Promise.resolve();
@@ -169,7 +170,7 @@ class MemoryAdapter implements TMemoryAdapterInterface {
     adapterState.configurationStatus = nextConfigurationStatus;
 
     adapterState.emitter.emit('statusStateChange', {
-      status: adapterState.configurationStatus,
+      configurationStatus: adapterState.configurationStatus,
     });
   }
 

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -88,6 +88,8 @@ export const updateFlags = (flags: TFlags) => {
   adapterState.emitter.emit('flagsStateChange', adapterState.flags);
 };
 
+const __internalConfiguredStatusChange__ = '__internalConfiguredStatusChange__';
+
 class MemoryAdapter implements TMemoryAdapterInterface {
   id: typeof interfaceIdentifiers.memory;
 
@@ -136,7 +138,7 @@ class MemoryAdapter implements TMemoryAdapterInterface {
         configurationStatus: adapterState.configurationStatus,
       });
 
-      adapterState.emitter.emit('__internalConfiguredStatusChange__');
+      adapterState.emitter.emit(__internalConfiguredStatusChange__);
     });
   }
 
@@ -185,8 +187,7 @@ class MemoryAdapter implements TMemoryAdapterInterface {
         TAdapterConfigurationStatus.Configured
       )
         resolve();
-      else
-        adapterState.emitter.on('__internalConfiguredStatusChange__', resolve);
+      else adapterState.emitter.on(__internalConfiguredStatusChange__, resolve);
     });
   }
 

--- a/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
+++ b/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
@@ -17,7 +17,7 @@ describe('without `untoggledComponent', () => {
 
       const rendered = render(<TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(
         rendered.queryByFlagName('isFeatureEnabled')
@@ -32,7 +32,7 @@ describe('without `untoggledComponent', () => {
 
         const rendered = render(<TestComponent />);
 
-        await rendered.waitUntilReady();
+        await rendered.waitUntilConfigured();
 
         rendered.changeFlagVariation('disabledFeature', true);
 
@@ -51,7 +51,7 @@ describe('without `untoggledComponent', () => {
 
       const rendered = render(<TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveAttribute(
         'data-flag-status',
@@ -71,7 +71,7 @@ describe('with `untoggledComponent', () => {
 
       const rendered = render(<TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).not.toHaveAttribute(
         'data-flag-status',
@@ -87,7 +87,7 @@ describe('with `untoggledComponent', () => {
 
       const rendered = render(<TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveAttribute(
         'data-flag-status',
@@ -105,7 +105,7 @@ describe('with `untoggledComponent', () => {
 
       const rendered = render(<TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveAttribute(
         'data-flag-status',
@@ -121,7 +121,7 @@ describe('with `untoggledComponent', () => {
 
       const rendered = render(<TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).not.toHaveAttribute(
         'data-flag-status',

--- a/packages/react-broadcast/modules/components/configure/configure.spec.js
+++ b/packages/react-broadcast/modules/components/configure/configure.spec.js
@@ -6,12 +6,14 @@ import Configure from './configure';
 
 const testFlagName = 'firstFlag';
 const TestComponent = () => {
-  const { isReady, isConfigured } = useAdapterStatus();
+  const { isUnconfigured, isConfiguring, isConfigured } = useAdapterStatus();
+
   const isFeatureEnabled = useFeatureToggle(testFlagName);
 
   return (
     <ul>
-      <li>Is ready: {isReady ? 'Yes' : 'No'}</li>
+      <li>Is unconfigured: {isUnconfigured ? 'Yes' : 'No'}</li>
+      <li>Is configuring: {isConfiguring ? 'Yes' : 'No'}</li>
       <li>Is configured: {isConfigured ? 'Yes' : 'No'}</li>
       <li>Feature enabled: {isFeatureEnabled ? 'Yes' : 'No'}</li>
     </ul>
@@ -34,16 +36,16 @@ const render = () => {
       <TestComponent />
     </Configure>
   );
-  const waitUntilReady = () => rendered.findByText(/Is ready: Yes/i);
+  const waitUntilConfigured = () => rendered.findByText(/Is configured: Yes/i);
 
-  return { ...rendered, waitUntilReady };
+  return { ...rendered, waitUntilConfigured };
 };
 
 describe('when feature is disabled', () => {
   it('should indicate the feature being disabled', async () => {
     const rendered = render();
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByText(/Feature enabled: No/i)).toBeInTheDocument();
   });
@@ -53,7 +55,7 @@ describe('when enabling feature is', () => {
   it('should indicate the feature being enabled', async () => {
     const rendered = render();
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     act(() =>
       updateFlags({
@@ -65,24 +67,25 @@ describe('when enabling feature is', () => {
   });
 });
 
-describe('when not configured and not ready', () => {
+describe('when unconfiguring', () => {
   it('should indicate through the adapter state', async () => {
     const rendered = render();
+    rendered.debug();
 
-    expect(rendered.queryByText(/Is ready: No/i)).toBeInTheDocument();
+    expect(rendered.queryByText(/Is configuring: Yes/i)).toBeInTheDocument();
     expect(rendered.queryByText(/Is configured: No/i)).toBeInTheDocument();
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
   });
 });
 
-describe('when configured and ready', () => {
+describe('when configured', () => {
   it('should indicate through the adapter state', async () => {
     const rendered = render();
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
-    expect(rendered.queryByText(/Is ready: Yes/i)).toBeInTheDocument();
+    expect(rendered.queryByText(/Is configuring: No/i)).toBeInTheDocument();
     expect(rendered.queryByText(/Is configured: Yes/i)).toBeInTheDocument();
   });
 });

--- a/packages/react-broadcast/modules/components/configure/configure.spec.js
+++ b/packages/react-broadcast/modules/components/configure/configure.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render as rtlRender, act } from '@flopflip/test-utils';
+import { render as rtlRender, act, waitForElement } from '@flopflip/test-utils';
 import adapter, { updateFlags } from '@flopflip/memory-adapter';
 import { useFeatureToggle, useAdapterStatus } from '../../hooks';
 import Configure from './configure';
@@ -67,12 +67,12 @@ describe('when enabling feature is', () => {
   });
 });
 
-describe('when unconfiguring', () => {
+describe('when unconfigured', () => {
   it('should indicate through the adapter state', async () => {
     const rendered = render();
-    rendered.debug();
 
-    expect(rendered.queryByText(/Is configuring: Yes/i)).toBeInTheDocument();
+    expect(rendered.queryByText(/Is unconfigured: Yes/i)).toBeInTheDocument();
+    expect(rendered.queryByText(/Is configuring: No/i)).toBeInTheDocument();
     expect(rendered.queryByText(/Is configured: No/i)).toBeInTheDocument();
 
     await rendered.waitUntilConfigured();

--- a/packages/react-broadcast/modules/components/configure/configure.spec.js
+++ b/packages/react-broadcast/modules/components/configure/configure.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render as rtlRender, act, waitForElement } from '@flopflip/test-utils';
+import { render as rtlRender, act } from '@flopflip/test-utils';
 import adapter, { updateFlags } from '@flopflip/memory-adapter';
 import { useFeatureToggle, useAdapterStatus } from '../../hooks';
 import Configure from './configure';

--- a/packages/react-broadcast/modules/components/configure/configure.tsx
+++ b/packages/react-broadcast/modules/components/configure/configure.tsx
@@ -7,6 +7,7 @@ import {
   TAdapterStatusChange,
   TConfigureAdapterChildren,
   TConfigureAdapterProps,
+  TAdapterConfigurationStatus,
   TAdapterSubscriptionStatus,
 } from '@flopflip/types';
 import { ConfigureAdapter, useAdapterSubscription } from '@flopflip/react';
@@ -26,8 +27,8 @@ type State = {
 };
 
 const initialAdapterStatus: State['status'] = {
-  isReady: false,
   subscriptionStatus: TAdapterSubscriptionStatus.Subscribed,
+  configurationStatus: TAdapterConfigurationStatus.Unconfigured,
 };
 const initialFlags: State['flags'] = {};
 

--- a/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
@@ -21,7 +21,7 @@ describe('without `propKey`', () => {
         'false'
       );
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
     });
 
     describe('when enabling feature', () => {
@@ -32,7 +32,7 @@ describe('without `propKey`', () => {
 
         const rendered = render(<TestComponent />);
 
-        await rendered.waitUntilReady();
+        await rendered.waitUntilConfigured();
 
         rendered.changeFlagVariation('disabledFeature', true);
 
@@ -51,7 +51,7 @@ describe('without `propKey`', () => {
 
       const rendered = render(<TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveTextContent(
         'true'
@@ -69,7 +69,7 @@ describe('with `propKey`', () => {
       )(components.FlagsToComponent);
       const rendered = render(<TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('customPropKey')).toHaveTextContent(
         'false'

--- a/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
+++ b/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
@@ -24,7 +24,7 @@ describe('without `propKey`', () => {
 
     const rendered = render(<TestComponent />);
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByFlagName('enabledFeature')).toHaveTextContent(
       'true'
@@ -39,7 +39,7 @@ describe('without `propKey`', () => {
 
     const rendered = render(<TestComponent />);
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByFlagName('disabledFeature')).toHaveTextContent(
       'false'
@@ -55,7 +55,7 @@ describe('without `propKey`', () => {
 
       const rendered = render(<TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       rendered.changeFlagVariation('disabledFeature', true);
 
@@ -75,7 +75,7 @@ describe('with `propKey`', () => {
 
     const rendered = render(<TestComponent />);
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByFlagName('enabledFeature')).toHaveTextContent(
       'true'
@@ -90,7 +90,7 @@ describe('with `propKey`', () => {
 
     const rendered = render(<TestComponent />);
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByFlagName('disabledFeature')).toHaveTextContent(
       'false'

--- a/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.spec.js
+++ b/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.spec.js
@@ -24,14 +24,14 @@ describe('when feature is disabled', () => {
 
     expect(rendered.queryByFlagName('disabledFeature')).not.toBeInTheDocument();
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
   });
 
   describe('when enabling feature', () => {
     it('should render the component representing a enabled feature', async () => {
       const rendered = render(<TestEnabledComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       rendered.changeFlagVariation('disabledFeature', true);
 
@@ -44,7 +44,7 @@ describe('when feature is enabled', () => {
   it('should render the component representing a enabled feature', async () => {
     const rendered = render(<TestDisabledComponent />);
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByFlagName('enabledFeature')).toHaveAttribute(
       'data-flag-status',

--- a/packages/react-broadcast/modules/hooks/use-adapter-status/use-adapter-status.spec.js
+++ b/packages/react-broadcast/modules/hooks/use-adapter-status/use-adapter-status.spec.js
@@ -9,36 +9,30 @@ const render = TestComponent =>
   });
 
 const TestComponent = () => {
-  const { isReady, isConfigured } = useAdapterStatus();
+  const { isConfiguring, isConfigured } = useAdapterStatus();
 
   return (
     <ul>
-      <li>Is ready: {isReady ? 'Yes' : 'No'}</li>
+      <li>Is configuring: {isConfiguring ? 'Yes' : 'No'}</li>
       <li>Is configured: {isConfigured ? 'Yes' : 'No'}</li>
     </ul>
   );
 };
 
-it('should indicate the adapter not being ready', async () => {
+it('should indicate the adapter not configured yet', async () => {
   const rendered = render(<TestComponent />);
 
-  expect(rendered.queryByText('Is ready: No')).toBeInTheDocument();
+  expect(rendered.queryByText(/Is configuring: Yes/i)).toBeInTheDocument();
+  expect(rendered.queryByText(/Is configured: No/i)).toBeInTheDocument();
 
-  await rendered.waitUntilReady();
+  await rendered.waitUntilConfigured();
 });
 
-it('should indicate the adapter being ready', async () => {
+it('should indicate the adapter is configured', async () => {
   const rendered = render(<TestComponent />);
 
-  await rendered.waitUntilReady();
+  await rendered.waitUntilConfigured();
 
-  expect(rendered.queryByText('Is ready: Yes')).toBeInTheDocument();
-});
-
-it('should indicate the adapter being configured', async () => {
-  const rendered = render(<TestComponent />);
-
-  await rendered.waitUntilReady();
-
-  expect(rendered.queryByText('Is configured: Yes')).toBeInTheDocument();
+  expect(rendered.queryByText(/Is configuring: No/i)).toBeInTheDocument();
+  expect(rendered.queryByText(/Is configured: Yes/i)).toBeInTheDocument();
 });

--- a/packages/react-broadcast/modules/hooks/use-adapter-status/use-adapter-status.ts
+++ b/packages/react-broadcast/modules/hooks/use-adapter-status/use-adapter-status.ts
@@ -1,11 +1,17 @@
 import React from 'react';
-import { AdapterContext } from '@flopflip/react';
-import { TAdapterContext } from '@flopflip/types';
+import {
+  useAdapterContext,
+  selectAdapterConfigurationStatus,
+} from '@flopflip/react';
 
 export default function useAdapterStatus() {
-  const adapterContext: TAdapterContext = React.useContext(AdapterContext);
+  const { status } = useAdapterContext();
 
-  React.useDebugValue(adapterContext.status);
+  const adapterStatus = selectAdapterConfigurationStatus(
+    status.configurationStatus
+  );
 
-  return adapterContext.status;
+  React.useDebugValue(adapterStatus);
+
+  return adapterStatus;
 }

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
@@ -25,7 +25,7 @@ const TestComponent = () => {
 it('should indicate a feature being disabled', async () => {
   const rendered = render(<TestComponent />);
 
-  await rendered.waitUntilReady();
+  await rendered.waitUntilConfigured();
 
   expect(rendered.queryByText('Is disabled: Yes')).toBeInTheDocument();
 });
@@ -33,7 +33,7 @@ it('should indicate a feature being disabled', async () => {
 it('should indicate a feature being enabled', async () => {
   const rendered = render(<TestComponent />);
 
-  await rendered.waitUntilReady();
+  await rendered.waitUntilConfigured();
 
   expect(rendered.queryByText('Is enabled: Yes')).toBeInTheDocument();
 });

--- a/packages/react-broadcast/modules/hooks/use-feature-toggles/use-feature-toggles.spec.js
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggles/use-feature-toggles.spec.js
@@ -28,7 +28,7 @@ const TestComponent = () => {
 it('should indicate a feature being disabled', async () => {
   const rendered = render(<TestComponent />);
 
-  await rendered.waitUntilReady();
+  await rendered.waitUntilConfigured();
 
   expect(rendered.queryByText('Is disabled: Yes')).toBeInTheDocument();
 });
@@ -36,7 +36,7 @@ it('should indicate a feature being disabled', async () => {
 it('should indicate a feature being enabled', async () => {
   const rendered = render(<TestComponent />);
 
-  await rendered.waitUntilReady();
+  await rendered.waitUntilConfigured();
 
   expect(rendered.queryByText('Is enabled: Yes')).toBeInTheDocument();
 });

--- a/packages/react-broadcast/modules/hooks/use-flag-variations/use-flag-variations.spec.js
+++ b/packages/react-broadcast/modules/hooks/use-flag-variations/use-flag-variations.spec.js
@@ -27,7 +27,7 @@ const TestComponent = () => {
 it('should indicate a feature being disabled', async () => {
   const rendered = render(<TestComponent />);
 
-  await rendered.waitUntilReady();
+  await rendered.waitUntilConfigured();
 
   expect(rendered.queryByText('Is disabled: Yes')).toBeInTheDocument();
 });
@@ -35,7 +35,7 @@ it('should indicate a feature being disabled', async () => {
 it('should indicate a feature being enabled', async () => {
   const rendered = render(<TestComponent />);
 
-  await rendered.waitUntilReady();
+  await rendered.waitUntilConfigured();
 
   expect(rendered.queryByText('Is enabled: Yes')).toBeInTheDocument();
 });
@@ -43,7 +43,7 @@ it('should indicate a feature being enabled', async () => {
 it('should indicate a flag variation', async () => {
   const rendered = render(<TestComponent />);
 
-  await rendered.waitUntilReady();
+  await rendered.waitUntilConfigured();
 
   expect(rendered.queryByText('Variation: A')).toBeInTheDocument();
 });

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.spec.js
@@ -26,7 +26,7 @@ describe('without `untoggledComponent', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(
         rendered.queryByFlagName('isFeatureEnabled')
@@ -44,7 +44,7 @@ describe('without `untoggledComponent', () => {
 
         const rendered = render(store, <TestComponent />);
 
-        await rendered.waitUntilReady();
+        await rendered.waitUntilConfigured();
 
         rendered.changeFlagVariation('disabledFeature', true);
 
@@ -66,7 +66,7 @@ describe('without `untoggledComponent', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveAttribute(
         'data-flag-status',
@@ -89,7 +89,7 @@ describe('with `untoggledComponent', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).not.toHaveAttribute(
         'data-flag-status',
@@ -108,7 +108,7 @@ describe('with `untoggledComponent', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveAttribute(
         'data-flag-status',
@@ -128,7 +128,7 @@ describe('with `untoggledComponent', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveAttribute(
         'data-flag-status',
@@ -146,7 +146,7 @@ describe('with `untoggledComponent', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).not.toHaveAttribute(
         'data-flag-status',

--- a/packages/react-redux/modules/components/configure/configure.spec.js
+++ b/packages/react-redux/modules/components/configure/configure.spec.js
@@ -9,12 +9,13 @@ import Configure from './configure';
 
 const testFlagName = 'firstFlag';
 const TestComponent = () => {
-  const { isReady, isConfigured } = useAdapterStatus();
+  const { isUnconfigured, isConfiguring, isConfigured } = useAdapterStatus();
   const isFeatureEnabled = useFeatureToggle(testFlagName);
 
   return (
     <ul>
-      <li>Is ready: {isReady ? 'Yes' : 'No'}</li>
+      <li>Is unconfigured: {isUnconfigured ? 'Yes' : 'No'}</li>
+      <li>Is configuring: {isConfiguring ? 'Yes' : 'No'}</li>
       <li>Is configured: {isConfigured ? 'Yes' : 'No'}</li>
       <li>Feature enabled: {isFeatureEnabled ? 'Yes' : 'No'}</li>
     </ul>
@@ -35,9 +36,10 @@ const render = () => {
     </Provider>
   );
 
-  const waitUntilReady = () => rtlRendered.findByText(`Is ready: Yes`);
+  const waitUntilConfigured = () =>
+    rtlRendered.findByText(/Is configured: Yes/i);
 
-  return { ...rtlRendered, waitUntilReady };
+  return { ...rtlRendered, waitUntilConfigured };
 };
 
 const createTestProps = custom => ({
@@ -53,7 +55,7 @@ describe('when feature is disabled', () => {
   it('should indicate the feature being disabled', async () => {
     const rendered = render();
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByText(/Feature enabled: No/i)).toBeInTheDocument();
   });
@@ -69,31 +71,31 @@ describe('when enabling feature is', () => {
       [testFlagName]: true,
     });
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByText(/Feature enabled: Yes/i)).toBeInTheDocument();
   });
 });
 
-describe('when not configured and not ready', () => {
+describe('when not configured and configuring', () => {
   it('should indicate through the adapter state', async () => {
     const rendered = render();
 
-    expect(rendered.queryByText(/Is ready: No/i)).toBeInTheDocument();
+    expect(rendered.queryByText(/Is configuring: Yes/i)).toBeInTheDocument();
     expect(rendered.queryByText(/Is configured: No/i)).toBeInTheDocument();
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
   });
 });
 
-describe('when configured and ready', () => {
+describe('when configured', () => {
   it('should indicate through the adapter state', async () => {
     const rendered = render();
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
     await adapter.waitUntilConfigured();
 
-    expect(rendered.queryByText(/Is ready: Yes/i)).toBeInTheDocument();
+    expect(rendered.queryByText(/Is configuring: No/i)).toBeInTheDocument();
     expect(rendered.queryByText(/Is configured: Yes/i)).toBeInTheDocument();
   });
 });

--- a/packages/react-redux/modules/components/configure/configure.spec.js
+++ b/packages/react-redux/modules/components/configure/configure.spec.js
@@ -77,11 +77,12 @@ describe('when enabling feature is', () => {
   });
 });
 
-describe('when not configured and configuring', () => {
+describe('when unconfigured', () => {
   it('should indicate through the adapter state', async () => {
     const rendered = render();
 
-    expect(rendered.queryByText(/Is configuring: Yes/i)).toBeInTheDocument();
+    expect(rendered.queryByText(/Is unconfigured: Yes/i)).toBeInTheDocument();
+    expect(rendered.queryByText(/Is configuring: No/i)).toBeInTheDocument();
     expect(rendered.queryByText(/Is configured: No/i)).toBeInTheDocument();
 
     await rendered.waitUntilConfigured();

--- a/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
+++ b/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.spec.js
@@ -26,7 +26,7 @@ describe('without `propKey`', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveTextContent(
         'false'
@@ -44,7 +44,7 @@ describe('without `propKey`', () => {
 
         const rendered = render(store, <TestComponent />);
 
-        await rendered.waitUntilReady();
+        await rendered.waitUntilConfigured();
 
         rendered.changeFlagVariation('disabledFeature', true);
 
@@ -66,7 +66,7 @@ describe('without `propKey`', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('isFeatureEnabled')).toHaveTextContent(
         'true'
@@ -88,7 +88,7 @@ describe('with `propKey`', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('customPropKey')).toHaveTextContent(
         'false'

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.spec.js
@@ -35,7 +35,7 @@ describe('injectFeatureToggles', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('enabledFeature')).toHaveTextContent(
         'true'
@@ -55,7 +55,7 @@ describe('injectFeatureToggles', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('disabledFeature')).toHaveTextContent(
         'false'
@@ -76,7 +76,7 @@ describe('injectFeatureToggles', () => {
 
         const rendered = render(store, <TestComponent />);
 
-        await rendered.waitUntilReady();
+        await rendered.waitUntilConfigured();
 
         rendered.changeFlagVariation('disabledFeature', true);
 
@@ -101,7 +101,7 @@ describe('injectFeatureToggles', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('enabledFeature')).toHaveTextContent(
         'true'
@@ -121,7 +121,7 @@ describe('injectFeatureToggles', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('disabledFeature')).toHaveTextContent(
         'false'

--- a/packages/react-redux/modules/components/toggle-feature/toggle-feature.spec.js
+++ b/packages/react-redux/modules/components/toggle-feature/toggle-feature.spec.js
@@ -28,7 +28,7 @@ describe('<ToggleFeature>', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(
         rendered.queryByFlagName('disabledFeature')
@@ -48,7 +48,7 @@ describe('<ToggleFeature>', () => {
 
         const rendered = render(store, <TestComponent />);
 
-        await rendered.waitUntilReady();
+        await rendered.waitUntilConfigured();
 
         rendered.changeFlagVariation('disabledFeature', true);
 
@@ -70,7 +70,7 @@ describe('<ToggleFeature>', () => {
 
       const rendered = render(store, <TestComponent />);
 
-      await rendered.waitUntilReady();
+      await rendered.waitUntilConfigured();
 
       expect(rendered.queryByFlagName('enabledFeature')).toHaveAttribute(
         'data-flag-status',

--- a/packages/react-redux/modules/ducks/status/status.spec.js
+++ b/packages/react-redux/modules/ducks/status/status.spec.js
@@ -1,3 +1,4 @@
+import { TAdapterConfigurationStatus } from '@flopflip/types';
 import { STATE_SLICE } from '../../store/constants';
 import reducer, { UPDATE_STATUS, updateStatus, selectStatus } from './status';
 
@@ -16,10 +17,18 @@ describe('action creators', () => {
       });
     });
 
-    it('should return passed `isReady` status', () => {
-      expect(updateStatus({ isReady: true })).toEqual({
+    it('should return passed configuration status', () => {
+      expect(
+        updateStatus({
+          configurationStatus: TAdapterConfigurationStatus.Configured,
+        })
+      ).toEqual({
         type: expect.any(String),
-        payload: { status: { isReady: true } },
+        payload: {
+          status: {
+            configurationStatus: TAdapterConfigurationStatus.Configured,
+          },
+        },
       });
     });
   });
@@ -31,14 +40,16 @@ describe('reducers', () => {
       let payload;
       beforeEach(() => {
         payload = {
-          status: { isReady: true },
+          status: {
+            configurationStatus: TAdapterConfigurationStatus.Configuring,
+          },
         };
       });
 
       it('should set the new status', () => {
         expect(reducer(undefined, { type: UPDATE_STATUS, payload })).toEqual(
           expect.objectContaining({
-            isReady: payload.status.isReady,
+            configurationStatus: TAdapterConfigurationStatus.Configuring,
           })
         );
       });
@@ -48,15 +59,20 @@ describe('reducers', () => {
       let payload;
       beforeEach(() => {
         payload = {
-          status: { isReady: false },
+          status: {
+            configurationStatus: TAdapterConfigurationStatus.Configuring,
+          },
         };
       });
 
       it('should set the new status', () => {
         expect(
-          reducer({ isReady: true }, { type: UPDATE_STATUS, payload })
+          reducer(
+            { configurationStatus: TAdapterConfigurationStatus.Configured },
+            { type: UPDATE_STATUS, payload }
+          )
         ).toEqual({
-          isReady: payload.status.isReady,
+          configurationStatus: TAdapterConfigurationStatus.Configuring,
         });
       });
     });
@@ -69,8 +85,8 @@ describe('selectors', () => {
 
   beforeEach(() => {
     status = {
-      isReady: true,
-      isConfigured: false,
+      configurationStatus: TAdapterConfigurationStatus.Configuring,
+      subscriptionStatus: {},
     };
     state = {
       [STATE_SLICE]: {
@@ -83,7 +99,8 @@ describe('selectors', () => {
     it('should return configuration and ready status', () => {
       expect(selectStatus(state)).toEqual(
         expect.objectContaining({
-          isReady: true,
+          isConfiguring: true,
+          isConfigured: false,
         })
       );
     });

--- a/packages/react-redux/modules/ducks/status/status.ts
+++ b/packages/react-redux/modules/ducks/status/status.ts
@@ -4,6 +4,7 @@ import {
   TAdapterSubscriptionStatus,
   TAdapterConfigurationStatus,
 } from '@flopflip/types';
+import { selectAdapterConfigurationStatus } from '@flopflip/react';
 import { TUpdateStatusAction } from './types';
 import { TState } from '../../types';
 import { STATE_SLICE } from '../../store/constants';
@@ -47,14 +48,5 @@ export const updateStatus = (
 export const selectStatus = (state: TState) => {
   const { status } = state[STATE_SLICE];
 
-  return {
-    isReady:
-      status?.configurationStatus === TAdapterConfigurationStatus.Configured,
-    isUnconfigured:
-      status?.configurationStatus === TAdapterConfigurationStatus.Unconfigured,
-    isConfiguring:
-      status?.configurationStatus === TAdapterConfigurationStatus.Configuring,
-    isConfigured:
-      status?.configurationStatus === TAdapterConfigurationStatus.Configured,
-  };
+  return selectAdapterConfigurationStatus(status?.configurationStatus);
 };

--- a/packages/react-redux/modules/ducks/status/status.ts
+++ b/packages/react-redux/modules/ducks/status/status.ts
@@ -2,6 +2,7 @@ import {
   TAdapterStatus,
   TAdapterStatusChange,
   TAdapterSubscriptionStatus,
+  TAdapterConfigurationStatus,
 } from '@flopflip/types';
 import { TUpdateStatusAction } from './types';
 import { TState } from '../../types';
@@ -11,8 +12,8 @@ import { STATE_SLICE } from '../../store/constants';
 export const UPDATE_STATUS = '@flopflip/status/update';
 
 const initialState: TAdapterStatus = {
-  isReady: false,
   subscriptionStatus: TAdapterSubscriptionStatus.Subscribed,
+  configurationStatus: TAdapterConfigurationStatus.Unconfigured,
 };
 
 // Reducer
@@ -37,10 +38,23 @@ export default reducer;
 
 // Action Creators
 export const updateStatus = (
-  status: TAdapterStatusChange
+  nextStatus: TAdapterStatusChange
 ): TUpdateStatusAction => ({
   type: UPDATE_STATUS,
-  payload: { status },
+  payload: { status: nextStatus },
 });
 // Selectors
-export const selectStatus = (state: TState) => state[STATE_SLICE].status ?? {};
+export const selectStatus = (state: TState) => {
+  const { status } = state[STATE_SLICE];
+
+  return {
+    isReady:
+      status?.configurationStatus === TAdapterConfigurationStatus.Configured,
+    isUnconfigured:
+      status?.configurationStatus === TAdapterConfigurationStatus.Unconfigured,
+    isConfiguring:
+      status?.configurationStatus === TAdapterConfigurationStatus.Configuring,
+    isConfigured:
+      status?.configurationStatus === TAdapterConfigurationStatus.Configured,
+  };
+};

--- a/packages/react-redux/modules/hooks/use-adapter-status/use-adapter-status.spec.js
+++ b/packages/react-redux/modules/hooks/use-adapter-status/use-adapter-status.spec.js
@@ -15,48 +15,38 @@ const render = (store, TestComponent) =>
   });
 
 const TestComponent = () => {
-  const { isReady, isConfigured } = useAdapterStatus();
+  const { isConfiguring, isConfigured } = useAdapterStatus();
 
   return (
     <ul>
-      <li>Is ready: {isReady ? 'Yes' : 'No'}</li>
+      <li>Is configuring: {isConfiguring ? 'Yes' : 'No'}</li>
       <li>Is configured: {isConfigured ? 'Yes' : 'No'}</li>
     </ul>
   );
 };
 
-it('should indicate the adapter not being ready', async () => {
+it('should indicate the adapter not configured yet', async () => {
   const store = createStore({
     [STATE_SLICE]: { flags: { disabledFeature: false } },
   });
 
   const rendered = render(store, <TestComponent />);
 
-  expect(rendered.queryByText('Is ready: No')).toBeInTheDocument();
+  expect(rendered.queryByText(/Is configured: No/i)).toBeInTheDocument();
+  expect(rendered.queryByText(/Is configuring: Yes/i)).toBeInTheDocument();
 
-  await rendered.waitUntilReady();
+  await rendered.waitUntilConfigured();
 });
 
-it('should indicate the adapter being ready', async () => {
+it('should indicate the adapter is configured and not configuring any longer', async () => {
   const store = createStore({
     [STATE_SLICE]: { flags: { disabledFeature: false } },
   });
 
   const rendered = render(store, <TestComponent />);
 
-  await rendered.waitUntilReady();
+  await rendered.waitUntilConfigured();
 
-  expect(rendered.queryByText('Is ready: Yes')).toBeInTheDocument();
-});
-
-it('should indicate the adapter being configured', async () => {
-  const store = createStore({
-    [STATE_SLICE]: { flags: { disabledFeature: false } },
-  });
-
-  const rendered = render(store, <TestComponent />);
-
-  await rendered.waitUntilReady();
-
-  expect(rendered.queryByText('Is configured: Yes')).toBeInTheDocument();
+  expect(rendered.queryByText(/Is configured: Yes/i)).toBeInTheDocument();
+  expect(rendered.queryByText(/Is configuring: No/i)).toBeInTheDocument();
 });

--- a/packages/react-redux/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
+++ b/packages/react-redux/modules/hooks/use-feature-toggle/use-feature-toggle.spec.js
@@ -28,14 +28,14 @@ const TestComponent = () => {
   );
 };
 
-describe('when adapter is ready', () => {
+describe('when adapter is configured', () => {
   it('should indicate a feature being disabled', async () => {
     const store = createStore({
       [STATE_SLICE]: { flags: { disabledFeature: false } },
     });
     const rendered = render(store, <TestComponent />);
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByText('Is disabled: Yes')).toBeInTheDocument();
   });
@@ -47,7 +47,7 @@ describe('when adapter is ready', () => {
 
     const rendered = render(store, <TestComponent />);
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByText('Is enabled: Yes')).toBeInTheDocument();
   });

--- a/packages/react-redux/modules/hooks/use-feature-toggles/use-feature-toggles.spec.js
+++ b/packages/react-redux/modules/hooks/use-feature-toggles/use-feature-toggles.spec.js
@@ -31,15 +31,15 @@ const TestComponent = () => {
   );
 };
 
-describe('when adapter is ready', () => {
+describe('when adapter is configured', () => {
   it('should indicate a feature being disabled', async () => {
     const store = createStore({
       [STATE_SLICE]: { flags: { disabledFeature: false } },
     });
 
-    const { getByText, waitUntilReady } = render(store, <TestComponent />);
+    const { getByText, waitUntilConfigured } = render(store, <TestComponent />);
 
-    await waitUntilReady();
+    await waitUntilConfigured();
 
     expect(getByText('Is disabled: Yes')).toBeInTheDocument();
   });
@@ -49,9 +49,9 @@ describe('when adapter is ready', () => {
       [STATE_SLICE]: { flags: { disabledFeature: false } },
     });
 
-    const { getByText, waitUntilReady } = render(store, <TestComponent />);
+    const { getByText, waitUntilConfigured } = render(store, <TestComponent />);
 
-    await waitUntilReady();
+    await waitUntilConfigured();
 
     expect(getByText('Is enabled: Yes')).toBeInTheDocument();
   });

--- a/packages/react-redux/modules/hooks/use-flag-variations/use-flag-variations.spec.js
+++ b/packages/react-redux/modules/hooks/use-flag-variations/use-flag-variations.spec.js
@@ -30,7 +30,7 @@ const TestComponent = () => {
   );
 };
 
-describe('when adaopter is ready', () => {
+describe('when adaopter is configured', () => {
   it('should indicate a feature being disabled', async () => {
     const store = createStore({
       [STATE_SLICE]: {
@@ -44,7 +44,7 @@ describe('when adaopter is ready', () => {
 
     const rendered = render(store, <TestComponent />);
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByText('Is disabled: Yes')).toBeInTheDocument();
   });
@@ -62,7 +62,7 @@ describe('when adaopter is ready', () => {
 
     const rendered = render(store, <TestComponent />);
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByText('Is enabled: Yes')).toBeInTheDocument();
   });
@@ -80,7 +80,7 @@ describe('when adaopter is ready', () => {
 
     const rendered = render(store, <TestComponent />);
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByText('Variation: A')).toBeInTheDocument();
   });

--- a/packages/react-redux/modules/store/enhancer/enhancer.spec.js
+++ b/packages/react-redux/modules/store/enhancer/enhancer.spec.js
@@ -1,3 +1,4 @@
+import { TAdapterConfigurationStatus } from '@flopflip/types';
 import { updateFlags, updateStatus } from '../../ducks';
 import createFlopFlipEnhancer from './enhancer';
 
@@ -71,7 +72,7 @@ describe('when creating enhancer', () => {
 
     describe('when invoking  `onStatusStateChange`', () => {
       let nextStatus = {
-        isReady: true,
+        adapterConfigurationStatus: TAdapterConfigurationStatus.Configured,
       };
 
       beforeEach(() => {

--- a/packages/react/modules/components/adapter-context/adapter-context.spec.js
+++ b/packages/react/modules/components/adapter-context/adapter-context.spec.js
@@ -1,0 +1,62 @@
+import { TAdapterConfigurationStatus } from '@flopflip/types';
+import { selectAdapterConfigurationStatus } from './adapter-context';
+
+describe('selectAdapterConfigurationStatus', () => {
+  describe('when configured', () => {
+    it('should indicate ready state', () => {
+      expect(
+        selectAdapterConfigurationStatus(TAdapterConfigurationStatus.Configured)
+      ).toEqual(
+        expect.objectContaining({
+          isReady: true,
+        })
+      );
+    });
+    it('should indicate configured state', () => {
+      expect(
+        selectAdapterConfigurationStatus(TAdapterConfigurationStatus.Configured)
+      ).toEqual(
+        expect.objectContaining({
+          isConfigured: true,
+        })
+      );
+    });
+  });
+  describe('when configuring', () => {
+    it('should indicate configuring state', () => {
+      expect(
+        selectAdapterConfigurationStatus(
+          TAdapterConfigurationStatus.Configuring
+        )
+      ).toEqual(
+        expect.objectContaining({
+          isConfiguring: true,
+        })
+      );
+    });
+    it('should not indicate configured state', () => {
+      expect(
+        selectAdapterConfigurationStatus(
+          TAdapterConfigurationStatus.Configuring
+        )
+      ).toEqual(
+        expect.objectContaining({
+          isConfigured: false,
+        })
+      );
+    });
+  });
+  describe('when unconfigured', () => {
+    it('should indicate unconfigured', () => {
+      expect(
+        selectAdapterConfigurationStatus(
+          TAdapterConfigurationStatus.Unconfigured
+        )
+      ).toEqual(
+        expect.objectContaining({
+          isUnconfigured: true,
+        })
+      );
+    });
+  });
+});

--- a/packages/react/modules/components/adapter-context/adapter-context.ts
+++ b/packages/react/modules/components/adapter-context/adapter-context.ts
@@ -4,13 +4,13 @@ import {
   TAdapterStatus,
   TReconfigureAdapter,
   TAdapterSubscriptionStatus,
+  TAdapterConfigurationStatus,
 } from '@flopflip/types';
 
 const initialReconfigureAdapter: TReconfigureAdapter = () => undefined;
 const initialAdapterStatus: TAdapterStatus = {
   subscriptionStatus: TAdapterSubscriptionStatus.Subscribed,
-  isReady: false,
-  isConfigured: false,
+  configurationStatus: TAdapterConfigurationStatus.Unconfigured,
 };
 const createAdapterContext = (
   reconfigure?: TReconfigureAdapter,
@@ -23,5 +23,22 @@ const createAdapterContext = (
 const initialAdapterContext = createAdapterContext();
 const AdapterContext = React.createContext(initialAdapterContext);
 
+const selectAdapterConfigurationStatus = (
+  configurationStatus: TAdapterConfigurationStatus
+) => ({
+  isReady: configurationStatus === TAdapterConfigurationStatus.Configured,
+  isUnconfigured:
+    configurationStatus === TAdapterConfigurationStatus.Unconfigured,
+  isConfiguring:
+    configurationStatus === TAdapterConfigurationStatus.Configuring,
+  isConfigured: configurationStatus === TAdapterConfigurationStatus.Configured,
+});
+
+const useAdapterContext = () => React.useContext(AdapterContext);
+
 export default AdapterContext;
-export { createAdapterContext };
+export {
+  createAdapterContext,
+  useAdapterContext,
+  selectAdapterConfigurationStatus,
+};

--- a/packages/react/modules/components/adapter-context/adapter-context.ts
+++ b/packages/react/modules/components/adapter-context/adapter-context.ts
@@ -24,7 +24,7 @@ const initialAdapterContext = createAdapterContext();
 const AdapterContext = React.createContext(initialAdapterContext);
 
 const selectAdapterConfigurationStatus = (
-  configurationStatus: TAdapterConfigurationStatus
+  configurationStatus?: TAdapterConfigurationStatus
 ) => ({
   isReady: configurationStatus === TAdapterConfigurationStatus.Configured,
   isUnconfigured:

--- a/packages/react/modules/components/adapter-context/index.ts
+++ b/packages/react/modules/components/adapter-context/index.ts
@@ -1,2 +1,6 @@
 export { default } from './adapter-context';
-export { createAdapterContext } from './adapter-context';
+export {
+  createAdapterContext,
+  useAdapterContext,
+  selectAdapterConfigurationStatus,
+} from './adapter-context';

--- a/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
@@ -1,10 +1,13 @@
+import { TAdapterConfigurationStatus } from '@flopflip/types';
 import React from 'react';
 import { render as rtlRender, wait } from '@flopflip/test-utils';
 import AdapterContext from '../adapter-context';
 import ConfigureAdapter, { AdapterStates } from './configure-adapter';
 
 const createAdapter = () => ({
-  getIsReady: jest.fn(() => false),
+  getIsConfigurationStatus: jest.fn(
+    () => TAdapterConfigurationStatus.Unconfigured
+  ),
   configure: jest.fn(() => Promise.resolve()),
   reconfigure: jest.fn(() => Promise.resolve()),
 });
@@ -61,11 +64,11 @@ const render = ({ props, adapter }) => {
 
 describe('rendering', () => {
   describe('when providing render prop', () => {
-    describe('when adapter is ready', () => {
+    describe('when adapter is configured', () => {
       it('should invoke render prop', async () => {
         const adapter = createAdapter();
-        adapter.getIsReady.mockReturnValue(true);
         const props = { render: jest.fn(() => <TestComponent />) };
+        adapter.getIsConfigurationStatus.mockReturnValue(true);
 
         const rendered = render({ props, adapter });
 
@@ -75,7 +78,7 @@ describe('rendering', () => {
       });
     });
 
-    describe('when adapter is not ready', () => {
+    describe('when adapter is not configured', () => {
       it('should invoke render prop', async () => {
         const adapter = createAdapter();
 
@@ -91,11 +94,13 @@ describe('rendering', () => {
   });
 
   describe('when providing function as a child', () => {
-    describe('when adapter is ready', () => {
+    describe('when adapter is configured', () => {
       it('should invoke children prop with ready state', async () => {
         const adapter = createAdapter();
 
-        adapter.getIsReady.mockReturnValue(true);
+        adapter.getIsConfigurationStatus.mockReturnValue(
+          TAdapterConfigurationStatus.Configured
+        );
 
         const props = { children: jest.fn(() => <TestComponent />) };
 
@@ -111,11 +116,13 @@ describe('rendering', () => {
   });
 
   describe('when providing React node as children', () => {
-    describe('when adapter is ready', () => {
+    describe('when adapter is configured', () => {
       it('should invoke render prop', async () => {
         const adapter = createAdapter();
 
-        adapter.getIsReady.mockReturnValue(true);
+        adapter.getIsConfigurationStatus.mockReturnValue(
+          TAdapterConfigurationStatus.Configured
+        );
 
         const props = {
           children: <TestComponent>Test component</TestComponent>,
@@ -129,7 +136,7 @@ describe('rendering', () => {
       });
     });
 
-    describe('when adapter is not ready', () => {
+    describe('when adapter is not configured', () => {
       it('should invoke render prop', async () => {
         const adapter = createAdapter();
         const props = {

--- a/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.spec.js
@@ -1,13 +1,10 @@
-import { TAdapterConfigurationStatus } from '@flopflip/types';
 import React from 'react';
 import { render as rtlRender, wait } from '@flopflip/test-utils';
 import AdapterContext from '../adapter-context';
 import ConfigureAdapter, { AdapterStates } from './configure-adapter';
 
 const createAdapter = () => ({
-  getIsConfigurationStatus: jest.fn(
-    () => TAdapterConfigurationStatus.Unconfigured
-  ),
+  getIsConfigurationStatus: jest.fn(() => false),
   configure: jest.fn(() => Promise.resolve()),
   reconfigure: jest.fn(() => Promise.resolve()),
 });
@@ -88,7 +85,9 @@ describe('rendering', () => {
 
         expect(props.render).not.toHaveBeenCalled();
 
-        await wait(() => expect(adapter.getIsReady).toHaveBeenCalled());
+        await wait(() =>
+          expect(adapter.getIsConfigurationStatus).toHaveBeenCalled()
+        );
       });
     });
   });
@@ -98,9 +97,7 @@ describe('rendering', () => {
       it('should invoke children prop with ready state', async () => {
         const adapter = createAdapter();
 
-        adapter.getIsConfigurationStatus.mockReturnValue(
-          TAdapterConfigurationStatus.Configured
-        );
+        adapter.getIsConfigurationStatus.mockReturnValue(true);
 
         const props = { children: jest.fn(() => <TestComponent />) };
 
@@ -120,9 +117,7 @@ describe('rendering', () => {
       it('should invoke render prop', async () => {
         const adapter = createAdapter();
 
-        adapter.getIsConfigurationStatus.mockReturnValue(
-          TAdapterConfigurationStatus.Configured
-        );
+        adapter.getIsConfigurationStatus.mockReturnValue(true);
 
         const props = {
           children: <TestComponent>Test component</TestComponent>,

--- a/packages/react/modules/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.tsx
@@ -275,6 +275,9 @@ const ConfigureAdapter = (props: TProps) => {
             isAdapterConfigured,
           });
 
+        if (props.children && !isEmptyChildren(props.children))
+          return React.Children.only<React.ReactNode>(props.children);
+
         return null;
       })()}
     </AdapterContext.Provider>

--- a/packages/react/modules/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   TFlags,
   TAdapter,
@@ -6,11 +5,13 @@ import {
   TAdapterArgs,
   TAdapterStatus,
   TAdapterReconfiguration,
+  TAdapterConfigurationStatus,
   TAdapterReconfigurationOptions,
   TConfigureAdapterChildren,
   TAdapterStatusChange,
   TFlagsChange,
 } from '@flopflip/types';
+import React from 'react';
 import {
   isFunctionChildren,
   isEmptyChildren,
@@ -259,19 +260,20 @@ const ConfigureAdapter = (props: TProps) => {
       value={createAdapterContext(reconfigureOrQueue, props.adapterStatus)}
     >
       {(() => {
-        const isAdapterReady = props.adapter.getIsReady();
+        const isAdapterConfigured = props.adapter.getIsConfigurationStatus(
+          TAdapterConfigurationStatus.Configured
+        );
 
-        if (isAdapterReady) {
+        if (isAdapterConfigured) {
           if (typeof props.render === 'function') return props.render();
         }
 
         if (isFunctionChildren(props.children))
           return props.children({
-            isAdapterReady,
+            // NOTE: Deprecated, please use `isAdapterConfigured`.
+            isAdapterReady: isAdapterConfigured,
+            isAdapterConfigured,
           });
-
-        if (props.children && !isEmptyChildren(props.children))
-          return React.Children.only<React.ReactNode>(props.children);
 
         return null;
       })()}

--- a/packages/react/modules/components/index.ts
+++ b/packages/react/modules/components/index.ts
@@ -1,6 +1,8 @@
 export {
   default as AdapterContext,
   createAdapterContext,
+  useAdapterContext,
+  selectAdapterConfigurationStatus,
 } from './adapter-context';
 export { default as ToggleFeature } from './toggle-feature';
 export { default as ConfigureAdapter } from './configure-adapter';

--- a/packages/react/modules/hooks/use-adapter-subscription/use-adapter-subscription.spec.js
+++ b/packages/react/modules/hooks/use-adapter-subscription/use-adapter-subscription.spec.js
@@ -1,10 +1,15 @@
-import { TAdapterSubscriptionStatus } from '@flopflip/types';
+import {
+  TAdapterSubscriptionStatus,
+  TAdapterConfigurationStatus,
+} from '@flopflip/types';
 import React from 'react';
 import { render as rtlRender } from '@flopflip/test-utils';
 import useAdapterSubscription from './use-adapter-subscription';
 
 const createAdapter = () => ({
-  getIsReady: jest.fn(() => false),
+  getIsConfigurationStatus: jest.fn(
+    () => TAdapterConfigurationStatus.Unconfigured
+  ),
   configure: jest.fn(() => Promise.resolve()),
   reconfigure: jest.fn(() => Promise.resolve()),
   subscribe: jest.fn(),
@@ -14,13 +19,15 @@ const createAdapter = () => ({
 const TestComponent = props => {
   const getHasAdapterSubscriptionStatus = useAdapterSubscription(props.adapter);
 
-  const isReady = props.adapter.getIsReady();
+  const isConfigured = props.adapter.getIsConfigurationStatus(
+    TAdapterConfigurationStatus.Configured
+  );
 
   return (
     <>
       <h1>Test Component</h1>;
       <ul>
-        <li>Is ready: {isReady ? 'Yes' : 'No'}</li>
+        <li>Is configured: {isConfigured ? 'Yes' : 'No'}</li>
         <li>
           Is subscribed:{' '}
           {getHasAdapterSubscriptionStatus(

--- a/packages/react/modules/hooks/use-adapter-subscription/use-adapter-subscription.spec.js
+++ b/packages/react/modules/hooks/use-adapter-subscription/use-adapter-subscription.spec.js
@@ -52,9 +52,9 @@ const TestComponent = props => {
 const render = ({ adapter }) => {
   const props = { adapter };
   const rendered = rtlRender(<TestComponent {...props} />);
-  const waitUntilReady = () => Promise.resolve();
+  const waitUntilConfigured = () => Promise.resolve();
 
-  return { ...rendered, waitUntilReady, props };
+  return { ...rendered, waitUntilConfigured, props };
 };
 
 describe('rendering', () => {
@@ -63,7 +63,7 @@ describe('rendering', () => {
 
     const rendered = render({ adapter });
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.props.adapter.subscribe).toHaveBeenCalled();
   });
@@ -73,7 +73,7 @@ describe('rendering', () => {
 
     const rendered = render({ adapter });
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     expect(rendered.queryByText(/Is subscribed: Yes/i)).toBeInTheDocument();
     expect(rendered.queryByText(/Is unsubscribed: No/i)).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe('rendering', () => {
 
     const rendered = render({ adapter });
 
-    await rendered.waitUntilReady();
+    await rendered.waitUntilConfigured();
 
     rendered.unmount();
 

--- a/packages/react/modules/index.ts
+++ b/packages/react/modules/index.ts
@@ -7,6 +7,8 @@ const version = '__@FLOPFLIP/VERSION_OF_RELEASE__';
 export {
   AdapterContext,
   createAdapterContext,
+  useAdapterContext,
+  selectAdapterConfigurationStatus,
   ToggleFeature,
   ConfigureAdapter,
   ReconfigureAdapter,

--- a/packages/splitio-adapter/modules/adapter/adapter.spec.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.spec.js
@@ -212,7 +212,7 @@ describe('when configuring', () => {
       });
     });
 
-    describe('when `splitio` is ready', () => {
+    describe('when `splitio` is configured', () => {
       it('should call getTreatments with attributes', () => {
         expect(treatmentStub).toHaveBeenCalledWith(names, {
           ...userWithKey,

--- a/packages/splitio-adapter/modules/adapter/adapter.spec.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.spec.js
@@ -20,6 +20,11 @@ jest.mock('@splitsoftware/splitio', () => ({
     })),
   })),
 }));
+const AdapterStatus = {
+  Unconfigured: 0,
+  Configuring: 1,
+  Configured: 2,
+};
 
 const authorizationKey = '123-abc';
 const userWithKey = { key: 'foo-user' };
@@ -38,8 +43,10 @@ describe('when configuring', () => {
     onFlagsStateChange = jest.fn();
   });
 
-  it('should indicate that the adapter is not ready', () => {
-    expect(adapter.getIsReady()).toBe(false);
+  it('should indicate that the adapter is not configured', () => {
+    expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
+      false
+    );
   });
 
   describe('when reconfiguring before configured', () => {
@@ -203,6 +210,12 @@ describe('when configuring', () => {
       );
     });
 
+    it('should `dispatch` `onUpdateStatus` action with configured', () => {
+      expect(onStatusStateChange).toHaveBeenCalledWith({
+        configurationStatus: AdapterStatus.Configuring,
+      });
+    });
+
     describe('when `splitio` is ready', () => {
       it('should call getTreatments with attributes', () => {
         expect(treatmentStub).toHaveBeenCalledWith(names, {
@@ -211,13 +224,15 @@ describe('when configuring', () => {
         });
       });
 
-      it('should indicate that the adapter is ready', () => {
-        expect(adapter.getIsReady()).toBe(true);
+      it('should indicate that the adapter is not configured', () => {
+        expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
+          true
+        );
       });
 
-      it('should `dispatch` `onUpdateStatus` action with `isReady`', () => {
+      it('should `dispatch` `onUpdateStatus` action with configured', () => {
         expect(onStatusStateChange).toHaveBeenCalledWith({
-          isReady: true,
+          configurationStatus: AdapterStatus.Configured,
         });
       });
 

--- a/packages/splitio-adapter/modules/adapter/adapter.spec.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.spec.js
@@ -1,3 +1,4 @@
+import { TAdapterConfigurationStatus } from '@flopflip/types';
 import { SplitFactory } from '@splitsoftware/splitio';
 import adapter, {
   normalizeFlags,
@@ -20,11 +21,6 @@ jest.mock('@splitsoftware/splitio', () => ({
     })),
   })),
 }));
-const AdapterStatus = {
-  Unconfigured: 0,
-  Configuring: 1,
-  Configured: 2,
-};
 
 const authorizationKey = '123-abc';
 const userWithKey = { key: 'foo-user' };
@@ -44,9 +40,9 @@ describe('when configuring', () => {
   });
 
   it('should indicate that the adapter is not configured', () => {
-    expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
-      false
-    );
+    expect(
+      adapter.getIsConfigurationStatus(TAdapterConfigurationStatus.Configured)
+    ).toBe(false);
   });
 
   describe('when reconfiguring before configured', () => {
@@ -212,7 +208,7 @@ describe('when configuring', () => {
 
     it('should `dispatch` `onUpdateStatus` action with configured', () => {
       expect(onStatusStateChange).toHaveBeenCalledWith({
-        configurationStatus: AdapterStatus.Configuring,
+        configurationStatus: TAdapterConfigurationStatus.Configuring,
       });
     });
 
@@ -225,14 +221,16 @@ describe('when configuring', () => {
       });
 
       it('should indicate that the adapter is not configured', () => {
-        expect(adapter.getIsConfigurationStatus(AdapterStatus.Configured)).toBe(
-          true
-        );
+        expect(
+          adapter.getIsConfigurationStatus(
+            TAdapterConfigurationStatus.Configured
+          )
+        ).toBe(true);
       });
 
       it('should `dispatch` `onUpdateStatus` action with configured', () => {
         expect(onStatusStateChange).toHaveBeenCalledWith({
-          configurationStatus: AdapterStatus.Configured,
+          configurationStatus: TAdapterConfigurationStatus.Configured,
         });
       });
 

--- a/packages/splitio-adapter/modules/adapter/adapter.ts
+++ b/packages/splitio-adapter/modules/adapter/adapter.ts
@@ -15,6 +15,7 @@ import {
   interfaceIdentifiers,
 } from '@flopflip/types';
 import merge from 'deepmerge';
+import warning from 'tiny-warning';
 import { SplitFactory } from '@splitsoftware/splitio';
 import camelCase from 'lodash/camelCase';
 import omit from 'lodash/omit';
@@ -292,6 +293,18 @@ class SplitioAdapter implements TSplitioAdapterInterface {
 
   subscribe() {
     adapterState.subscriptionStatus = TAdapterSubscriptionStatus.Subscribed;
+  }
+
+  // NOTE: This function is deprecated. Please use `getIsConfigurationStatus`.
+  getIsReady() {
+    warning(
+      false,
+      '@flopflip/splitio-adapter: `getIsReady` has been deprecated. Please use `getIsConfigurationStatus` instead.'
+    );
+
+    return this.getIsConfigurationStatus(
+      TAdapterConfigurationStatus.Configured
+    );
   }
 }
 

--- a/packages/splitio-adapter/modules/adapter/adapter.ts
+++ b/packages/splitio-adapter/modules/adapter/adapter.ts
@@ -166,7 +166,7 @@ const subscribe = ({
           // First update internal state
           adapterState.configurationStatus =
             TAdapterConfigurationStatus.Configured;
-          // ...to then signal that the adapter is ready
+          // ...to then signal that the adapter is configured
 
           if (!getIsUnsubscribed()) {
             onStatusStateChange({

--- a/packages/splitio-adapter/package.json
+++ b/packages/splitio-adapter/package.json
@@ -40,7 +40,8 @@
     "@flopflip/types": "^2.3.5",
     "@splitsoftware/splitio": "10.10.0",
     "deepmerge": "4.2.2",
-    "lodash": "4.17.15"
+    "lodash": "4.17.15",
+    "tiny-warning": "1.0.3"
   },
   "keywords": [
     "feature-flags",

--- a/packages/test-utils/index.js
+++ b/packages/test-utils/index.js
@@ -126,7 +126,7 @@ const renderWithAdapter = (
   return {
     changeFlagVariation: (flagName, flagVariation) =>
       changeFlagVariation(rendered, flagName, flagVariation),
-    waitUntilReady: async () =>
+    waitUntilConfigured: async () =>
       waitForElement(() => rendered.getByTestId('change-flag-variation')),
     ...rendered,
   };

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -208,7 +208,8 @@ export type TAdapterReconfiguration = {
   options: TAdapterReconfigurationOptions;
 };
 export type TConfigureAdapterChildrenAsFunctionArgs = {
-  isAdapterReady: boolean;
+  isAdapterReady?: boolean;
+  isAdapterConfigured: boolean;
 };
 export type TConfigureAdapterChildrenAsFunction = (
   args: TConfigureAdapterChildrenAsFunctionArgs

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -11,9 +11,13 @@ export enum TAdapterSubscriptionStatus {
   Subscribed,
   Unsubscribed,
 }
+export enum TAdapterConfigurationStatus {
+  Unconfigured,
+  Configuring,
+  Configured,
+}
 export type TAdapterStatus = {
-  isReady?: boolean;
-  isConfigured?: boolean;
+  configurationStatus: TAdapterConfigurationStatus;
   subscriptionStatus: TAdapterSubscriptionStatus;
 };
 export type TAdapterStatusChange = Partial<TAdapterStatus>;
@@ -64,6 +68,7 @@ export const interfaceIdentifiers = {
   splitio: 'splitio',
 } as const;
 export type TAdapterInterfaceIdentifiers = typeof interfaceIdentifiers[keyof typeof interfaceIdentifiers];
+
 export interface TAdapterInterface<Args extends TAdapterArgs> {
   // Identifiers are used to uniquely identify an interface when performing a condition check.
   id: TAdapterInterfaceIdentifiers;
@@ -75,8 +80,12 @@ export interface TAdapterInterface<Args extends TAdapterArgs> {
     adapterArgs: Args,
     adapterEventHandlers: TAdapterEventHandlers
   ): Promise<unknown>;
-  getIsReady(): boolean;
-  setIsReady?(nextStatus: TAdapterStatus): void;
+  getIsConfigurationStatus(
+    configurationStatus: TAdapterConfigurationStatus
+  ): boolean;
+  setConfigurationStatus(
+    nextConfigurationStatus: TAdapterConfigurationStatus
+  ): void;
   waitUntilConfigured?(): Promise<unknown>;
   reset?(): void;
   getFlag?(flagName: TFlagName): TFlagVariation | undefined;
@@ -94,7 +103,9 @@ export interface TLaunchDarklyAdapterInterface
     adapterArgs: TLaunchDarklyAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
   ): Promise<unknown>;
-  getIsReady(): boolean;
+  getIsConfigurationStatus(
+    adapterConfigurationStatus: TAdapterConfigurationStatus
+  ): boolean;
   getClient(): TLDClient | undefined;
   getFlag(flagName: TFlagName): TFlagVariation | undefined;
   updateUserContext(updatedUserProps: TUser): Promise<unknown>;
@@ -112,7 +123,9 @@ export interface TLocalStorageAdapterInterface
     adapterArgs: TLocalStorageAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
   ): Promise<unknown>;
-  getIsReady(): boolean;
+  getIsConfigurationStatus(
+    adapterConfigurationStatus: TAdapterConfigurationStatus
+  ): boolean;
   waitUntilConfigured(): Promise<unknown>;
   unsubscribe(): void;
   subscribe(): void;
@@ -128,8 +141,9 @@ export interface TMemoryAdapterInterface
     adapterArgs: TMemoryAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
   ): Promise<unknown>;
-  getIsReady(): boolean;
-  setIsReady(nextStatus: TAdapterStatus): void;
+  getIsConfigurationStatus(
+    adapterConfigurationStatus: TAdapterConfigurationStatus
+  ): boolean;
   waitUntilConfigured(): Promise<unknown>;
   reset(): void;
   updateFlags(flags: TFlags): void;
@@ -147,7 +161,9 @@ export interface TSplitioAdapterInterface
     adapterArgs: TSplitioAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
   ): Promise<unknown>;
-  getIsReady(): boolean;
+  getIsConfigurationStatus(
+    adapterConfigurationStatus: TAdapterConfigurationStatus
+  ): boolean;
   unsubscribe(): void;
   subscribe(): void;
 }

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -83,7 +83,7 @@ export interface TAdapterInterface<Args extends TAdapterArgs> {
   getIsConfigurationStatus(
     configurationStatus: TAdapterConfigurationStatus
   ): boolean;
-  setConfigurationStatus(
+  setConfigurationStatus?(
     nextConfigurationStatus: TAdapterConfigurationStatus
   ): void;
   waitUntilConfigured?(): Promise<unknown>;

--- a/readme.md
+++ b/readme.md
@@ -310,7 +310,7 @@ You can also pass `render` or `children` as a function to act differently based 
 
 ```jsx
 <ConfigureFlopFlip adapter={adapter} adapterArgs={{ clientSideId, user }}>
-  {{isAdapterReady} => isAdapterReady ? <App /> : <LoadingSpinner />}
+  {{isAdapterConfigured} => isAdapterConfigured ? <App /> : <LoadingSpinner />}
 </ConfigureFlopFlip>;
 ```
 
@@ -322,7 +322,7 @@ You can also pass `render` or `children` as a function to act differently based 
 />
 ```
 
-Note that `children` will be called with a loading state prop while `render` will only be called when the adapter is ready. This behaviour mirrors the workings of `<ToggleFeature>`.
+Note that `children` will be called with a loading state prop while `render` will only be called when the adapter is configured. This behaviour mirrors the workings of `<ToggleFeature>`.
 
 This variant of the `ConfigureFlopFlip` component form
 `@flopflip/react-broadcast` will use the context and a broadcasting system to
@@ -448,7 +448,7 @@ down the tree but that information should be used for user targeting (through `a
 can use `ReconfigureFlopflip`. `ReconfigureFlopflip` itself communicates with `ConfigureFlopflip`
 to reconfigure the given adapter for more fine grained targeting with the passed `user`.
 You also do not have to worry about rendering any number of `ReconfigureFlopflip`s before the adapter is
-initialized (e.g. LaunchDarkly). Requested reconfigurations will be queued and processed once the adapter is ready.
+initialized (e.g. LaunchDarkly). Requested reconfigurations will be queued and processed once the adapter is configured.
 
 Imagine having `ConfigureFlopflip` above a given component wrapped by a `Route`:
 
@@ -555,9 +555,9 @@ import { useAdapterStatus } from '@flopflip/react-broadcast';
 
 const ComponentWithFeatureToggle = () => {
   const isFeatureEnabled = useFeatureToggle('myFeatureToggle');
-  const { isReady } = useAdapterStatus();
+  const { isConfigured } = useAdapterStatus();
 
-  if (!isReady) return <LoadingSpinner />;
+  if (!isConfigured) return <LoadingSpinner />;
   else if (!isFeatureEnabled) <PageNotFound />;
   else return <FeatureComponent />;
 };


### PR DESCRIPTION
#### Summary

This pull request is a refactoring to _not_ use booleans as adapter status state.

#### Description

Booleans are hard to maintain over type. Better are enums. In that this PR:

1. Adds a `adapterConfigurationStatus` field on adapters and components
2. Adds a `TAdapterConfigurationStatus` to on the type level
3. Adds a backwards compatible layer to not have this being a breaking change
    - The `isReady` flag is mapped into in the selectors in all packages
4. Adapters get a `getIsAdapterStatus`-fn while mapping `getIsReady` with a warning onto it
5. All state in Redux and the Context (broadcast) is not cleaner while selectors map out of it