### PR TITLE
fix(local-storage-adapter): add tests for flag update from localstorage

### DIFF
--- a/packages/localstorage-adapter/modules/adapter/adapter.spec.js
+++ b/packages/localstorage-adapter/modules/adapter/adapter.spec.js
@@ -150,8 +150,22 @@ describe('when configuring', () => {
       it('should invoke `onFlagsStateChange`', () => {
         jest.advanceTimersByTime(5 * 60 * 1000);
         expect(adapterEventHandlers.onFlagsStateChange).toHaveBeenCalledTimes(
-          5
+          1
         );
+      });
+    });
+
+    describe('when localstorage has no changes', () => {
+      const initialFlags = { fooFlag: false, barFlag: false };
+
+      beforeEach(() => {
+        updateFlags(initialFlags);
+        adapterEventHandlers.onFlagsStateChange.mockClear();
+      });
+
+      it('should not invoke `onFlagsStateChange`', () => {
+        jest.advanceTimersByTime(5 * 60 * 1000);
+        expect(adapterEventHandlers.onFlagsStateChange).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/localstorage-adapter/modules/adapter/adapter.spec.js
+++ b/packages/localstorage-adapter/modules/adapter/adapter.spec.js
@@ -12,7 +12,11 @@ const createAdapterEventHandlers = (custom = {}) => ({
 
 describe('when configuring', () => {
   let adapterArgs = {};
-  let adapterEventHandlers = createAdapterEventHandlers();
+  let adapterEventHandlers;
+
+  beforeEach(() => {
+    adapterEventHandlers = createAdapterEventHandlers();
+  });
 
   describe('when not configured', () => {
     it('should indicate that the adapter is not configured', () => {
@@ -33,7 +37,14 @@ describe('when configuring', () => {
   });
 
   describe('when configured', () => {
-    beforeEach(() => adapter.configure(adapterArgs, adapterEventHandlers));
+    beforeEach(() => {
+      jest.useFakeTimers();
+      adapter.configure(adapterArgs, adapterEventHandlers);
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+    });
 
     it('should invoke `onStatusStateChange` with configuring', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
@@ -79,6 +90,12 @@ describe('when configuring', () => {
         updateFlags(updatedFlags);
       });
 
+      it('should set localstorage', () => {
+        expect(
+          JSON.parse(localStorage.getItem(`${STORAGE_SLICE}__flags`))
+        ).toStrictEqual(updatedFlags);
+      });
+
       it('should invoke but not trigger `warning`', () => {
         expect(warning).toHaveBeenCalledWith(true, expect.any(String));
       });
@@ -113,6 +130,28 @@ describe('when configuring', () => {
             })
           );
         });
+      });
+    });
+
+    describe('when localstorage changes', () => {
+      const initialFlags = { fooFlag: false, barFlag: false };
+      const updatedFlags = { fooFlag: true, barFlag: false };
+
+      beforeEach(() => {
+        updateFlags(initialFlags);
+        adapterEventHandlers.onFlagsStateChange.mockClear();
+
+        localStorage.setItem(
+          `${STORAGE_SLICE}__flags`,
+          JSON.stringify(updatedFlags)
+        );
+      });
+
+      it('should invoke `onFlagsStateChange`', () => {
+        jest.advanceTimersByTime(5 * 60 * 1000);
+        expect(adapterEventHandlers.onFlagsStateChange).toHaveBeenCalledTimes(
+          5
+        );
       });
     });
 

--- a/packages/localstorage-adapter/modules/adapter/adapter.ts
+++ b/packages/localstorage-adapter/modules/adapter/adapter.ts
@@ -120,7 +120,7 @@ const didFlagsChange = (nextFlags: TFlags) => {
 
   if (previousFlags === undefined) return true;
 
-  return isEqual(nextFlags, previousFlags);
+  return !isEqual(nextFlags, previousFlags);
 };
 
 const subscribeToFlagsChanges = ({
@@ -155,6 +155,7 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
     const handleFlagsChange = (nextFlags: TFlags) => {
       if (getIsUnsubscribed()) return;
 
+      adapterState.flags = nextFlags
       adapterEventHandlers.onFlagsStateChange(nextFlags);
     };
 


### PR DESCRIPTION
#### Summary

Add tests for localstorage interactions

#### Description

The tests use `jest.useFakeTimers()` to advance the timers and trigger the `localStorage` read.  I initially implemented it to pass as the behavior was before #1001. In a subsequent commit, changed to pass as intended.

This pull request doesn't change the adapter logic as the underlying issue was fixed in #1003, but I did use a different approach by putting `adapterState.flags = nextFlags` in `handleFlagsChange`, but that was reverted when I merged from `upstream/master`.  setting `adapterState.flags` before emitting `flagsStateChange` is probably more clear.