### PR TITLE
chore: bump all packages

### DIFF
--- a/.changeset/stale-ads-play.md
+++ b/.changeset/stale-ads-play.md
@@ -1,0 +1,19 @@
+---
+'@flopflip/adapter-utilities': patch
+'@flopflip/combine-adapters': patch
+'@flopflip/cypress-plugin': patch
+'@flopflip/graphql-adapter': patch
+'@flopflip/http-adapter': patch
+'@flopflip/launchdarkly-adapter': patch
+'@flopflip/localstorage-adapter': patch
+'@flopflip/localstorage-cache': patch
+'@flopflip/memory-adapter': patch
+'@flopflip/react': patch
+'@flopflip/react-broadcast': patch
+'@flopflip/react-redux': patch
+'@flopflip/sessionstorage-cache': patch
+'@flopflip/splitio-adapter': patch
+'@flopflip/types': patch
+---
+
+Bump version of all packages. The previous release didn't include all changes so we're forcing a new release.

--- a/packages/adapter-utilities/index.ts
+++ b/packages/adapter-utilities/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/combine-adapters/index.ts
+++ b/packages/combine-adapters/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/cypress-plugin/index.ts
+++ b/packages/cypress-plugin/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/graphql-adapter/index.ts
+++ b/packages/graphql-adapter/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/http-adapter/index.ts
+++ b/packages/http-adapter/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/launchdarkly-adapter/index.ts
+++ b/packages/launchdarkly-adapter/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/localstorage-adapter/index.ts
+++ b/packages/localstorage-adapter/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/localstorage-cache/index.ts
+++ b/packages/localstorage-cache/index.ts
@@ -1,6 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';
-export { default } from './src';

--- a/packages/memory-adapter/index.ts
+++ b/packages/memory-adapter/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/react-broadcast/index.ts
+++ b/packages/react-broadcast/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/react-redux/index.ts
+++ b/packages/react-redux/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/sessionstorage-cache/index.ts
+++ b/packages/sessionstorage-cache/index.ts
@@ -1,6 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';
-export { default } from './src';

--- a/packages/splitio-adapter/index.ts
+++ b/packages/splitio-adapter/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,5 +1,0 @@
-// This file exists  because we want jest to use our non-compiled code to run tests
-// if this file is missing, and you have a `module` or `main` that points to a non-existing file
-// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
-// all apps should export all their named exports from their root index.js
-export * from './src';


### PR DESCRIPTION
See https://github.com/tdeekens/flopflip/pull/1606#issuecomment-1082298998

The `index.ts` file is not needed anymore since using preconstruct. Removing it just to formally mark packages with unreleased changes.