### PR TITLE
fix: to check subscription of flag upon initial sdk fetch

### DIFF
--- a/.changeset/fresh-pens-clean.md
+++ b/.changeset/fresh-pens-clean.md
@@ -1,0 +1,8 @@
+---
+"@flopflip/launchdarkly-adapter": patch
+"@flopflip/localstorage-adapter": patch
+"@flopflip/memory-adapter": patch
+"@flopflip/splitio-adapter": patch
+---
+
+fix: to check subscription of flag upon initial sdk fetch

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.ts
@@ -107,8 +107,8 @@ const getIsFlagUnsubcribed = (flagName: TFlagName) =>
 const getIsFlagLocked = (flagName: TFlagName) =>
   adapterState.lockedFlags.has(flagName);
 
-const withoutUnsubscribedOrLockedFlags = (flags: TFlags): Partial<TFlags> =>
-  Object.fromEntries<TFlags>(
+const withoutUnsubscribedOrLockedFlags = (flags: TFlags) =>
+  Object.fromEntries(
     Object.entries(flags).filter(
       ([flagName]) =>
         !getIsFlagUnsubcribed(flagName) && !getIsFlagLocked(flagName)

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.ts
@@ -63,7 +63,7 @@ const updateFlagsInAdapterState = (
 ): void => {
   const updatedFlags = Object.entries(flags).reduce(
     (updatedFlags, [flagName, flagValue]) => {
-      if (adapterState.lockedFlags.has(flagName)) return updatedFlags;
+      if (getIsFlagLocked(flagName)) return updatedFlags;
 
       if (options?.lockFlags) {
         adapterState.lockedFlags.add(flagName);
@@ -94,13 +94,25 @@ const updateFlags: TFlagsUpdateFunction = (flags, options) => {
   updateFlagsInAdapterState(flags, options);
 
   // ...and flush initial state of flags
-  if (!getIsUnsubscribed()) {
+  if (!getIsAdapterUnsubscribed()) {
     adapterState.emitter.emit('flagsStateChange', adapterState.flags);
   }
 };
 
-const getIsUnsubscribed = () =>
+const getIsAdapterUnsubscribed = () =>
   adapterState.subscriptionStatus === TAdapterSubscriptionStatus.Unsubscribed;
+
+const getIsFlagUnsubcribed = (flagName: TFlagName) =>
+  adapterState.unsubscribedFlags.has(flagName);
+const getIsFlagLocked = (flagName: TFlagName) =>
+  adapterState.lockedFlags.has(flagName);
+
+const withoutUnsubscribedFlags = (flags: TFlags): Partial<TFlags> =>
+  Object.fromEntries<TFlags>(
+    Object.entries(flags).filter(
+      ([flagName]) => !getIsFlagUnsubcribed(flagName)
+    )
+  );
 
 const normalizeFlag = (
   flagName: TFlagName,
@@ -190,7 +202,9 @@ const getInitialFlags = async ({
         }
 
         if (flagsFromSdk) {
-          const flags: TFlags = normalizeFlags(flagsFromSdk);
+          const normalizedFlags = normalizeFlags(flagsFromSdk);
+          const flags = withoutUnsubscribedFlags(normalizedFlags);
+
           updateFlags(flags);
         }
 
@@ -199,7 +213,7 @@ const getInitialFlags = async ({
           TAdapterConfigurationStatus.Configured;
 
         // ...to then signal that the adapter is configured
-        if (!getIsUnsubscribed()) {
+        if (!getIsAdapterUnsubscribed()) {
           adapterState.emitter.emit('statusStateChange', {
             configurationStatus: adapterState.configurationStatus,
           });
@@ -401,7 +415,7 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
             flagValue
           );
 
-          if (adapterState.unsubscribedFlags.has(normalizedFlagName)) return;
+          if (getIsFlagUnsubcribed(normalizedFlagName)) return;
 
           // Sometimes the SDK flushes flag changes without a value having changed.
           if (!this._didFlagChange(normalizedFlagName, normalizedFlagValue))
@@ -416,7 +430,7 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
           updateFlagsInAdapterState(updatedFlags);
 
           const flushFlagsUpdate = () => {
-            if (!getIsUnsubscribed()) {
+            if (!getIsAdapterUnsubscribed()) {
               adapterState.emitter.emit('flagsStateChange', adapterState.flags);
             }
           };

--- a/packages/launchdarkly-adapter/modules/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/modules/adapter/adapter.ts
@@ -107,10 +107,11 @@ const getIsFlagUnsubcribed = (flagName: TFlagName) =>
 const getIsFlagLocked = (flagName: TFlagName) =>
   adapterState.lockedFlags.has(flagName);
 
-const withoutUnsubscribedFlags = (flags: TFlags): Partial<TFlags> =>
+const withoutUnsubscribedOrLockedFlags = (flags: TFlags): Partial<TFlags> =>
   Object.fromEntries<TFlags>(
     Object.entries(flags).filter(
-      ([flagName]) => !getIsFlagUnsubcribed(flagName)
+      ([flagName]) =>
+        !getIsFlagUnsubcribed(flagName) && !getIsFlagLocked(flagName)
     )
   );
 
@@ -203,7 +204,7 @@ const getInitialFlags = async ({
 
         if (flagsFromSdk) {
           const normalizedFlags = normalizeFlags(flagsFromSdk);
-          const flags = withoutUnsubscribedFlags(normalizedFlags);
+          const flags = withoutUnsubscribedOrLockedFlags(normalizedFlags);
 
           updateFlags(flags);
         }

--- a/packages/localstorage-adapter/modules/adapter/adapter.ts
+++ b/packages/localstorage-adapter/modules/adapter/adapter.ts
@@ -54,8 +54,10 @@ let adapterState: TAdapterStatus & LocalStorageAdapterState = {
   ...intialAdapterState,
 };
 
-const getIsUnsubscribed = () =>
+const getIsAdapterUnsubscribed = () =>
   adapterState.subscriptionStatus === TAdapterSubscriptionStatus.Unsubscribed;
+const getIsFlagLocked = (flagName: TFlagName) =>
+  adapterState.lockedFlags.has(flagName);
 
 const STORAGE_SLICE = '@flopflip';
 
@@ -122,7 +124,7 @@ const updateFlags: TFlagsUpdateFunction = (flags, options) => {
         flagValue
       );
 
-      if (adapterState.lockedFlags.has(normalizedFlagName)) return updatedFlags;
+      if (getIsFlagLocked(normalizedFlagName)) return updatedFlags;
 
       if (options?.lockFlags) {
         adapterState.lockedFlags.add(normalizedFlagName);
@@ -161,7 +163,7 @@ const subscribeToFlagsChanges = ({
   pollingInteral = 1000 * 60,
 }: Readonly<TLocalStorageAdapterSubscriptionOptions>) => {
   setInterval(() => {
-    if (!getIsUnsubscribed()) {
+    if (!getIsAdapterUnsubscribed()) {
       const nextFlags = normalizeFlags(storage.get('flags'));
 
       if (didFlagsChange(nextFlags)) {
@@ -186,13 +188,13 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
     adapterEventHandlers: Readonly<TAdapterEventHandlers>
   ) {
     const handleFlagsChange = (nextFlags: Readonly<TFlags>) => {
-      if (getIsUnsubscribed()) return;
+      if (getIsAdapterUnsubscribed()) return;
 
       adapterEventHandlers.onFlagsStateChange(nextFlags);
     };
 
     const handleStatusChange = (nextStatus: Readonly<TAdapterStatusChange>) => {
-      if (getIsUnsubscribed()) return;
+      if (getIsAdapterUnsubscribed()) return;
 
       adapterEventHandlers.onStatusStateChange(nextStatus);
     };

--- a/packages/memory-adapter/modules/adapter/adapter.ts
+++ b/packages/memory-adapter/modules/adapter/adapter.ts
@@ -49,8 +49,10 @@ const updateUser = (user: Readonly<TUser>) => {
   adapterState.user = user;
 };
 
-const getIsUnsubscribed = () =>
+const getIsAdapterUnsubscribed = () =>
   adapterState.subscriptionStatus === TAdapterSubscriptionStatus.Unsubscribed;
+const getIsFlagLocked = (flagName: TFlagName) =>
+  adapterState.lockedFlags.has(flagName);
 
 const normalizeFlag = (
   flagName: TFlagName,
@@ -80,7 +82,7 @@ const updateFlags: TFlagsUpdateFunction = (flags, options) => {
       flagValue
     );
 
-    if (adapterState.lockedFlags.has(normalizedFlagName)) return;
+    if (getIsFlagLocked(normalizedFlagName)) return;
 
     if (options?.lockFlags) {
       adapterState.lockedFlags.add(normalizedFlagName);
@@ -109,13 +111,13 @@ class MemoryAdapter implements TMemoryAdapterInterface {
     adapterEventHandlers: Readonly<TAdapterEventHandlers>
   ) {
     const handleFlagsChange = (nextFlags: Readonly<TFlags>) => {
-      if (getIsUnsubscribed()) return;
+      if (getIsAdapterUnsubscribed()) return;
 
       adapterEventHandlers.onFlagsStateChange(nextFlags);
     };
 
     const handleStatusChange = (nextStatus: Readonly<TAdapterStatusChange>) => {
-      if (getIsUnsubscribed()) return;
+      if (getIsAdapterUnsubscribed()) return;
 
       adapterEventHandlers.onStatusStateChange(nextStatus);
     };

--- a/packages/splitio-adapter/modules/adapter/adapter.ts
+++ b/packages/splitio-adapter/modules/adapter/adapter.ts
@@ -54,7 +54,7 @@ const adapterState: TAdapterStatus & SplitIOAdapterState = {
   splitioSettings: undefined,
 };
 
-const getIsUnsubscribed = () =>
+const getIsAdapterUnsubscribed = () =>
   adapterState.subscriptionStatus === TAdapterSubscriptionStatus.Unsubscribed;
 
 const normalizeFlag = (
@@ -115,7 +115,7 @@ const subscribeToFlagsChanges = ({
           } as SplitIO.Attributes
         );
 
-        if (!getIsUnsubscribed()) {
+        if (!getIsAdapterUnsubscribed()) {
           onFlagsStateChange(normalizeFlags(flags));
         }
       }
@@ -182,7 +182,7 @@ const subscribe = async ({
             } as SplitIO.Attributes
           );
 
-          if (!getIsUnsubscribed()) {
+          if (!getIsAdapterUnsubscribed()) {
             onFlagsStateChange(normalizeFlags(flags));
           }
 
@@ -191,7 +191,7 @@ const subscribe = async ({
             TAdapterConfigurationStatus.Configured;
           // ...to then signal that the adapter is configured
 
-          if (!getIsUnsubscribed()) {
+          if (!getIsAdapterUnsubscribed()) {
             onStatusStateChange({
               configurationStatus: adapterState.configurationStatus,
             });


### PR DESCRIPTION
#### Summary

Flags might have been set locked/unsubscribed when flags are initially loaded from the SDK.