### PR TITLE
feat(localstorage-adapter): Only emit flagStateChange when the flags change

### DIFF
--- a/packages/localstorage-adapter/modules/adapter/adapter.ts
+++ b/packages/localstorage-adapter/modules/adapter/adapter.ts
@@ -119,12 +119,18 @@ const subscribeToFlagsChanges = ({
 }: {
   pollingInteral?: number;
 }) => {
+  let prevFlagsJson = 'null';
   setInterval(() => {
     if (!getIsUnsubscribed()) {
-      adapterState.emitter.emit(
-        'flagsStateChange',
-        normalizeFlags(storage.get('flags'))
-      );
+      const nextFlags = normalizeFlags(storage.get('flags'));
+      const nextFlagsJson = JSON.stringify(nextFlags);
+      if (prevFlagsJson !== nextFlagsJson) {
+        prevFlagsJson = nextFlagsJson;
+        adapterState.emitter.emit(
+          'flagsStateChange',
+          nextFlags
+        );
+      }
     }
   }, pollingInteral);
 };


### PR DESCRIPTION
#### Summary

To improve responsiveness between tabs when changing flags on one tab and watching for the action on another tab, a quicker polling interval is required, but that started emitting lots of redux actions, filling up the log for Redux DevTools.  (our system also centrally logs all redux actions).

#### Description

This change allows responding to flag changes between tabs faster by increasing `pollingInteral` (was 60 seconds) without broadcasting large amounts of unneeded redux actions.

#### Technical debt & future

Next steps after this pull request could be to change the default  `pollingInteral` for the `localstorage-adaptor` to `1000` ms.  Also correcting the name of that parameter to `pollingInterval`.