### PR TITLE
fix: to not set status too eagerly

### DIFF
--- a/packages/react/modules/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.tsx
@@ -6,6 +6,7 @@ import {
   TAdapterStatus,
   TAdapterReconfiguration,
   TAdapterConfigurationStatus,
+  TAdapterInitializationStatus,
   TAdapterReconfigurationOptions,
   TConfigureAdapterChildren,
   TAdapterStatusChange,
@@ -202,11 +203,24 @@ const useConfigurationEffect = ({
           onFlagsStateChange,
           onStatusStateChange,
         })
-        .then(() => {
-          setAdapterState(AdapterStates.CONFIGURED);
+        .then(configuration => {
+          /**
+           * NOTE:
+           *    The configuration can be `undefined` then assuming `initializationStatus` to have
+           *    succeeded to work with old adapters.
+           */
+          const isAdapterWithoutInitializationStatus = !configuration?.initializationStatus;
 
-          if (pendingAdapterArgsRef.current) {
-            applyAdapterArgs(pendingAdapterArgsRef.current);
+          if (
+            isAdapterWithoutInitializationStatus ||
+            configuration.initializationStatus ===
+              TAdapterInitializationStatus.Succeeded
+          ) {
+            setAdapterState(AdapterStates.CONFIGURED);
+
+            if (pendingAdapterArgsRef.current) {
+              applyAdapterArgs(pendingAdapterArgsRef.current);
+            }
           }
         });
       return;
@@ -220,8 +234,21 @@ const useConfigurationEffect = ({
           onFlagsStateChange,
           onStatusStateChange,
         })
-        .then(() => {
-          setAdapterState(AdapterStates.CONFIGURED);
+        .then(reconfiguration => {
+          /**
+           * NOTE:
+           *    The configuration can be `undefined` then assuming `initializationStatus` to have
+           *    succeeded to work with old adapters.
+           */
+          const isAdapterWithoutInitializationStatus = !reconfiguration?.initializationStatus;
+
+          if (
+            isAdapterWithoutInitializationStatus ||
+            reconfiguration.initializationStatus ===
+              TAdapterInitializationStatus.Succeeded
+          ) {
+            setAdapterState(AdapterStates.CONFIGURED);
+          }
         });
     }
   }, [
@@ -265,10 +292,24 @@ const useDefaultFlagsEffect = ({
           onFlagsStateChange,
           onStatusStateChange,
         })
-        .then(() => {
-          setAdapterState(AdapterStates.CONFIGURED);
-          if (pendingAdapterArgsRef.current) {
-            applyAdapterArgs(pendingAdapterArgsRef.current);
+        .then(configuration => {
+          /**
+           * NOTE:
+           *    The configuration can be `undefined` then assuming `initializationStatus` to have
+           *    succeeded to work with old adapters.
+           */
+          const isAdapterWithoutInitializationStatus = !configuration?.initializationStatus;
+
+          if (
+            isAdapterWithoutInitializationStatus ||
+            configuration.initializationStatus ===
+              TAdapterInitializationStatus.Succeeded
+          ) {
+            setAdapterState(AdapterStates.CONFIGURED);
+
+            if (pendingAdapterArgsRef.current) {
+              applyAdapterArgs(pendingAdapterArgsRef.current);
+            }
           }
         });
     }

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -20,6 +20,9 @@ export enum TAdapterInitializationStatus {
   Succeeded,
   Failed,
 }
+export type TAdapterConfiguration = {
+  initializationStatus?: TAdapterInitializationStatus;
+};
 export type TAdapterStatus = {
   configurationStatus: TAdapterConfigurationStatus;
   subscriptionStatus: TAdapterSubscriptionStatus;
@@ -79,11 +82,11 @@ export interface TAdapterInterface<Args extends TAdapterArgs> {
   configure(
     adapterArgs: Args,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<unknown>;
+  ): Promise<TAdapterConfiguration>;
   reconfigure(
     adapterArgs: Args,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<unknown>;
+  ): Promise<TAdapterConfiguration>;
   getIsConfigurationStatus(
     configurationStatus: TAdapterConfigurationStatus
   ): boolean;
@@ -102,11 +105,11 @@ export interface TLaunchDarklyAdapterInterface
   configure(
     adapterArgs: TLaunchDarklyAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<unknown>;
+  ): Promise<TAdapterConfiguration>;
   reconfigure(
     adapterArgs: TLaunchDarklyAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<unknown>;
+  ): Promise<TAdapterConfiguration>;
   getIsConfigurationStatus(
     adapterConfigurationStatus: TAdapterConfigurationStatus
   ): boolean;
@@ -122,11 +125,11 @@ export interface TLocalStorageAdapterInterface
   configure(
     adapterArgs: TLocalStorageAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<unknown>;
+  ): Promise<TAdapterConfiguration>;
   reconfigure(
     adapterArgs: TLocalStorageAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<unknown>;
+  ): Promise<TAdapterConfiguration>;
   getIsConfigurationStatus(
     adapterConfigurationStatus: TAdapterConfigurationStatus
   ): boolean;
@@ -140,11 +143,11 @@ export interface TMemoryAdapterInterface
   configure(
     adapterArgs: TMemoryAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<unknown>;
+  ): Promise<TAdapterConfiguration>;
   reconfigure(
     adapterArgs: TMemoryAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<unknown>;
+  ): Promise<TAdapterConfiguration>;
   getIsConfigurationStatus(
     adapterConfigurationStatus: TAdapterConfigurationStatus
   ): boolean;
@@ -160,11 +163,11 @@ export interface TSplitioAdapterInterface
   configure(
     adapterArgs: TSplitioAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<unknown>;
+  ): Promise<TAdapterConfiguration>;
   reconfigure(
     adapterArgs: TSplitioAdapterArgs,
     adapterEventHandlers: TAdapterEventHandlers
-  ): Promise<unknown>;
+  ): Promise<TAdapterConfiguration>;
   getIsConfigurationStatus(
     adapterConfigurationStatus: TAdapterConfigurationStatus
   ): boolean;


### PR DESCRIPTION
#### Summary

This builds on the previous PR to not set the status too eagerly if possible. It has a fallback mechanism to respect old adapters which don't resolve configuration or reconfiguration with a result of it.