### PR TITLE
refactor(broadcast): to use sync external store and concurrent mode 

### DIFF
--- a/.changeset/friendly-insects-lick.md
+++ b/.changeset/friendly-insects-lick.md
@@ -1,0 +1,6 @@
+---
+"@flopflip/react-broadcast": minor
+"@flopflip/react": patch
+---
+
+Refactor `react-broadcast` to use `useSyncExternalStore` to make it concurrent mode compatible.

--- a/packages/react-broadcast/package.json
+++ b/packages/react-broadcast/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "@babel/runtime": "7.18.6",
     "@flopflip/react": "^11.2.0",
-    "@flopflip/types": "4.1.23"
+    "@flopflip/types": "4.1.23",
+    "use-sync-external-store": "1.2.0"
   },
   "keywords": [
     "react",

--- a/packages/react-broadcast/src/components/toggle-feature/toggle-feature.spec.js
+++ b/packages/react-broadcast/src/components/toggle-feature/toggle-feature.spec.js
@@ -51,7 +51,7 @@ describe('when feature is disabled', () => {
 
 describe('when feature is enabled', () => {
   it('should render the component representing a enabled feature', async () => {
-    const { waitUntilConfigured, queryByFlagName } = render(
+    const { waitUntilConfigured, queryByFlagName, debug } = render(
       <TestDisabledComponent />
     );
 

--- a/packages/react-broadcast/src/store/index.ts
+++ b/packages/react-broadcast/src/store/index.ts
@@ -1,0 +1,1 @@
+export { default as createStore } from './store';

--- a/packages/react-broadcast/src/store/store.ts
+++ b/packages/react-broadcast/src/store/store.ts
@@ -1,0 +1,29 @@
+type TListener = () => void;
+
+function createStore<TState extends Record<string, unknown>>(
+  initialState: TState
+) {
+  let state = initialState;
+  const getSnapshot = () => state;
+  const listeners = new Set<TListener>();
+
+  function setState(fn: (prevState: TState) => TState) {
+    state = fn(state);
+
+    listeners.forEach((listener) => {
+      listener();
+    });
+  }
+
+  function subscribe(listener: TListener) {
+    listeners.add(listener);
+
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  return { getSnapshot, setState, subscribe };
+}
+
+export default createStore;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,6 +2156,7 @@ __metadata:
     "@types/react-dom": 18.0.6
     react: 18.2.0
     react-dom: 18.2.0
+    use-sync-external-store: 1.2.0
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0.0
     react-dom: ^16.8 || ^17.0 || ^18.0.0
@@ -12403,7 +12404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.0.0":
+"use-sync-external-store@npm:1.2.0, use-sync-external-store@npm:^1.0.0":
   version: 1.2.0
   resolution: "use-sync-external-store@npm:1.2.0"
   peerDependencies:


### PR DESCRIPTION
#### Summary

This refactors react-broadcast's usage of state for flags and adapter status to move it into a small external store implementation. This then allows to use useSyncExternalStore which in turn makes flopflip ready for concurrent mode of React v18.