### PR TITLE
refactor: migrate ld adapter to allow contexts

### DIFF
--- a/.changeset/six-toes-double.md
+++ b/.changeset/six-toes-double.md
@@ -33,8 +33,8 @@ You will have to replace `user` with `context`
 The `context` itself which previously was a `user` of for instance
 
 ```js
-user: {
-  key: props.user?.id,
+const user = {
+  key: user?.id,
   custom: {
      foo: 'bar'
   }
@@ -44,9 +44,9 @@ user: {
 should now be
 
 ```js
-context: {
+const context = {
   kind: 'user',
-  key: props.user?.id,
+  key: user?.id,
   foo: 'bar'
 },
 ```

--- a/.changeset/six-toes-double.md
+++ b/.changeset/six-toes-double.md
@@ -1,0 +1,75 @@
+---
+"@flopflip/launchdarkly-adapter": major
+"@flopflip/types": major
+---
+
+Refactor to support v3 of the LaunchDarkly JavaScript SDK. The offical migration guide can be found [here](https://docs.launchdarkly.com/sdk/client-side/javascript/migration-2-to-3). 
+
+If you're using LaunchDarkly as your adapter, then the shape of the `adapterArgs` passed to `ConfigureFlopflip` has changed.
+
+Assuming you are currently only using a user context (please refer to LaunchDarkly's documentation for more) then your previous configuration was:
+
+```jsx
+<ConfigureFlopFlip
+  adapter={adapter}
+  adapterArgs={{ sdk: { clientSideId }, user }}
+>
+  <App />
+</ConfigureFlopFlip>;
+```
+
+You will have to replace `user` with `context`
+
+```diff
+<ConfigureFlopFlip
+  adapter={adapter}
+-  adapterArgs={{ sdk: { clientSideId }, user }}
++  adapterArgs={{ sdk: { clientSideId }, context }}
+>
+  <App />
+</ConfigureFlopFlip>;
+```
+
+The `context` itself which previously was a `user` of for instance
+
+```js
+user: {
+  key: props.user?.id,
+  custom: {
+     foo: 'bar'
+  }
+},
+```
+
+should now be
+
+```js
+context: {
+  kind: 'user',
+  key: props.user?.id,
+  foo: 'bar'
+},
+```
+
+Please note that if you previously used a large user object with a lot of different information you might want to think about splitting it. This is the main purpose of the change on LaunchDarkly's side.
+
+```js
+const deviceContext = {
+  kind: 'device',
+  type: 'iPad',
+  key: 'device-key-123abc'
+}
+
+const userContext = {
+  kind: 'user',
+  key: 'user-key-123abc',
+  name: 'Sandy',
+  role: 'doctor'
+}
+
+const multiContext = {
+  kind: 'multi',
+  user: userContext,
+  device: deviceContext
+}
+```

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,7 +1,7 @@
 import {
   type LDClient as TLDClient,
+  type LDContext,
   type LDOptions as TLDOptions,
-  type LDUser,
 } from 'launchdarkly-js-client-sdk';
 import type React from 'react';
 
@@ -52,7 +52,8 @@ export type TBaseAdapterArgs<
 > = {
   user: TUser<TAdditionalUserProperties>;
 };
-export type TLaunchDarklyAdapterArgs = TBaseAdapterArgs<LDUser> & {
+export type TLaunchDarklyContextArgs = { context: LDContext };
+export type TLaunchDarklyAdapterArgs = TLaunchDarklyContextArgs & {
   sdk: {
     clientSideId: string;
     clientOptions?: TLDOptions;
@@ -138,14 +139,14 @@ export const adapterIdentifiers = {
 } as const;
 export type TAdapterIdentifiers =
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-  typeof adapterIdentifiers[keyof typeof adapterIdentifiers] | string;
+  (typeof adapterIdentifiers)[keyof typeof adapterIdentifiers] | string;
 export type TFlagsContext = Record<TAdapterIdentifiers, TFlags>;
 export const cacheIdentifiers = {
   local: 'local',
   session: 'session',
 } as const;
 export type TCacheIdentifiers =
-  typeof cacheIdentifiers[keyof typeof cacheIdentifiers];
+  (typeof cacheIdentifiers)[keyof typeof cacheIdentifiers];
 export type TUpdateFlagsOptions = {
   lockFlags?: boolean;
   unsubscribeFlags?: boolean;
@@ -201,8 +202,8 @@ export interface TLaunchDarklyAdapterInterface
   ) => boolean;
   getClient: () => TLDClient | undefined;
   getFlag: (flagName: TFlagName) => TFlagVariation | undefined;
-  updateUserContext: (
-    updatedUserProps: TLaunchDarklyAdapterArgs['user']
+  updateClientContext: (
+    updatedContextProps: TLaunchDarklyAdapterArgs['context']
   ) => Promise<unknown>;
   unsubscribe: () => void;
   subscribe: () => void;


### PR DESCRIPTION
#### Summary

LaunchDarkly released a v3 of their JS SDK. This supports a feature called contexts. More can be found in the [migration guide here](https://docs.launchdarkly.com/sdk/client-side/javascript/migration-2-to-3).

Generally, it's a non breaking change for the SDK but eventually the old "user only" context will be removed. Flopflip could also build this in a non breaking way. That however would be tricky and one can basically remain using an old version of the library.

#### Tasks

- [x] Change adapter 
- [x] Update types and tests
- [x] Write changeset
- [ ] Update documentation