### PR TITLE
feat: add initialization status to adapters

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.spec.js
@@ -138,12 +138,13 @@ describe('when configuring', () => {
     });
   });
 
-  describe('when ready', () => {
+  describe('when configured', () => {
     let client;
     let onStatusStateChange;
     let onFlagsStateChange;
+    let configurationResult;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       onStatusStateChange = jest.fn();
       onFlagsStateChange = jest.fn();
       client = createClient({
@@ -153,7 +154,7 @@ describe('when configuring', () => {
 
       ldClient.initialize.mockReturnValue(client);
 
-      return adapter.configure(
+      configurationResult = await adapter.configure(
         {
           clientSideId,
           user: userWithKey,
@@ -162,6 +163,14 @@ describe('when configuring', () => {
           onStatusStateChange,
           onFlagsStateChange,
         }
+      );
+    });
+
+    it('should resolve to a successful initialization status', () => {
+      expect(configurationResult).toEqual(
+        expect.objectContaining({
+          initializationStatus: 0,
+        })
       );
     });
 
@@ -452,25 +461,33 @@ describe('when configuring', () => {
       const nextUser = { key: 'bar-user' };
       let client;
 
-      beforeEach(() => {
+      beforeEach(async () => {
         client = createClient({
           identify: jest.fn(() => Promise.resolve()),
         });
 
         ldClient.initialize.mockReturnValue(client);
 
-        return adapter
-          .configure(
-            {
-              clientSideId,
-              user: userWithKey,
-            },
-            {
-              onStatusStateChange,
-              onFlagsStateChange,
-            }
-          )
-          .then(() => adapter.reconfigure({ user: nextUser }));
+        await adapter.configure(
+          {
+            clientSideId,
+            user: userWithKey,
+          },
+          {
+            onStatusStateChange,
+            onFlagsStateChange,
+          }
+        );
+
+        configurationResult = await adapter.reconfigure({ user: nextUser });
+      });
+
+      it('should resolve to a successful initialization status', () => {
+        expect(configurationResult).toEqual(
+          expect.objectContaining({
+            initializationStatus: 0,
+          })
+        );
       });
 
       it('should invoke `identify` on the `client` with the `user`', () => {

--- a/packages/localstorage-adapter/modules/adapter/adapter.spec.js
+++ b/packages/localstorage-adapter/modules/adapter/adapter.spec.js
@@ -37,13 +37,25 @@ describe('when configuring', () => {
   });
 
   describe('when configured', () => {
-    beforeEach(() => {
+    let configurationResult;
+    beforeEach(async () => {
       jest.useFakeTimers();
-      adapter.configure(adapterArgs, adapterEventHandlers);
+      configurationResult = await adapter.configure(
+        adapterArgs,
+        adapterEventHandlers
+      );
     });
 
     afterEach(() => {
       jest.clearAllTimers();
+    });
+
+    it('should resolve to a successful initialization status', () => {
+      expect(configurationResult).toEqual(
+        expect.objectContaining({
+          initializationStatus: 0,
+        })
+      );
     });
 
     it('should invoke `onStatusStateChange` with configuring', () => {
@@ -172,10 +184,18 @@ describe('when configuring', () => {
     describe('when reconfiguring', () => {
       const user = { id: 'bar' };
 
-      beforeEach(() => {
+      beforeEach(async () => {
         updateFlags({ foo: 'bar' });
 
-        return adapter.reconfigure({ user });
+        configurationResult = await adapter.reconfigure({ user });
+      });
+
+      it('should resolve to a successful initialization status', () => {
+        expect(configurationResult).toEqual(
+          expect.objectContaining({
+            initializationStatus: 0,
+          })
+        );
       });
 
       it('should reset localstorage', () => {

--- a/packages/localstorage-adapter/modules/adapter/adapter.ts
+++ b/packages/localstorage-adapter/modules/adapter/adapter.ts
@@ -15,6 +15,7 @@ import {
   TFlags,
   TAdapterSubscriptionStatus,
   TAdapterConfigurationStatus,
+  TAdapterInitializationStatus,
   interfaceIdentifiers,
 } from '@flopflip/types';
 
@@ -194,6 +195,10 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
       subscribeToFlagsChanges({
         pollingInteral: adapterConfiguration?.pollingInteral,
       });
+
+      return {
+        initializationStatus: TAdapterInitializationStatus.Succeeded,
+      };
     });
   }
 
@@ -209,7 +214,9 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
 
     adapterState.emitter.emit('flagsStateChange', {});
 
-    return Promise.resolve();
+    return Promise.resolve({
+      initializationStatus: TAdapterInitializationStatus.Succeeded,
+    });
   }
 
   waitUntilConfigured() {

--- a/packages/memory-adapter/modules/adapter/adapter.spec.js
+++ b/packages/memory-adapter/modules/adapter/adapter.spec.js
@@ -44,7 +44,22 @@ describe('when configuring', () => {
   });
 
   describe('when configured', () => {
-    beforeEach(() => adapter.configure(adapterArgs, adapterEventHandlers));
+    let configurationResult;
+
+    beforeEach(async () => {
+      configurationResult = await adapter.configure(
+        adapterArgs,
+        adapterEventHandlers
+      );
+    });
+
+    it('should resolve to a successful initialization status', () => {
+      expect(configurationResult).toEqual(
+        expect.objectContaining({
+          initializationStatus: 0,
+        })
+      );
+    });
 
     it('should invoke `onStatusStateChange` with configuring', () => {
       expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
@@ -128,7 +143,17 @@ describe('when configuring', () => {
     describe('when reconfiguring', () => {
       const user = { id: 'bar' };
 
-      beforeEach(() => adapter.reconfigure({ user }));
+      beforeEach(async () => {
+        configurationResult = await adapter.reconfigure({ user });
+      });
+
+      it('should resolve to a successful initialization status', () => {
+        expect(configurationResult).toEqual(
+          expect.objectContaining({
+            initializationStatus: 0,
+          })
+        );
+      });
 
       it('should update the user', () => {
         expect(getUser()).toEqual(user);

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -12,6 +12,7 @@ import {
   TMemoryAdapterInterface,
   TAdapterSubscriptionStatus,
   TAdapterConfigurationStatus,
+  TAdapterInitializationStatus,
   TMemoryAdapterArgs,
   interfaceIdentifiers,
 } from '@flopflip/types';
@@ -139,6 +140,10 @@ class MemoryAdapter implements TMemoryAdapterInterface {
       });
 
       adapterState.emitter.emit(__internalConfiguredStatusChange__);
+
+      return {
+        initializationStatus: TAdapterInitializationStatus.Succeeded,
+      };
     });
   }
 
@@ -159,7 +164,9 @@ class MemoryAdapter implements TMemoryAdapterInterface {
       configurationStatus: adapterState.configurationStatus,
     });
 
-    return Promise.resolve();
+    return Promise.resolve({
+      initializationStatus: TAdapterInitializationStatus.Succeeded,
+    });
   }
 
   getIsConfigurationStatus(configurationStatus: TAdapterConfigurationStatus) {

--- a/packages/splitio-adapter/modules/adapter/adapter.spec.js
+++ b/packages/splitio-adapter/modules/adapter/adapter.spec.js
@@ -163,14 +163,15 @@ describe('when configuring', () => {
     });
   });
 
-  describe('when ready', () => {
+  describe('when configured', () => {
     let factory;
     let onStub;
     let onStatusStateChange;
     let onFlagsStateChange;
     let treatmentStub = jest.fn(() => flags);
+    let configurationResult;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       onStatusStateChange = jest.fn();
       onFlagsStateChange = jest.fn();
       onStub = jest.fn((_, cb) => cb());
@@ -191,7 +192,7 @@ describe('when configuring', () => {
 
       SplitFactory.mockReturnValue(factory);
 
-      return adapter.configure(
+      configurationResult = await adapter.configure(
         {
           authorizationKey,
           user: userWithKey,
@@ -203,6 +204,14 @@ describe('when configuring', () => {
           onStatusStateChange,
           onFlagsStateChange,
         }
+      );
+    });
+
+    it('should resolve to a successful initialization status', () => {
+      expect(configurationResult).toEqual(
+        expect.objectContaining({
+          initializationStatus: 0,
+        })
       );
     });
 
@@ -255,7 +264,7 @@ describe('when configuring', () => {
       let getTreatmentsStub;
       let factory;
 
-      beforeEach(() => {
+      beforeEach(async () => {
         onStatusStateChange = jest.fn();
         onFlagsStateChange = jest.fn();
         namesStub = jest.fn(() => names);
@@ -278,7 +287,7 @@ describe('when configuring', () => {
 
         SplitFactory.mockReturnValue(factory);
 
-        return adapter
+        configurationResult = await adapter
           .configure(
             {
               authorizationKey,
@@ -298,7 +307,7 @@ describe('when configuring', () => {
             namesStub.mockClear();
             getTreatmentsStub.mockClear();
 
-            adapter.reconfigure({
+            return adapter.reconfigure({
               user: nextUser,
               onStatusStateChange,
               onFlagsStateChange,
@@ -307,6 +316,14 @@ describe('when configuring', () => {
               },
             });
           });
+      });
+
+      it('should resolve to a successful initialization status', () => {
+        expect(configurationResult).toEqual(
+          expect.objectContaining({
+            initializationStatus: 0,
+          })
+        );
       });
 
       it('should call getTreatments with attributes', () => {

--- a/packages/splitio-adapter/modules/adapter/adapter.ts
+++ b/packages/splitio-adapter/modules/adapter/adapter.ts
@@ -12,6 +12,7 @@ import {
   TSplitioAdapterArgs,
   TAdapterSubscriptionStatus,
   TAdapterConfigurationStatus,
+  TAdapterInitializationStatus,
   interfaceIdentifiers,
 } from '@flopflip/types';
 import merge from 'deepmerge';
@@ -196,7 +197,9 @@ const configureSplitio = () => {
     onFlagsStateChange: adapterState.configuredCallbacks.onFlagsStateChange,
     onStatusStateChange: adapterState.configuredCallbacks.onStatusStateChange,
   }).then(() => {
-    return adapterState.client;
+    return {
+      initializationStatus: TAdapterInitializationStatus.Succeeded,
+    };
   });
 };
 
@@ -280,7 +283,9 @@ class SplitioAdapter implements TSplitioAdapterInterface {
       return configureSplitio();
     }
 
-    return Promise.resolve();
+    return Promise.resolve({
+      initializationStatus: TAdapterInitializationStatus.Succeeded,
+    });
   }
 
   getIsConfigurationStatus(configurationStatus: TAdapterConfigurationStatus) {

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -16,6 +16,10 @@ export enum TAdapterConfigurationStatus {
   Configuring,
   Configured,
 }
+export enum TAdapterInitializationStatus {
+  Succeeded,
+  Failed,
+}
 export type TAdapterStatus = {
   configurationStatus: TAdapterConfigurationStatus;
   subscriptionStatus: TAdapterSubscriptionStatus;


### PR DESCRIPTION
#### Summary

Adds the notion of an initialization status to all adapters. No configure call returns the client anymore. This could be seen breaking but configure should never been called yourself.

The TAdapterInitializationStatus can be Succeeded or Failed and is very similar to the TAdapterSubscriptionStatus.