### PR TITLE
Fix the syntax on isAdapterConfigured

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -319,7 +319,7 @@ You can also pass `render` or `children` as a function to act differently based 
 
 ```jsx
 <ConfigureFlopFlip adapter={adapter} adapterArgs={{ clientSideId, user }}>
-  {{isAdapterConfigured} => isAdapterConfigured ? <App /> : <LoadingSpinner />}
+  {(isAdapterConfigured) => isAdapterConfigured ? <App /> : <LoadingSpinner />}
 </ConfigureFlopFlip>;
 ```
 


### PR DESCRIPTION
#### Summary

Fixed the syntax on one of the examples for isAdapterConfigured

#### Description

If you copy and paste from that example it doesn't work!
