### PR TITLE
refactor: to only use import type

### DIFF
--- a/packages/launchdarkly-adapter/modules/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.ts
@@ -1,19 +1,22 @@
-import { DeepReadonly } from 'ts-essentials';
-import {
+import type { DeepReadonly } from 'ts-essentials';
+import type {
   TFlagName,
   TFlagVariation,
   TAdapterStatus,
   TUser,
   TFlag,
   TFlags,
-  TLaunchDarklyAdapterInterface,
   TLaunchDarklyAdapterArgs,
   TAdapterEventHandlers,
+} from '@flopflip/types';
+import {
+  TLaunchDarklyAdapterInterface,
   TAdapterSubscriptionStatus,
   TAdapterConfigurationStatus,
   TAdapterInitializationStatus,
   interfaceIdentifiers,
 } from '@flopflip/types';
+
 import merge from 'deepmerge';
 import warning from 'tiny-warning';
 import isEqual from 'lodash/isEqual';

--- a/packages/localstorage-adapter/modules/adapter/adapter.ts
+++ b/packages/localstorage-adapter/modules/adapter/adapter.ts
@@ -1,25 +1,28 @@
-import { DeepReadonly } from 'ts-essentials';
-import warning from 'tiny-warning';
-import mitt, { Emitter } from 'mitt';
-import camelCase from 'lodash/camelCase';
-import isEqual from 'lodash/isEqual';
-import {
+import type { DeepReadonly } from 'ts-essentials';
+import type {
   TUser,
   TAdapterStatus,
   TAdapterStatusChange,
   TAdapterEventHandlers,
-  TLocalStorageAdapterInterface,
   TLocalStorageAdapterArgs,
   TFlagName,
   TFlagVariation,
   TFlag,
   TFlags,
   TLocalStorageAdapterSubscriptionOptions,
+} from '@flopflip/types';
+import {
+  TLocalStorageAdapterInterface,
   TAdapterSubscriptionStatus,
   TAdapterConfigurationStatus,
   TAdapterInitializationStatus,
   interfaceIdentifiers,
 } from '@flopflip/types';
+
+import warning from 'tiny-warning';
+import mitt, { Emitter } from 'mitt';
+import camelCase from 'lodash/camelCase';
+import isEqual from 'lodash/isEqual';
 
 type Storage = {
   get: (key: string) => any;

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -1,7 +1,5 @@
-import { DeepReadonly } from 'ts-essentials';
-import warning from 'tiny-warning';
-import mitt, { Emitter } from 'mitt';
-import {
+import type { DeepReadonly } from 'ts-essentials';
+import type {
   TUser,
   TAdapterStatus,
   TAdapterStatusChange,
@@ -10,13 +8,18 @@ import {
   TFlag,
   TFlags,
   TAdapterEventHandlers,
+  TMemoryAdapterArgs,
+} from '@flopflip/types';
+import {
   TMemoryAdapterInterface,
   TAdapterSubscriptionStatus,
   TAdapterConfigurationStatus,
   TAdapterInitializationStatus,
-  TMemoryAdapterArgs,
   interfaceIdentifiers,
 } from '@flopflip/types';
+
+import warning from 'tiny-warning';
+import mitt, { Emitter } from 'mitt';
 import camelCase from 'lodash/camelCase';
 
 type MemoryAdapterState = {

--- a/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
+++ b/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
@@ -1,4 +1,4 @@
-import { TFlagName, TFlagVariation } from '@flopflip/types';
+import type { TFlagName, TFlagVariation } from '@flopflip/types';
 
 import React from 'react';
 import { useFeatureToggle } from '../../hooks';

--- a/packages/react-broadcast/modules/components/configure/configure.tsx
+++ b/packages/react-broadcast/modules/components/configure/configure.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import {
+import type {
   TAdapter,
   TFlags,
   TAdapterStatus,
@@ -7,9 +6,13 @@ import {
   TAdapterStatusChange,
   TConfigureAdapterChildren,
   TConfigureAdapterProps,
+} from '@flopflip/types';
+import {
   TAdapterConfigurationStatus,
   TAdapterSubscriptionStatus,
 } from '@flopflip/types';
+
+import React from 'react';
 import { ConfigureAdapter, useAdapterSubscription } from '@flopflip/react';
 import { FlagsContext } from '../flags-context';
 
@@ -67,14 +70,14 @@ const Configure = <AdapterInstance extends TAdapter>(
   const getHasAdapterSubscriptionStatus = useAdapterSubscription(props.adapter);
 
   const handleUpdateFlags = React.useCallback<(flags: TFlagsChange) => void>(
-    flags => {
+    (flags) => {
       if (
         getHasAdapterSubscriptionStatus(TAdapterSubscriptionStatus.Unsubscribed)
       ) {
         return;
       }
 
-      setFlags(prevFlags => ({
+      setFlags((prevFlags) => ({
         ...prevFlags,
         ...flags,
       }));
@@ -85,14 +88,14 @@ const Configure = <AdapterInstance extends TAdapter>(
   const handleUpdateStatus = React.useCallback<
     (status: TAdapterStatusChange) => void
   >(
-    status => {
+    (status) => {
       if (
         getHasAdapterSubscriptionStatus(TAdapterSubscriptionStatus.Unsubscribed)
       ) {
         return;
       }
 
-      setStatus(prevStatus => ({
+      setStatus((prevStatus) => ({
         ...prevStatus,
         ...status,
       }));

--- a/packages/react-broadcast/modules/components/flags-context/flags-context.ts
+++ b/packages/react-broadcast/modules/components/flags-context/flags-context.ts
@@ -1,5 +1,6 @@
+import type { TFlags } from '@flopflip/types';
+
 import React from 'react';
-import { TFlags } from '@flopflip/types';
 
 const intialFlagsContext = {};
 const FlagsContext = React.createContext<TFlags>(intialFlagsContext);

--- a/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.tsx
+++ b/packages/react-broadcast/modules/components/inject-feature-toggle/inject-feature-toggle.tsx
@@ -1,3 +1,5 @@
+import type { TFlagName, TFlagVariation } from '@flopflip/types';
+
 import React from 'react';
 import {
   wrapDisplayName,
@@ -5,7 +7,6 @@ import {
   DEFAULT_FLAG_PROP_KEY,
 } from '@flopflip/react';
 import { useFlagVariations } from '../../hooks';
-import { TFlagName, TFlagVariation } from '@flopflip/types';
 
 type InjectedProps = {
   [propKey: string]: TFlagVariation;

--- a/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.tsx
+++ b/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.tsx
@@ -1,3 +1,5 @@
+import type { TFlagName, TFlags } from '@flopflip/types';
+
 import React from 'react';
 import {
   wrapDisplayName,
@@ -5,7 +7,6 @@ import {
   DEFAULT_FLAGS_PROP_KEY,
 } from '@flopflip/react';
 import { useFlagVariations } from '../../hooks';
-import { TFlagName, TFlags } from '@flopflip/types';
 
 type InjectedProps = {
   [propKey: string]: TFlags;

--- a/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.tsx
+++ b/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.tsx
@@ -1,4 +1,4 @@
-import { TFlagName, TFlagVariation } from '@flopflip/types';
+import type { TFlagName, TFlagVariation } from '@flopflip/types';
 
 import React from 'react';
 import {

--- a/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.ts
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggle/use-feature-toggle.ts
@@ -1,6 +1,7 @@
+import type { TFlagName, TFlags, TFlagVariation } from '@flopflip/types';
+
 import React from 'react';
 import { getIsFeatureEnabled } from '@flopflip/react';
-import { TFlagName, TFlags, TFlagVariation } from '@flopflip/types';
 import { FlagsContext } from '../../components/flags-context';
 
 export default function useFeatureToggle(

--- a/packages/react-broadcast/modules/hooks/use-feature-toggles/use-feature-toggles.ts
+++ b/packages/react-broadcast/modules/hooks/use-feature-toggles/use-feature-toggles.ts
@@ -1,6 +1,7 @@
+import type { TFlagName, TFlags, TFlagVariation } from '@flopflip/types';
+
 import React from 'react';
 import { getIsFeatureEnabled } from '@flopflip/react';
-import { TFlagName, TFlags, TFlagVariation } from '@flopflip/types';
 import { FlagsContext } from '../../components/flags-context';
 
 export default function useFeatureToggles(flags: Readonly<TFlags>) {

--- a/packages/react-broadcast/modules/hooks/use-flag-variations/use-flag-variations.ts
+++ b/packages/react-broadcast/modules/hooks/use-flag-variations/use-flag-variations.ts
@@ -1,6 +1,7 @@
+import type { TFlagName, TFlags, TFlagVariation } from '@flopflip/types';
+
 import React from 'react';
 import { getFlagVariation } from '@flopflip/react';
-import { TFlagName, TFlags, TFlagVariation } from '@flopflip/types';
 import { FlagsContext } from '../../components/flags-context';
 
 export default function useFlagVariations(flagNames: Readonly<TFlagName[]>) {

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
@@ -1,4 +1,4 @@
-import { TFlagName, TFlagVariation } from '@flopflip/types';
+import type { TFlagName, TFlagVariation } from '@flopflip/types';
 
 import React from 'react';
 import { useFeatureToggle } from '../../hooks';

--- a/packages/react-redux/modules/components/configure/configure.tsx
+++ b/packages/react-redux/modules/components/configure/configure.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import { ConfigureAdapter, useAdapterSubscription } from '@flopflip/react';
-import {
+import type {
   TFlags,
   TAdapter,
   TConfigureAdapterProps,
   TConfigureAdapterChildren,
 } from '@flopflip/types';
+
+import React from 'react';
+import { ConfigureAdapter, useAdapterSubscription } from '@flopflip/react';
 import { useUpdateFlags, useUpdateStatus } from '../../hooks';
 
 type BaseProps = {

--- a/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.tsx
+++ b/packages/react-redux/modules/components/inject-feature-toggle/inject-feature-toggle.tsx
@@ -1,3 +1,5 @@
+import type { TFlagName, TFlagVariation } from '@flopflip/types';
+
 import React from 'react';
 import {
   wrapDisplayName,
@@ -5,7 +7,6 @@ import {
   DEFAULT_FLAG_PROP_KEY,
 } from '@flopflip/react';
 import { useFlagVariations } from '../../hooks';
-import { TFlagName, TFlagVariation } from '@flopflip/types';
 
 type InjectedProps = {
   [propKey: string]: TFlagVariation;

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.tsx
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.tsx
@@ -1,3 +1,5 @@
+import type { TFlagName, TFlags } from '@flopflip/types';
+
 import React from 'react';
 import {
   wrapDisplayName,
@@ -5,7 +7,6 @@ import {
   DEFAULT_FLAGS_PROP_KEY,
 } from '@flopflip/react';
 import { useFlagVariations } from '../../hooks';
-import { TFlagName, TFlags } from '@flopflip/types';
 
 type InjectedProps = {
   [propKey: string]: TFlags;

--- a/packages/react-redux/modules/components/toggle-feature/toggle-feature.tsx
+++ b/packages/react-redux/modules/components/toggle-feature/toggle-feature.tsx
@@ -1,4 +1,4 @@
-import { TFlagName, TFlagVariation } from '@flopflip/types';
+import type { TFlagName, TFlagVariation } from '@flopflip/types';
 
 import React from 'react';
 import {

--- a/packages/react-redux/modules/ducks/flags/flags.ts
+++ b/packages/react-redux/modules/ducks/flags/flags.ts
@@ -1,10 +1,11 @@
-import { DeepReadonly } from 'ts-essentials';
-import {
+import type { DeepReadonly } from 'ts-essentials';
+import type {
   TFlagName,
   TFlagVariation,
   TFlags,
   TFlagsChange,
 } from '@flopflip/types';
+
 import { isNil } from '@flopflip/react';
 import { TUpdateFlagsAction } from './types.js';
 import { TState } from '../../types';

--- a/packages/react-redux/modules/ducks/flags/types.ts
+++ b/packages/react-redux/modules/ducks/flags/types.ts
@@ -1,4 +1,4 @@
-import { TFlags } from '@flopflip/types';
+import type { TFlags } from '@flopflip/types';
 
 export type TUpdateFlagsAction = {
   type: string;

--- a/packages/react-redux/modules/ducks/status/status.ts
+++ b/packages/react-redux/modules/ducks/status/status.ts
@@ -1,10 +1,10 @@
-import { DeepReadonly } from 'ts-essentials';
+import type { DeepReadonly } from 'ts-essentials';
+import type { TAdapterStatus, TAdapterStatusChange } from '@flopflip/types';
 import {
-  TAdapterStatus,
-  TAdapterStatusChange,
   TAdapterSubscriptionStatus,
   TAdapterConfigurationStatus,
 } from '@flopflip/types';
+
 import { selectAdapterConfigurationStatus } from '@flopflip/react';
 import { TUpdateStatusAction } from './types';
 import { TState } from '../../types';

--- a/packages/react-redux/modules/ducks/status/types.ts
+++ b/packages/react-redux/modules/ducks/status/types.ts
@@ -1,4 +1,4 @@
-import { TAdapterStatusChange } from '@flopflip/types';
+import type { TAdapterStatusChange } from '@flopflip/types';
 
 export type TUpdateStatusAction = {
   type: string;

--- a/packages/react-redux/modules/hooks/use-feature-toggle/use-feature-toggle.ts
+++ b/packages/react-redux/modules/hooks/use-feature-toggle/use-feature-toggle.ts
@@ -1,4 +1,4 @@
-import { TFlagName, TFlagVariation } from '@flopflip/types';
+import type { TFlagName, TFlagVariation } from '@flopflip/types';
 
 import React from 'react';
 import { useSelector } from 'react-redux';

--- a/packages/react-redux/modules/hooks/use-feature-toggles/use-feature-toggles.ts
+++ b/packages/react-redux/modules/hooks/use-feature-toggles/use-feature-toggles.ts
@@ -1,4 +1,4 @@
-import { TFlags, TFlagName, TFlagVariation } from '@flopflip/types';
+import type { TFlags, TFlagName, TFlagVariation } from '@flopflip/types';
 
 import { useSelector } from 'react-redux';
 import { getIsFeatureEnabled } from '@flopflip/react';

--- a/packages/react-redux/modules/hooks/use-flag-variations/use-flag-variations.ts
+++ b/packages/react-redux/modules/hooks/use-flag-variations/use-flag-variations.ts
@@ -1,4 +1,4 @@
-import { TFlagName, TFlagVariation } from '@flopflip/types';
+import type { TFlagName, TFlagVariation } from '@flopflip/types';
 
 import { getFlagVariation } from '@flopflip/react';
 import { useSelector } from 'react-redux';

--- a/packages/react-redux/modules/hooks/use-update-flags/use-update-flags.ts
+++ b/packages/react-redux/modules/hooks/use-update-flags/use-update-flags.ts
@@ -1,4 +1,5 @@
-import { TFlagsChange } from '@flopflip/types';
+import type { TFlagsChange } from '@flopflip/types';
+
 import React from 'react';
 import { Dispatch } from 'redux';
 import { useDispatch } from 'react-redux';

--- a/packages/react-redux/modules/hooks/use-update-status/use-update-status.ts
+++ b/packages/react-redux/modules/hooks/use-update-status/use-update-status.ts
@@ -1,4 +1,5 @@
-import { TAdapterStatusChange } from '@flopflip/types';
+import type { TAdapterStatusChange } from '@flopflip/types';
+
 import React from 'react';
 import { Dispatch } from 'redux';
 import { useDispatch } from 'react-redux';

--- a/packages/react-redux/modules/store/enhancer/enhancer.ts
+++ b/packages/react-redux/modules/store/enhancer/enhancer.ts
@@ -1,17 +1,18 @@
-import {
+import type {
   Store,
   StoreEnhancerStoreCreator,
   Reducer,
   PreloadedState,
 } from 'redux';
-import {
+import type {
   TAdapter,
   TAdapterArgs,
   TAdapterStatusChange,
   TFlagsChange,
   TAdapterInterface,
 } from '@flopflip/types';
-import { TState } from '../../types';
+import type { TState } from '../../types';
+
 import { updateFlags, updateStatus } from '../../ducks';
 
 export default function createFlopFlipEnhancer(

--- a/packages/react-redux/modules/types.ts
+++ b/packages/react-redux/modules/types.ts
@@ -1,6 +1,6 @@
-import { TFlags, TAdapterStatus } from '@flopflip/types';
-import { TUpdateStatusAction } from './ducks/status/types';
-import { TUpdateFlagsAction } from './ducks/flags/types';
+import type { TFlags, TAdapterStatus } from '@flopflip/types';
+import type { TUpdateStatusAction } from './ducks/status/types';
+import type { TUpdateFlagsAction } from './ducks/flags/types';
 
 import { STATE_SLICE } from './store/constants';
 

--- a/packages/react/modules/components/adapter-context/adapter-context.ts
+++ b/packages/react/modules/components/adapter-context/adapter-context.ts
@@ -1,11 +1,14 @@
-import React from 'react';
-import {
+import type {
+  TReconfigureAdapter,
   TAdapterContext,
   TAdapterStatus,
-  TReconfigureAdapter,
+} from '@flopflip/types';
+import {
   TAdapterSubscriptionStatus,
   TAdapterConfigurationStatus,
 } from '@flopflip/types';
+
+import React from 'react';
 
 const initialReconfigureAdapter: TReconfigureAdapter = () => undefined;
 const initialAdapterStatus: TAdapterStatus = {

--- a/packages/react/modules/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/modules/components/configure-adapter/configure-adapter.tsx
@@ -1,17 +1,20 @@
-import {
+import type {
   TFlags,
   TAdapter,
   TAdapterInterface,
   TAdapterArgs,
   TAdapterStatus,
   TAdapterReconfiguration,
-  TAdapterConfigurationStatus,
-  TAdapterInitializationStatus,
   TAdapterReconfigurationOptions,
   TConfigureAdapterChildren,
   TAdapterStatusChange,
   TFlagsChange,
 } from '@flopflip/types';
+import {
+  TAdapterConfigurationStatus,
+  TAdapterInitializationStatus,
+} from '@flopflip/types';
+
 import React from 'react';
 import {
   isFunctionChildren,
@@ -203,7 +206,7 @@ const useConfigurationEffect = ({
           onFlagsStateChange,
           onStatusStateChange,
         })
-        .then(configuration => {
+        .then((configuration) => {
           /**
            * NOTE:
            *    The configuration can be `undefined` then assuming `initializationStatus` to have
@@ -234,7 +237,7 @@ const useConfigurationEffect = ({
           onFlagsStateChange,
           onStatusStateChange,
         })
-        .then(reconfiguration => {
+        .then((reconfiguration) => {
           /**
            * NOTE:
            *    The configuration can be `undefined` then assuming `initializationStatus` to have
@@ -292,7 +295,7 @@ const useDefaultFlagsEffect = ({
           onFlagsStateChange,
           onStatusStateChange,
         })
-        .then(configuration => {
+        .then((configuration) => {
           /**
            * NOTE:
            *    The configuration can be `undefined` then assuming `initializationStatus` to have

--- a/packages/react/modules/components/reconfigure-adapter/reconfigure-adapter.ts
+++ b/packages/react/modules/components/reconfigure-adapter/reconfigure-adapter.ts
@@ -1,6 +1,7 @@
-import { DeepReadonly } from 'ts-essentials';
+import type { DeepReadonly } from 'ts-essentials';
+import type { TUser } from '@flopflip/types';
+
 import React from 'react';
-import { TUser } from '@flopflip/types';
 import AdapterContext from '../adapter-context';
 
 type Props = DeepReadonly<{

--- a/packages/react/modules/components/toggle-feature/toggle-feature.ts
+++ b/packages/react/modules/components/toggle-feature/toggle-feature.ts
@@ -1,4 +1,5 @@
-import { DeepReadonly } from 'ts-essentials';
+import type { DeepReadonly } from 'ts-essentials';
+
 import React from 'react';
 import warning from 'tiny-warning';
 import { isValidElementType } from 'react-is';

--- a/packages/react/modules/helpers/get-flag-variation/get-flag-variation.ts
+++ b/packages/react/modules/helpers/get-flag-variation/get-flag-variation.ts
@@ -1,4 +1,5 @@
-import { TFlagName, TFlagVariation, TFlags } from '@flopflip/types';
+import type { TFlagName, TFlagVariation, TFlags } from '@flopflip/types';
+
 import warning from 'tiny-warning';
 import { DEFAULT_FLAG_PROP_KEY } from '../../constants';
 import getNormalizedFlagName from '../get-normalized-flag-name';

--- a/packages/react/modules/helpers/get-is-feature-enabled/get-is-feature-enabled.ts
+++ b/packages/react/modules/helpers/get-is-feature-enabled/get-is-feature-enabled.ts
@@ -1,4 +1,5 @@
-import { TFlagName, TFlagVariation, TFlags } from '@flopflip/types';
+import type { TFlagName, TFlagVariation, TFlags } from '@flopflip/types';
+
 import { DEFAULT_FLAG_PROP_KEY } from '../../constants';
 import getFlagVariation from '../get-flag-variation';
 

--- a/packages/react/modules/helpers/get-normalized-flag-name/get-normalized-flag-name.ts
+++ b/packages/react/modules/helpers/get-normalized-flag-name/get-normalized-flag-name.ts
@@ -1,4 +1,5 @@
-import { TFlagName } from '@flopflip/types';
+import type { TFlagName } from '@flopflip/types';
+
 import camelCase from 'lodash/camelCase';
 
 const getNormalizedFlagName = (flagName: TFlagName): TFlagName => {

--- a/packages/react/modules/hooks/use-adapter-reconfiguration/use-adapter-reconfiguration.ts
+++ b/packages/react/modules/hooks/use-adapter-reconfiguration/use-adapter-reconfiguration.ts
@@ -1,6 +1,7 @@
+import type { TAdapterContext } from '@flopflip/types';
+
 import React from 'react';
 import { AdapterContext } from '@flopflip/react';
-import { TAdapterContext } from '@flopflip/types';
 
 export default function useAdapterReconfiguration() {
   const adapterContext: TAdapterContext = React.useContext(AdapterContext);

--- a/packages/react/modules/hooks/use-adapter-subscription/use-adapter-subscription.ts
+++ b/packages/react/modules/hooks/use-adapter-subscription/use-adapter-subscription.ts
@@ -1,4 +1,6 @@
-import { TAdapter, TAdapterSubscriptionStatus } from '@flopflip/types';
+import type { TAdapter } from '@flopflip/types';
+import { TAdapterSubscriptionStatus } from '@flopflip/types';
+
 import React from 'react';
 
 function useAdapterSubscription(adapter: TAdapter) {

--- a/packages/splitio-adapter/modules/adapter/adapter.ts
+++ b/packages/splitio-adapter/modules/adapter/adapter.ts
@@ -1,5 +1,5 @@
-import { DeepReadonly, Writable, DeepWritable } from 'ts-essentials';
-import {
+import type { DeepReadonly, Writable, DeepWritable } from 'ts-essentials';
+import type {
   TFlagName,
   TFlagVariation,
   TAdapterStatus,
@@ -11,11 +11,14 @@ import {
   TAdapterEventHandlers,
   TSplitioAdapterInterface,
   TSplitioAdapterArgs,
+} from '@flopflip/types';
+import {
   TAdapterSubscriptionStatus,
   TAdapterConfigurationStatus,
   TAdapterInitializationStatus,
   interfaceIdentifiers,
 } from '@flopflip/types';
+
 import merge from 'deepmerge';
 import warning from 'tiny-warning';
 import { SplitFactory } from '@splitsoftware/splitio';

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,5 +1,5 @@
-import { LDClient as TLDClient } from 'launchdarkly-js-client-sdk';
-import { DeepReadonly } from 'ts-essentials';
+import type { LDClient as TLDClient } from 'launchdarkly-js-client-sdk';
+import type { DeepReadonly } from 'ts-essentials';
 
 export type TFlagName = string;
 export type TFlagVariation = boolean | string;


### PR DESCRIPTION
#### Summary

This pull request refactors flopflip to only used `import type` where possible. A feature available since TypeScript 3.8.