### PR TITLE
feat: add use-flag-variation

### DIFF
--- a/.changeset/rare-tools-tie.md
+++ b/.changeset/rare-tools-tie.md
@@ -1,0 +1,23 @@
+---
+"@flopflip/react-broadcast": minor
+"@flopflip/react-redux": minor
+"@flopflip/react": patch
+---
+
+feat: add use-flag-variation hook
+
+You can now conveniently a flag variation without evaluating its actual state (as with `useFeatureToggle`).
+
+```js
+const variation = useFlagVariation('myFlagName');
+
+const isAEnabled = variation === VARIATION_A;
+const isBEnabled = variation === VARIATION_B;
+
+// Is the same as
+
+const isAEnabled = useFlagVariation('myFlagName', VARIATION_A);
+const isBEnabled = useFlagVariation('myFlagName', VARIATION_B);
+```
+
+Using `useFlagVariation` is often a bit more concise if you want to work with the variation value yourself.

--- a/packages/react-broadcast/modules/hooks/index.ts
+++ b/packages/react-broadcast/modules/hooks/index.ts
@@ -1,5 +1,6 @@
 export { default as useFeatureToggle } from './use-feature-toggle';
 export { default as useFeatureToggles } from './use-feature-toggles';
+export { default as useFlagVariation } from './use-flag-variation';
 export { default as useFlagVariations } from './use-flag-variations';
 export { default as useAdapterStatus } from './use-adapter-status';
 export { default as useAdapterReconfiguration } from './use-adapter-reconfiguration';

--- a/packages/react-broadcast/modules/hooks/use-flag-variation/index.ts
+++ b/packages/react-broadcast/modules/hooks/use-flag-variation/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-flag-variation';

--- a/packages/react-broadcast/modules/hooks/use-flag-variation/use-flag-variation.spec.js
+++ b/packages/react-broadcast/modules/hooks/use-flag-variation/use-flag-variation.spec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import useFlagVariation from './use-flag-variation';
+import { renderWithAdapter } from '@flopflip/test-utils';
+import Configure from '../../components/configure';
+
+const render = (TestComponent) =>
+  renderWithAdapter(TestComponent, {
+    components: { ConfigureFlopFlip: Configure },
+  });
+
+const TestComponent = () => {
+  const variation = useFlagVariation('variation');
+
+  return (
+    <ul>
+      <li>Variation: {variation}</li>
+    </ul>
+  );
+};
+
+it('should indicate a flag variation', async () => {
+  const rendered = render(<TestComponent />);
+
+  await rendered.waitUntilConfigured();
+
+  expect(rendered.getByText('Variation: A')).toBeInTheDocument();
+});

--- a/packages/react-broadcast/modules/hooks/use-flag-variation/use-flag-variation.ts
+++ b/packages/react-broadcast/modules/hooks/use-flag-variation/use-flag-variation.ts
@@ -1,0 +1,9 @@
+import type { TFlagName } from '@flopflip/types';
+
+import useFlagVariations from '../use-flag-variations';
+
+export default function useFlagVariation(flagName: Readonly<TFlagName>) {
+  const [flagVariation] = useFlagVariations([flagName]);
+
+  return flagVariation;
+}

--- a/packages/react-broadcast/modules/index.ts
+++ b/packages/react-broadcast/modules/index.ts
@@ -8,10 +8,13 @@ export {
   ConfigureFlopFlip,
   ReconfigureFlopFlip,
 } from './components';
+
 export {
   useFeatureToggle,
   useFeatureToggles,
   useAdapterStatus,
   useAdapterReconfiguration,
+  useFlagVariation,
 } from './hooks';
+
 export { version };

--- a/packages/react-redux/modules/hooks/index.ts
+++ b/packages/react-redux/modules/hooks/index.ts
@@ -1,8 +1,8 @@
 export { default as useUpdateFlags } from './use-update-flags';
 export { default as useUpdateStatus } from './use-update-status';
-
 export { default as useAdapterReconfiguration } from './use-adapter-reconfiguration';
 export { default as useAdapterStatus } from './use-adapter-status';
 export { default as useFeatureToggle } from './use-feature-toggle';
 export { default as useFeatureToggles } from './use-feature-toggles';
+export { default as useFlagVariation } from './use-flag-variation';
 export { default as useFlagVariations } from './use-flag-variations';

--- a/packages/react-redux/modules/hooks/use-flag-variation/index.ts
+++ b/packages/react-redux/modules/hooks/use-flag-variation/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-flag-variation';

--- a/packages/react-redux/modules/hooks/use-flag-variation/use-flag-variation.spec.js
+++ b/packages/react-redux/modules/hooks/use-flag-variation/use-flag-variation.spec.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import useFlagVariation from './use-flag-variation';
+import { renderWithAdapter } from '@flopflip/test-utils';
+import { createStore } from '../../../test-utils';
+import { STATE_SLICE } from '../../store/constants';
+import Configure from '../../components/configure';
+
+const render = (store, TestComponent) =>
+  renderWithAdapter(TestComponent, {
+    components: {
+      ConfigureFlopFlip: Configure,
+      Wrapper: <Provider store={store} />,
+    },
+  });
+
+const TestComponent = () => {
+  const variation = useFlagVariation('variation');
+
+  return (
+    <ul>
+      <li>Variation: {variation}</li>
+    </ul>
+  );
+};
+
+it('should indicate a flag variation', async () => {
+  const store = createStore({
+    [STATE_SLICE]: {
+      flags: {
+        variation: 'A',
+      },
+    },
+  });
+  const rendered = render(store, <TestComponent />);
+
+  await rendered.waitUntilConfigured();
+
+  expect(rendered.getByText('Variation: A')).toBeInTheDocument();
+});

--- a/packages/react-redux/modules/hooks/use-flag-variation/use-flag-variation.ts
+++ b/packages/react-redux/modules/hooks/use-flag-variation/use-flag-variation.ts
@@ -1,0 +1,9 @@
+import type { TFlagName } from '@flopflip/types';
+
+import useFlagVariations from '../use-flag-variations';
+
+export default function useFlagVariation(flagName: Readonly<TFlagName>) {
+  const [flagVariation] = useFlagVariations([flagName]);
+
+  return flagVariation;
+}

--- a/packages/react-redux/modules/index.ts
+++ b/packages/react-redux/modules/index.ts
@@ -27,6 +27,7 @@ export {
   useAdapterStatus,
   useFeatureToggle,
   useFeatureToggles,
+  useFlagVariation,
 } from './hooks';
 
 export { version };


### PR DESCRIPTION
#### Summary

This pull request adds a `useFlagVariation`-hook which allows convienent access to flag variations without evaluating their "actual" variation.

```js
const variation = useFlagVariation('foo')

const isEnabled = variation === MY_VARIATION.VARIATION_A;
```