### PR TITLE
fix: to simplify types of configure

### DIFF
--- a/.changeset/happy-hornets-give.md
+++ b/.changeset/happy-hornets-give.md
@@ -1,0 +1,8 @@
+---
+"@flopflip/react": patch
+"@flopflip/types": patch
+"@flopflip/react-redux": patch
+"@flopflip/react-broadcast": patch
+---
+
+fix: to simplify types of configure

--- a/packages/react/src/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/src/components/configure-adapter/configure-adapter.tsx
@@ -482,7 +482,7 @@ const ConfigureAdapter = (props: Readonly<TProps>) => {
           if (typeof props.render === 'function') return props.render();
         }
 
-        if (isFunctionChildren(props.children))
+        if (props.children && isFunctionChildren(props.children))
           return props.children({
             // NOTE: Deprecated, please use `isAdapterConfigured`.
             isAdapterReady: isAdapterConfigured,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,3 @@
-import type React from 'react';
 import type { LDClient as TLDClient } from 'launchdarkly-js-client-sdk';
 import type { DeepReadonly } from 'ts-essentials';
 
@@ -226,10 +225,10 @@ export type TConfigureAdapterChildrenAsFunctionArgs = {
 };
 export type TConfigureAdapterChildrenAsFunction = (
   args: Readonly<TConfigureAdapterChildrenAsFunctionArgs>
-) => React.ReactNode;
+) => JSX.Element;
 export type TConfigureAdapterChildren =
   | TConfigureAdapterChildrenAsFunction
-  | React.ReactNode;
+  | JSX.Element;
 export type TReconfigureAdapter = (
   adapterArgs: TAdapterArgs,
   options: Readonly<TAdapterReconfigurationOptions>

--- a/readme.md
+++ b/readme.md
@@ -319,8 +319,10 @@ You can also pass `render` or `children` as a function to act differently based 
 
 ```jsx
 <ConfigureFlopFlip adapter={adapter} adapterArgs={{ clientSideId, user }}>
-  {(isAdapterConfigured) => isAdapterConfigured ? <App /> : <LoadingSpinner />}
-</ConfigureFlopFlip>;
+  {(isAdapterConfigured) =>
+    isAdapterConfigured ? <App /> : <LoadingSpinner />
+  }
+</ConfigureFlopFlip>
 ```
 
 ```jsx


### PR DESCRIPTION
#### Summary

JSX.Element can be less than React.ReactNode. ReactNode can be booleans and undefined. As a result it creates quite bloated types which cause the library to fail typechecking.