### PR TITLE
test: react 18

### DIFF
--- a/.changeset/chatty-horses-jog.md
+++ b/.changeset/chatty-horses-jog.md
@@ -1,20 +1,20 @@
 ---
-"@flopflip/adapter-utilities": patch
-"@flopflip/combine-adapters": patch
-"@flopflip/cypress-plugin": patch
-"@flopflip/graphql-adapter": patch
-"@flopflip/http-adapter": patch
-"@flopflip/launchdarkly-adapter": patch
-"@flopflip/localstorage-adapter": patch
-"@flopflip/localstorage-cache": patch
-"@flopflip/memory-adapter": patch
-"@flopflip/react-broadcast": patch
-"@flopflip/react-redux": patch
-"@flopflip/react": patch
-"@flopflip/sessionstorage-cache": patch
-"@flopflip/splitio-adapter": patch
-"@flopflip/test-utils": patch
-"@flopflip/types": patch
+'@flopflip/adapter-utilities': patch
+'@flopflip/combine-adapters': patch
+'@flopflip/cypress-plugin': patch
+'@flopflip/graphql-adapter': patch
+'@flopflip/http-adapter': patch
+'@flopflip/launchdarkly-adapter': patch
+'@flopflip/localstorage-adapter': patch
+'@flopflip/localstorage-cache': patch
+'@flopflip/memory-adapter': patch
+'@flopflip/react-broadcast': patch
+'@flopflip/react-redux': patch
+'@flopflip/react': patch
+'@flopflip/sessionstorage-cache': patch
+'@flopflip/splitio-adapter': patch
+'@flopflip/test-utils': patch
+'@flopflip/types': patch
 ---
 
 refactor: to migrate to yarn#3

--- a/babel-plugin-package-version.js
+++ b/babel-plugin-package-version.js
@@ -6,9 +6,7 @@ const pluginReplacePackageVersion = function (babel) {
   return {
     visitor: {
       StringLiteral(path, state) {
-        if (
-          path.node.value === '__@FLOPFLIP/VERSION_OF_RELEASE__'
-        ) {
+        if (path.node.value === '__@FLOPFLIP/VERSION_OF_RELEASE__') {
           const packageJsonPath = findUpSync('package.json', {
             cwd: state.file.opts.filename,
           });

--- a/packages/graphql-adapter/src/adapter/adapter.spec.js
+++ b/packages/graphql-adapter/src/adapter/adapter.spec.js
@@ -302,9 +302,7 @@ describe('when configured', () => {
     });
 
     it('should reset cache', () => {
-      expect(sessionStorage.removeItem).toHaveBeenCalledWith(
-        '@flopflip/flags'
-      );
+      expect(sessionStorage.removeItem).toHaveBeenCalledWith('@flopflip/flags');
     });
   });
 

--- a/packages/react-broadcast/package.json
+++ b/packages/react-broadcast/package.json
@@ -31,8 +31,8 @@
     "@flopflip/test-utils": "*",
     "@types/react": "17.0.34",
     "@types/react-dom": "17.0.11",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react": "beta",
+    "react-dom": "beta"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0",

--- a/packages/react-broadcast/src/hooks/use-adapter-status/use-adapter-status.spec.js
+++ b/packages/react-broadcast/src/hooks/use-adapter-status/use-adapter-status.spec.js
@@ -1,4 +1,4 @@
-import { renderWithAdapter, screen } from '@flopflip/test-utils';
+import { act, renderWithAdapter, screen } from '@flopflip/test-utils';
 import React from 'react';
 
 import Configure from '../../components/configure';
@@ -33,6 +33,18 @@ it('should indicate the adapter is configured', async () => {
   const { waitUntilConfigured } = render(<TestComponent />);
 
   await waitUntilConfigured();
+
+  // UI is tearing. If this test is run in isolation we have "Is configuring: Yes"
+  expect(screen.getByText(/Is configuring: No/i)).toBeInTheDocument();
+  expect(screen.getByText(/Is configured: No/i)).toBeInTheDocument();
+
+  // Need 2 (only 1 if we only run this suite) more microtask to get UI into a consistent state.
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
 
   expect(screen.getByText(/Is configuring: No/i)).toBeInTheDocument();
   expect(screen.getByText(/Is configured: Yes/i)).toBeInTheDocument();

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -29,9 +29,9 @@
   "devDependencies": {
     "@flopflip/memory-adapter": "3.0.22",
     "@flopflip/test-utils": "*",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "react-redux": "7.2.6",
+    "react": "beta",
+    "react-dom": "beta",
+    "react-redux": "next",
     "redux": "4.1.2"
   },
   "dependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,8 +30,8 @@
     "@flopflip/test-utils": "*",
     "@types/react": "17.0.34",
     "@types/react-dom": "17.0.11",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react": "beta",
+    "react-dom": "beta"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0",

--- a/packages/react/src/components/configure-adapter/configure-adapter.spec.js
+++ b/packages/react/src/components/configure-adapter/configure-adapter.spec.js
@@ -1,4 +1,9 @@
-import { render as rtlRender, screen, waitFor } from '@flopflip/test-utils';
+import {
+  act,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from '@flopflip/test-utils';
 import React, { useContext } from 'react';
 
 import AdapterContext from '../adapter-context';
@@ -262,6 +267,12 @@ describe('when adapter args change after adapter was configured', () => {
     );
 
     await waitUntilStatus();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(adapter.reconfigure).toHaveBeenCalledWith(
       nextAdapterArgs,

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -18,11 +18,11 @@
     "@babel/runtime": "7.16.3",
     "@flopflip/memory-adapter": "3.0.22",
     "@testing-library/jest-dom": "5.15.0",
-    "@testing-library/react": "12.1.2",
+    "@testing-library/react": "alpha",
     "jest-localstorage-mock": "2.4.18",
     "jest-plugin-filename": "0.0.1",
     "jest-runner-eslint": "1.0.0",
     "jest-watch-yarn-workspaces": "1.1.0",
-    "react": "17.0.2"
+    "react": "beta"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,7 +1413,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.16.3, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.7, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:7.16.3, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.7, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.16.3
   resolution: "@babel/runtime@npm:7.16.3"
   dependencies:
@@ -2099,8 +2099,8 @@ __metadata:
     "@flopflip/types": 4.1.18
     "@types/react": 17.0.34
     "@types/react-dom": 17.0.11
-    react: 17.0.2
-    react-dom: 17.0.2
+    react: beta
+    react-dom: beta
   peerDependencies:
     react: ^16.8 || ^17.0
     react-dom: ^16.8 || ^17.0
@@ -2117,9 +2117,9 @@ __metadata:
     "@flopflip/test-utils": "*"
     "@flopflip/types": 4.1.18
     "@types/react-redux": 7.1.20
-    react: 17.0.2
-    react-dom: 17.0.2
-    react-redux: 7.2.6
+    react: beta
+    react-dom: beta
+    react-redux: next
     redux: 4.1.2
   peerDependencies:
     react: ^16.8 || ^17.0
@@ -2141,8 +2141,8 @@ __metadata:
     "@types/react-is": 17.0.3
     deepmerge: 4.2.2
     lodash: 4.17.21
-    react: 17.0.2
-    react-dom: 17.0.2
+    react: beta
+    react-dom: beta
     react-is: 17.0.2
     tiny-warning: 1.0.3
   peerDependencies:
@@ -2180,12 +2180,12 @@ __metadata:
     "@babel/runtime": 7.16.3
     "@flopflip/memory-adapter": 3.0.22
     "@testing-library/jest-dom": 5.15.0
-    "@testing-library/react": 12.1.2
+    "@testing-library/react": alpha
     jest-localstorage-mock: 2.4.18
     jest-plugin-filename: 0.0.1
     jest-runner-eslint: 1.0.0
     jest-watch-yarn-workspaces: 1.1.0
-    react: 17.0.2
+    react: beta
   languageName: unknown
   linkType: soft
 
@@ -2761,7 +2761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^8.0.0":
+"@testing-library/dom@npm:^8.5.0":
   version: 8.11.1
   resolution: "@testing-library/dom@npm:8.11.1"
   dependencies:
@@ -2794,16 +2794,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:12.1.2":
-  version: 12.1.2
-  resolution: "@testing-library/react@npm:12.1.2"
+"@testing-library/react@npm:alpha":
+  version: 13.0.0-alpha.4
+  resolution: "@testing-library/react@npm:13.0.0-alpha.4"
   dependencies:
     "@babel/runtime": ^7.12.5
-    "@testing-library/dom": ^8.0.0
+    "@testing-library/dom": ^8.5.0
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 70b0f7f27c83fe1a33e7df01b1e64850fbab4050c403848d611d852cadaa25ccde58518773002ae569a1350b2282c2ccbcbe5eb6af8b29ab377ab2a8ab573b3b
+  checksum: a3dd131f3beae549991d54dcf5a937fb5688b204dd51b451ee13a4bad09fead3e340ab70bec2860d91a09362b7e72814095db3fb5f032bf69a38509bda6e429d
   languageName: node
   linkType: hard
 
@@ -2912,7 +2912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/hoist-non-react-statics@npm:^3.3.0":
+"@types/hoist-non-react-statics@npm:^3.3.0, @types/hoist-non-react-statics@npm:^3.3.1":
   version: 3.3.1
   resolution: "@types/hoist-non-react-statics@npm:3.3.1"
   dependencies:
@@ -3061,7 +3061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-redux@npm:7.1.20, @types/react-redux@npm:^7.1.20":
+"@types/react-redux@npm:7.1.20":
   version: 7.1.20
   resolution: "@types/react-redux@npm:7.1.20"
   dependencies:
@@ -3143,6 +3143,13 @@ __metadata:
   dependencies:
     "@types/jest": "*"
   checksum: 77fe7ad3a9d49250972a0e3289b6d536942f95f0d539f32a917cf78c9422113d55c00de53b53dd4de1de49b68c8b500faea62e3017c4a64736cfbfbade749e04
+  languageName: node
+  linkType: hard
+
+"@types/use-sync-external-store@npm:^0.0.0":
+  version: 0.0.0
+  resolution: "@types/use-sync-external-store@npm:0.0.0"
+  checksum: 7921597f1a854f99d8ec861295b937d23dddd002685f5c2064ff488db850df56fccd361afd7cbec9f16852c325e97e6875e15b01a1be7843ec3de0e38f6587e4
   languageName: node
   linkType: hard
 
@@ -10254,61 +10261,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:17.0.2":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
+"react-dom@npm:beta":
+  version: 18.0.0-beta-96ca8d915-20211115
+  resolution: "react-dom@npm:18.0.0-beta-96ca8d915-20211115"
   dependencies:
     loose-envify: ^1.1.0
     object-assign: ^4.1.1
-    scheduler: ^0.20.2
+    scheduler: 0.21.0-beta-96ca8d915-20211115
   peerDependencies:
-    react: 17.0.2
-  checksum: 1c1eaa3bca7c7228d24b70932e3d7c99e70d1d04e13bb0843bbf321582bc25d7961d6b8a6978a58a598af2af496d1cedcfb1bf65f6b0960a0a8161cb8dab743c
+    react: 18.0.0-beta-96ca8d915-20211115
+  checksum: f5d1e61d8a3d95e18f2e9df29420955d9f5767aacfb56e86ebd7c9623123e6c0fa90ce2d887a71b3edd3002e80380266a1424189348a8fba133eeaefdec877f7
   languageName: node
   linkType: hard
 
-"react-is@npm:17.0.2, react-is@npm:^17.0.1, react-is@npm:^17.0.2":
+"react-is@npm:17.0.2, react-is@npm:^17.0.1":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.7.0, react-is@npm:^16.8.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0, react-is@npm:^16.8.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
   languageName: node
   linkType: hard
 
-"react-redux@npm:7.2.6":
-  version: 7.2.6
-  resolution: "react-redux@npm:7.2.6"
+"react-redux@npm:next":
+  version: 8.0.0-alpha.1
+  resolution: "react-redux@npm:8.0.0-alpha.1"
   dependencies:
-    "@babel/runtime": ^7.15.4
-    "@types/react-redux": ^7.1.20
+    "@babel/runtime": ^7.12.1
+    "@types/hoist-non-react-statics": ^3.3.1
+    "@types/use-sync-external-store": ^0.0.0
     hoist-non-react-statics: ^3.3.2
     loose-envify: ^1.4.0
-    prop-types: ^15.7.2
-    react-is: ^17.0.2
+    react-is: ^16.13.1
+    use-sync-external-store: 1.0.0-alpha-5cccacd13-20211101
   peerDependencies:
-    react: ^16.8.3 || ^17
+    react: ^18.0.0-alpha || ^18.0.0-beta
   peerDependenciesMeta:
     react-dom:
       optional: true
     react-native:
       optional: true
-  checksum: 0bf142ce0d0b80aef955650fd5e9489fca32d94f19ee23893b332f1b01ceee7bd3623337c942cbda642667d1dc9de5ac869c3c1946afa6cf2046407b57d24741
+  checksum: 80c76d18c38ffaec84f07a6a196792d7a968b848eeeb4e6b86f9ceb44f434569217e5f56356f27f05e7e393ec9391b5a3a7f43441896125bbbc6b9f78341278b
   languageName: node
   linkType: hard
 
-"react@npm:17.0.2":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
+"react@npm:beta":
+  version: 18.0.0-beta-96ca8d915-20211115
+  resolution: "react@npm:18.0.0-beta-96ca8d915-20211115"
   dependencies:
     loose-envify: ^1.1.0
     object-assign: ^4.1.1
-  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
+  checksum: 24dfb1099aecd0c2276edacd3c3e4db32d17e02d254ba8122f04b262fa7861cbf5196986f526284b467d2206f4b7887deb2c8ac362102636e0cd86df26b16144
   languageName: node
   linkType: hard
 
@@ -10799,13 +10807,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
+"scheduler@npm:0.21.0-beta-96ca8d915-20211115":
+  version: 0.21.0-beta-96ca8d915-20211115
+  resolution: "scheduler@npm:0.21.0-beta-96ca8d915-20211115"
   dependencies:
     loose-envify: ^1.1.0
     object-assign: ^4.1.1
-  checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
+  checksum: 3c9b2c460948b085c397487473c97766f78ed1f8e553b76a9182ab7b59f453f21275676492ffe6fc22fe9b875d0a78c1835d1a275417e3bd1e893f02f541a98a
   languageName: node
   linkType: hard
 
@@ -12186,6 +12194,15 @@ __metadata:
   dependencies:
     fast-url-parser: ^1.1.3
   checksum: bc09df2474da59f95c8577746322bfb0f219c3a084722b427a916906ea7dab538fdbaf6a5582f64f617e9405fb1c9cc437ce40ec73abdddf26d7771a3d2f088b
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:1.0.0-alpha-5cccacd13-20211101":
+  version: 1.0.0-alpha-5cccacd13-20211101
+  resolution: "use-sync-external-store@npm:1.0.0-alpha-5cccacd13-20211101"
+  peerDependencies:
+    react: 18.0.0-alpha-5cccacd13-20211101
+  checksum: d09c616cbbf13a362020e0b43edb41ad3e669a52273835696e5727a3800c861c33ab2f44f619f1011bf3f981c50af84a692a2c9efde27c3e1709a4b93304c072
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Summary

Re: https://twitter.com/tdeekens/status/1460559774966292482

#### Description

Adjust tests to highlight problems in React 18.

#### Technical debt & future

I had a glance at how the "status" is handled. I've seen some subscription-like patterns so you probably need to use [`useSyncExternalStore`](https://github.com/reactwg/react-18/discussions/86) to avoid the tearing that now occurs in React 18.

Considering test results change depending on how focused tests are run (full suite, single file, single test etc) there's probably also some cleanup issue. If a test schedules a microtask that changes global state then this could affect subsequent test.
