### PR TITLE
refactor: to use debug value more

### DIFF
--- a/packages/react-broadcast/modules/components/configure/configure.tsx
+++ b/packages/react-broadcast/modules/components/configure/configure.tsx
@@ -32,7 +32,11 @@ const initialAdapterStatus: State['status'] = {
 };
 const initialFlags: State['flags'] = {};
 
-const useFlagsState = ({ initialFlags }: { initialFlags: State['flags'] }) => {
+const useFlagsState = ({
+  initialFlags,
+}: {
+  initialFlags: State['flags'];
+}): [TFlags, React.Dispatch<React.SetStateAction<TFlags>>] => {
   const [flags, setFlags] = React.useState<State['flags']>(initialFlags);
 
   React.useDebugValue({
@@ -46,7 +50,7 @@ const useStatusState = ({
   initialAdapterStatus,
 }: {
   initialAdapterStatus: State['status'];
-}) => {
+}): [TAdapterStatus, React.Dispatch<React.SetStateAction<TAdapterStatus>>] => {
   const [status, setStatus] = React.useState<State['status']>(
     initialAdapterStatus
   );

--- a/packages/react-broadcast/modules/components/configure/configure.tsx
+++ b/packages/react-broadcast/modules/components/configure/configure.tsx
@@ -32,13 +32,37 @@ const initialAdapterStatus: State['status'] = {
 };
 const initialFlags: State['flags'] = {};
 
-const Configure = <AdapterInstance extends TAdapter>(
-  props: Props<AdapterInstance>
-) => {
+const useFlagsState = ({ initialFlags }: { initialFlags: State['flags'] }) => {
   const [flags, setFlags] = React.useState<State['flags']>(initialFlags);
+
+  React.useDebugValue({
+    flags,
+  });
+
+  return [flags, setFlags];
+};
+
+const useStatusState = ({
+  initialAdapterStatus,
+}: {
+  initialAdapterStatus: State['status'];
+}) => {
   const [status, setStatus] = React.useState<State['status']>(
     initialAdapterStatus
   );
+
+  React.useDebugValue({
+    status,
+  });
+
+  return [status, setStatus];
+};
+
+const Configure = <AdapterInstance extends TAdapter>(
+  props: Props<AdapterInstance>
+) => {
+  const [flags, setFlags] = useFlagsState({ initialFlags });
+  const [status, setStatus] = useStatusState({ initialAdapterStatus });
 
   // NOTE:
   //   Using this prevents the callbacks being invoked

--- a/packages/react/modules/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.tsx
@@ -44,7 +44,7 @@ const useApplieAdapterArgsState = ({
   initialAdapterArgs,
 }: {
   initialAdapterArgs: TAdapterArgs;
-}) => {
+}): [TAdapterArgs, React.Dispatch<React.SetStateAction<TAdapterArgs>>] => {
   const [appliedAdapterArgs, setAppliedAdapterArgs] = React.useState<
     TAdapterArgs
   >(initialAdapterArgs);


### PR DESCRIPTION
#### Summary

Last nite fun.

Using `useDebugValue` can help with debugging and in the DevTools quite a bit. As a result the code also get's some leaner and more consise.