### PR TITLE
fix: to not infer returns

### DIFF
--- a/.changeset/wise-cats-turn.md
+++ b/.changeset/wise-cats-turn.md
@@ -1,0 +1,12 @@
+---
+"@flopflip/launchdarkly-adapter": patch
+"@flopflip/localstorage-adapter": patch
+"@flopflip/memory-adapter": patch
+"@flopflip/react-broadcast": patch
+"@flopflip/react-redux": patch
+"@flopflip/react": patch
+"@flopflip/splitio-adapter": patch
+"@flopflip/types": patch
+---
+
+fix: to not infer returns

--- a/packages/launchdarkly-adapter/src/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/src/adapter/adapter.ts
@@ -152,7 +152,9 @@ const changeUserContext = async (nextUser: Readonly<TUser>) =>
         new Error('Can not change user context: client not yet initialized.')
       );
 
-const normalizeFlags = (rawFlags: Readonly<TFlags>) =>
+const normalizeFlags = (
+  rawFlags: Readonly<TFlags>
+): Record<string, TFlagVariation> =>
   Object.entries(rawFlags).reduce<TFlags>(
     (normalizedFlags: TFlags, [flagName, flagValue]) => {
       const [normalizedFlagName, normalizedFlagValue]: TFlag = normalizeFlag(
@@ -350,7 +352,7 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
     return adapterState.client;
   }
 
-  getFlag(flagName: TFlagName) {
+  getFlag(flagName: TFlagName): TFlagVariation {
     return adapterState.flags[flagName];
   }
 

--- a/packages/localstorage-adapter/src/adapter/adapter.ts
+++ b/packages/localstorage-adapter/src/adapter/adapter.ts
@@ -70,7 +70,9 @@ const normalizeFlag = (
   // Multi variate flags contain a string or `null` - `false` seems more natural.
   flagValue === null || flagValue === undefined ? false : flagValue,
 ];
-const normalizeFlags = (rawFlags: Readonly<TFlags>) => {
+const normalizeFlags = (
+  rawFlags: Readonly<TFlags>
+): Record<'string', TFlagVariation> => {
   if (!rawFlags) return {};
 
   return Object.entries(rawFlags).reduce<TFlags>(

--- a/packages/localstorage-adapter/src/adapter/adapter.ts
+++ b/packages/localstorage-adapter/src/adapter/adapter.ts
@@ -73,7 +73,7 @@ const normalizeFlag = (
 const normalizeFlags = (
   rawFlags: Readonly<TFlags>
 ): Record<'string', TFlagVariation> =>
-  Object.entries(rawFlags).reduce<TFlags>(
+  Object.entries(rawFlags || {}).reduce<TFlags>(
     (normalizedFlags: TFlags, [flagName, flagValue]) => {
       const [normalizedFlagName, normalizedFlagValue]: TFlag = normalizeFlag(
         flagName,

--- a/packages/localstorage-adapter/src/adapter/adapter.ts
+++ b/packages/localstorage-adapter/src/adapter/adapter.ts
@@ -72,10 +72,8 @@ const normalizeFlag = (
 ];
 const normalizeFlags = (
   rawFlags: Readonly<TFlags>
-): Record<'string', TFlagVariation> => {
-  if (!rawFlags) return {};
-
-  return Object.entries(rawFlags).reduce<TFlags>(
+): Record<'string', TFlagVariation> =>
+  Object.entries(rawFlags).reduce<TFlags>(
     (normalizedFlags: TFlags, [flagName, flagValue]) => {
       const [normalizedFlagName, normalizedFlagValue]: TFlag = normalizeFlag(
         flagName,
@@ -88,7 +86,6 @@ const normalizeFlags = (
     },
     {}
   );
-};
 
 const storage: Storage = {
   get: (key) => {

--- a/packages/memory-adapter/src/adapter/adapter.ts
+++ b/packages/memory-adapter/src/adapter/adapter.ts
@@ -215,7 +215,7 @@ class MemoryAdapter implements TMemoryAdapterInterface {
     });
   }
 
-  getFlag(flagName: TFlagName) {
+  getFlag(flagName: TFlagName): TFlagVariation {
     return adapterState?.flags[flagName];
   }
 

--- a/packages/react-broadcast/src/hooks/use-flag-variation/use-flag-variation.ts
+++ b/packages/react-broadcast/src/hooks/use-flag-variation/use-flag-variation.ts
@@ -1,8 +1,10 @@
-import type { TFlagName } from '@flopflip/types';
+import type { TFlagName, TFlagVariation } from '@flopflip/types';
 
 import useFlagVariations from '../use-flag-variations';
 
-export default function useFlagVariation(flagName: Readonly<TFlagName>) {
+export default function useFlagVariation(
+  flagName: Readonly<TFlagName>
+): TFlagVariation {
   const [flagVariation] = useFlagVariations([flagName]);
 
   return flagVariation;

--- a/packages/react-broadcast/src/hooks/use-flag-variations/use-flag-variations.ts
+++ b/packages/react-broadcast/src/hooks/use-flag-variations/use-flag-variations.ts
@@ -4,7 +4,9 @@ import React from 'react';
 import { getFlagVariation } from '@flopflip/react';
 import { FlagsContext } from '../../components/flags-context';
 
-export default function useFlagVariations(flagNames: Readonly<TFlagName[]>) {
+export default function useFlagVariations(
+  flagNames: Readonly<TFlagName[]>
+): TFlagVariation[] {
   const allFlags: TFlags = React.useContext(FlagsContext);
 
   const flagVariations: TFlagVariation[] = flagNames.map((requestedVariation) =>

--- a/packages/react-redux/src/hooks/use-flag-variation/use-flag-variation.ts
+++ b/packages/react-redux/src/hooks/use-flag-variation/use-flag-variation.ts
@@ -1,8 +1,10 @@
-import type { TFlagName } from '@flopflip/types';
+import type { TFlagName, TFlagVariation } from '@flopflip/types';
 
 import useFlagVariations from '../use-flag-variations';
 
-export default function useFlagVariation(flagName: Readonly<TFlagName>) {
+export default function useFlagVariation(
+  flagName: Readonly<TFlagName>
+): TFlagVariation {
   const [flagVariation] = useFlagVariations([flagName]);
 
   return flagVariation;

--- a/packages/react-redux/src/hooks/use-flag-variations/use-flag-variations.ts
+++ b/packages/react-redux/src/hooks/use-flag-variations/use-flag-variations.ts
@@ -4,7 +4,9 @@ import { getFlagVariation } from '@flopflip/react';
 import { useSelector } from 'react-redux';
 import { selectFlags } from '../../ducks/flags';
 
-export default function useFlagVariations(flagNames: Readonly<TFlagName[]>) {
+export default function useFlagVariations(
+  flagNames: Readonly<TFlagName[]>
+): TFlagVariation[] {
   const allFlags = useSelector(selectFlags);
 
   const flagVariations: TFlagVariation[] = flagNames.map((requestedVariation) =>

--- a/packages/react-redux/src/hooks/use-update-flags/use-update-flags.ts
+++ b/packages/react-redux/src/hooks/use-update-flags/use-update-flags.ts
@@ -1,11 +1,11 @@
-import type { TFlagsChange } from '@flopflip/types';
+import type { TFlagsChange, TUpdateFlagsAction } from '@flopflip/types';
 
 import React from 'react';
 import { Dispatch } from 'redux';
 import { useDispatch } from 'react-redux';
 import { updateFlags } from '../../ducks';
 
-const useUpdateFlags = () => {
+const useUpdateFlags = (): TUpdateFlagsAction => {
   const dispatch = useDispatch<Dispatch<ReturnType<typeof updateFlags>>>();
   return React.useCallback(
     (flags: Readonly<TFlagsChange>) => dispatch(updateFlags(flags)),

--- a/packages/react-redux/src/hooks/use-update-flags/use-update-flags.ts
+++ b/packages/react-redux/src/hooks/use-update-flags/use-update-flags.ts
@@ -1,11 +1,11 @@
-import type { TFlagsChange, TUpdateFlagsAction } from '@flopflip/types';
+import type { TFlagsChange, TAdapterEventHandlers } from '@flopflip/types';
 
 import React from 'react';
 import { Dispatch } from 'redux';
 import { useDispatch } from 'react-redux';
 import { updateFlags } from '../../ducks';
 
-const useUpdateFlags = (): TUpdateFlagsAction => {
+const useUpdateFlags = (): TAdapterEventHandlers['onFlagsStateChange'] => {
   const dispatch = useDispatch<Dispatch<ReturnType<typeof updateFlags>>>();
   return React.useCallback(
     (flags: Readonly<TFlagsChange>) => dispatch(updateFlags(flags)),

--- a/packages/react-redux/src/hooks/use-update-status/use-update-status.ts
+++ b/packages/react-redux/src/hooks/use-update-status/use-update-status.ts
@@ -1,11 +1,14 @@
-import type { TAdapterStatusChange } from '@flopflip/types';
+import type {
+  TAdapterStatusChange,
+  TUpdateStatusAction,
+} from '@flopflip/types';
 
 import React from 'react';
 import { Dispatch } from 'redux';
 import { useDispatch } from 'react-redux';
 import { updateStatus } from '../../ducks';
 
-const useUpdateStatus = () => {
+const useUpdateStatus = (): TUpdateStatusAction => {
   const dispatch = useDispatch<Dispatch<ReturnType<typeof updateStatus>>>();
   return React.useCallback(
     (status: Readonly<TAdapterStatusChange>) => dispatch(updateStatus(status)),

--- a/packages/react-redux/src/hooks/use-update-status/use-update-status.ts
+++ b/packages/react-redux/src/hooks/use-update-status/use-update-status.ts
@@ -1,6 +1,6 @@
 import type {
   TAdapterStatusChange,
-  TUpdateStatusAction,
+  TAdapterEventHandlers,
 } from '@flopflip/types';
 
 import React from 'react';
@@ -8,7 +8,7 @@ import { Dispatch } from 'redux';
 import { useDispatch } from 'react-redux';
 import { updateStatus } from '../../ducks';
 
-const useUpdateStatus = (): TUpdateStatusAction => {
+const useUpdateStatus = (): TAdapterEventHandlers['onStatusStateChange'] => {
   const dispatch = useDispatch<Dispatch<ReturnType<typeof updateStatus>>>();
   return React.useCallback(
     (status: Readonly<TAdapterStatusChange>) => dispatch(updateStatus(status)),

--- a/packages/react/src/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/src/components/configure-adapter/configure-adapter.tsx
@@ -8,8 +8,6 @@ import type {
   TAdapterReconfiguration,
   TAdapterReconfigurationOptions,
   TConfigureAdapterChildren,
-  TAdapterStatusChange,
-  TFlagsChange,
   TAdapterEventHandlers,
   TAdapterConfiguration,
 } from '@flopflip/types';
@@ -41,8 +39,8 @@ type TProps = {
   adapterArgs: TAdapterArgs;
   adapterStatus?: TAdapterStatus;
   defaultFlags?: TFlags;
-  onFlagsStateChange: (flags: Readonly<TFlagsChange>) => void;
-  onStatusStateChange: (status: Readonly<TAdapterStatusChange>) => void;
+  onFlagsStateChange: TAdapterEventHandlers['onFlagsStateChange'],
+  onStatusStateChange: TAdapterEventHandlers['onStatusStateChange'],
   render?: () => React.ReactNode;
   children?: TConfigureAdapterChildren;
 };

--- a/packages/splitio-adapter/src/adapter/adapter.ts
+++ b/packages/splitio-adapter/src/adapter/adapter.ts
@@ -77,7 +77,9 @@ const normalizeFlag = (
   return [camelCase(flagName), normalizeFlagValue];
 };
 
-const normalizeFlags = (flags: Readonly<TFlags>) =>
+const normalizeFlags = (
+  flags: Readonly<TFlags>
+): Record<'string', TFlagVariation> =>
   Object.entries(flags).reduce<TFlags>(
     (normalizedFlags: TFlags, [flagName, flaValue]) => {
       const [normalizedFlagName, normalizedFlagValue]: TFlag = normalizeFlag(

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -72,7 +72,6 @@ export const interfaceIdentifiers = {
   localstorage: 'localstorage',
   memory: 'memory',
   splitio: 'splitio',
-  // eslint-disable-next-line no-undef
 } as const;
 export type TAdapterInterfaceIdentifiers = typeof interfaceIdentifiers[keyof typeof interfaceIdentifiers];
 


### PR DESCRIPTION
#### Summary

This fixes the `(): import('../../types')` issue which seems to be Babel adding them.