### PR TITLE
refactor: to use only readonly types

### DIFF
--- a/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
+++ b/packages/react-broadcast/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
@@ -3,11 +3,12 @@ import type { TFlagName, TFlagVariation } from '@flopflip/types';
 import React from 'react';
 import { useFeatureToggle } from '../../hooks';
 
+type TBranchOnFeatureToggleOptions = Readonly<{
+  flag: TFlagName;
+  variation?: TFlagVariation;
+}>;
 export default function branchOnFeatureToggle<OwnProps extends object>(
-  {
-    flag: flagName,
-    variation: flagVariation,
-  }: { flag: TFlagName; variation?: TFlagVariation },
+  { flag: flagName, variation: flagVariation }: TBranchOnFeatureToggleOptions,
   UntoggledComponent?: React.ComponentType
 ) {
   return (ToggledComponent: React.ComponentType<OwnProps>) => {

--- a/packages/react-broadcast/modules/components/configure/configure.tsx
+++ b/packages/react-broadcast/modules/components/configure/configure.tsx
@@ -1,3 +1,4 @@
+import type { DeepReadonly } from 'ts-essentials';
 import type {
   TAdapter,
   TFlags,
@@ -35,21 +36,29 @@ const initialAdapterStatus: State['status'] = {
 };
 const initialFlags: State['flags'] = {};
 
+type TUseFlagStateOptions = DeepReadonly<{
+  initialFlags: State['flags'];
+}>;
 const useFlagsState = ({
   initialFlags,
-}: {
-  initialFlags: State['flags'];
-}): [TFlags, React.Dispatch<React.SetStateAction<TFlags>>] => {
+}: TUseFlagStateOptions): [
+  TFlags,
+  React.Dispatch<React.SetStateAction<Readonly<TFlags>>>
+] => {
   const [flags, setFlags] = React.useState<State['flags']>(initialFlags);
 
   return [flags, setFlags];
 };
 
+type TUseStatusStateOptions = DeepReadonly<{
+  initialAdapterStatus: State['status'];
+}>;
 const useStatusState = ({
   initialAdapterStatus,
-}: {
-  initialAdapterStatus: State['status'];
-}): [TAdapterStatus, React.Dispatch<React.SetStateAction<TAdapterStatus>>] => {
+}: TUseStatusStateOptions): [
+  TAdapterStatus,
+  React.Dispatch<React.SetStateAction<Readonly<TAdapterStatus>>>
+] => {
   const [status, setStatus] = React.useState<State['status']>(
     initialAdapterStatus
   );
@@ -58,7 +67,7 @@ const useStatusState = ({
 };
 
 const Configure = <AdapterInstance extends TAdapter>(
-  props: Props<AdapterInstance>
+  props: DeepReadonly<Props<AdapterInstance>>
 ) => {
   const [flags, setFlags] = useFlagsState({ initialFlags });
   const [status, setStatus] = useStatusState({ initialAdapterStatus });
@@ -69,7 +78,9 @@ const Configure = <AdapterInstance extends TAdapter>(
   //   component.
   const getHasAdapterSubscriptionStatus = useAdapterSubscription(props.adapter);
 
-  const handleUpdateFlags = React.useCallback<(flags: TFlagsChange) => void>(
+  const handleUpdateFlags = React.useCallback<
+    (flags: Readonly<TFlagsChange>) => void
+  >(
     (flags) => {
       if (
         getHasAdapterSubscriptionStatus(TAdapterSubscriptionStatus.Unsubscribed)
@@ -86,7 +97,7 @@ const Configure = <AdapterInstance extends TAdapter>(
   );
 
   const handleUpdateStatus = React.useCallback<
-    (status: TAdapterStatusChange) => void
+    (status: Readonly<TAdapterStatusChange>) => void
   >(
     (status) => {
       if (

--- a/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.tsx
+++ b/packages/react-broadcast/modules/components/inject-feature-toggles/inject-feature-toggles.tsx
@@ -13,7 +13,7 @@ type InjectedProps = {
 };
 
 export default function injectFeatureToggles<OwnProps extends object>(
-  flagNames: TFlagName[],
+  flagNames: Readonly<TFlagName[]>,
   propKey: string = DEFAULT_FLAGS_PROP_KEY
 ) {
   return (

--- a/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.tsx
+++ b/packages/react-broadcast/modules/components/toggle-feature/toggle-feature.tsx
@@ -1,3 +1,4 @@
+import type { DeepReadonly } from 'ts-essentials';
 import type { TFlagName, TFlagVariation } from '@flopflip/types';
 
 import React from 'react';
@@ -7,11 +8,13 @@ import {
 } from '@flopflip/react';
 import { useFeatureToggle } from '../../hooks/';
 
-type Props = {
-  flag: TFlagName;
-  variation?: TFlagVariation;
-  // eslint-disable-next-line @typescript-eslint/ban-types
-} & Omit<TToggleFeatureProps, 'isFeatureEnabled'>;
+type Props = DeepReadonly<
+  {
+    flag: TFlagName;
+    variation?: TFlagVariation;
+    // eslint-disable-next-line @typescript-eslint/ban-types
+  } & Omit<TToggleFeatureProps, 'isFeatureEnabled'>
+>;
 
 const ToggleFeature = <OwnProps extends Props>(props: OwnProps) => {
   const isFeatureEnabled = useFeatureToggle(props.flag, props.variation);

--- a/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
+++ b/packages/react-redux/modules/components/branch-on-feature-toggle/branch-on-feature-toggle.tsx
@@ -3,11 +3,12 @@ import type { TFlagName, TFlagVariation } from '@flopflip/types';
 import React from 'react';
 import { useFeatureToggle } from '../../hooks';
 
+type TBranchOnFeatureToggleOptions = Readonly<{
+  flag: TFlagName;
+  variation?: TFlagVariation;
+}>;
 export default function branchOnFeatureToggle<OwnProps extends object>(
-  {
-    flag: flagName,
-    variation: flagVariation,
-  }: { flag: TFlagName; variation?: TFlagVariation },
+  { flag: flagName, variation: flagVariation }: TBranchOnFeatureToggleOptions,
   UntoggledComponent?: React.ComponentType
 ) {
   return (ToggledComponent: React.ComponentType<OwnProps>) => {

--- a/packages/react-redux/modules/components/configure/configure.tsx
+++ b/packages/react-redux/modules/components/configure/configure.tsx
@@ -1,3 +1,4 @@
+import type { DeepReadonly } from 'ts-essentials';
 import type {
   TFlags,
   TAdapter,
@@ -26,7 +27,7 @@ const defaultProps: Pick<
 };
 
 const Configure = <AdapterInstance extends TAdapter>(
-  props: Props<AdapterInstance>
+  props: DeepReadonly<Props<AdapterInstance>>
 ) => {
   const handleUpdateFlags = useUpdateFlags();
   const handleUpdateStatus = useUpdateStatus();

--- a/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.tsx
+++ b/packages/react-redux/modules/components/inject-feature-toggles/inject-feature-toggles.tsx
@@ -13,7 +13,7 @@ type InjectedProps = {
 };
 
 export default <OwnProps extends object>(
-  flagNames: TFlagName[],
+  flagNames: Readonly<TFlagName[]>,
   propKey: string = DEFAULT_FLAGS_PROP_KEY
 ) => (
   Component: React.ComponentType


### PR DESCRIPTION
This pull request moves on with the new ESLint recommendation to only use readonly types. While doing so previously untyped parts of the code base are now also more strictly typed.
