### PR TITLE
fix: fix TypeError in the demo

### DIFF
--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -143,7 +143,11 @@ class App extends Component {
 
     return (
       <Provider store={store}>
-        <ConfigureFlopFlip adapter={adapter} defaultFlags={allFlags}>
+        <ConfigureFlopFlip
+          adapter={adapter}
+          adapterArgs={{}}
+          defaultFlags={allFlags}
+        >
           <div className="App">
             <div className="App-header">
               <img src={logo} className="App-logo" alt="logo" />


### PR DESCRIPTION
#### Summary

This PR fixes TypeError in the demo.

#### Description

TypeError occurs when launching the demo.

```
cjs.js:61 Uncaught TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at getKeys (cjs.js:61:1)
    at mergeObject (cjs.js:86:1)
    at deepmerge (cjs.js:117:1)
    at mergeAdapterArgs (flopflip-react.browser.esm.js:56:1)
    at flopflip-react.browser.esm.js:112:1
    at flopflip-react.browser.esm.js:281:1
    at flopflip-react.browser.esm.js:298:1
    at invokePassiveEffectCreate (react-dom.development.js:23487:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945:1)
```

The error is different, but I think this PR closes #1418 since the demo works.