### PR TITLE
fix(react-broadcast): do not reconfigure adapter multiple times

### DIFF
--- a/.changeset/eight-tables-drum.md
+++ b/.changeset/eight-tables-drum.md
@@ -1,0 +1,5 @@
+---
+'@flopflip/react-broadcast': patch
+---
+
+Fix ConfigureFlopFlip to not reconfigure adapter multiple times

--- a/packages/react-broadcast/src/components/configure/configure.spec.js
+++ b/packages/react-broadcast/src/components/configure/configure.spec.js
@@ -66,6 +66,22 @@ describe('when enabling feature', () => {
 
     expect(screen.getByText(/Feature enabled: Yes/i)).toBeInTheDocument();
   });
+
+  it('should not reconfigure the adapter multiple times', async () => {
+    const { waitUntilConfigured } = render();
+    const spy = jest.spyOn(adapter, 'reconfigure');
+
+    await waitUntilConfigured();
+
+    act(() => {
+      adapter.updateFlags({
+        [testFlagName]: true,
+      });
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
 });
 
 describe('when unconfigured', () => {

--- a/packages/react/src/hooks/use-adapter-subscription/use-adapter-subscription.ts
+++ b/packages/react/src/hooks/use-adapter-subscription/use-adapter-subscription.ts
@@ -1,6 +1,6 @@
 import type { TAdapter } from '@flopflip/types';
 import { AdapterSubscriptionStatus } from '@flopflip/types';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 function useAdapterSubscription(adapter: TAdapter) {
   /**
@@ -36,9 +36,12 @@ function useAdapterSubscription(adapter: TAdapter) {
     };
   }, [subscribe, unsubscribe]);
 
-  return (demandedAdapterSubscriptionStatus: AdapterSubscriptionStatus) =>
-    useAdapterSubscriptionStatusRef.current ===
-    demandedAdapterSubscriptionStatus;
+  return useCallback(
+    (demandedAdapterSubscriptionStatus: AdapterSubscriptionStatus) =>
+      useAdapterSubscriptionStatusRef.current ===
+      demandedAdapterSubscriptionStatus,
+    [useAdapterSubscriptionStatusRef]
+  );
 }
 
 export default useAdapterSubscription;


### PR DESCRIPTION
Fix `useAdapterSubscription` hook to return callback using `useCallback`
so that it does not force rerenders.
Fix `adapterIdentifiers` in `ConfigureFlopFlip` hoc to not cause
rerender as well.

Added a regression test that validates the bug.

fixes #1498
