### PR TITLE
fix: adapter status state to be kept independently

### DIFF
--- a/packages/http-adapter/src/adapter/adapter.ts
+++ b/packages/http-adapter/src/adapter/adapter.ts
@@ -238,11 +238,11 @@ class HttpAdapter implements THttpAdapterInterface {
         }
       }
 
-      this.setConfigurationStatus(AdapterConfigurationStatus.Configured);
-
       const flags = normalizeFlags(await this.#fetchFlags(adapterArgs));
 
       this.#adapterState.flags = flags;
+
+      this.setConfigurationStatus(AdapterConfigurationStatus.Configured);
 
       if (adapterArgs.cacheIdentifier) {
         const cache = await this.#getCache(adapterArgs.cacheIdentifier);

--- a/packages/react-broadcast/src/components/test-provider/test-provider.spec.js
+++ b/packages/react-broadcast/src/components/test-provider/test-provider.spec.js
@@ -48,8 +48,10 @@ describe('when configured', () => {
   it('should expose a passed adapter status', async () => {
     render({
       status: {
-        subscriptionStatus: AdapterSubscriptionStatus.Unsubscribed,
-        configurationStatus: AdapterConfigurationStatus.Unconfigured,
+        memory: {
+          subscriptionStatus: AdapterSubscriptionStatus.Unsubscribed,
+          configurationStatus: AdapterConfigurationStatus.Unconfigured,
+        },
       },
     });
 

--- a/packages/react-broadcast/src/components/test-provider/test-provider.tsx
+++ b/packages/react-broadcast/src/components/test-provider/test-provider.tsx
@@ -3,7 +3,7 @@ import {
   AdapterConfigurationStatus,
   AdapterSubscriptionStatus,
   type TAdapterIdentifiers,
-  type TAdapterStatus,
+  type TAdaptersStatus,
   type TFlags,
   type TReconfigureAdapter,
 } from '@flopflip/types';
@@ -12,11 +12,11 @@ import React from 'react';
 import { createIntialFlagsContext, FlagsContext } from '../flags-context';
 
 type TProps = {
-  children: React.ReactNode;
-  flags: TFlags;
-  adapterIdentifiers?: TAdapterIdentifiers[];
-  reconfigure?: TReconfigureAdapter;
-  status?: TAdapterStatus;
+  readonly children: React.ReactNode;
+  readonly flags: TFlags;
+  readonly adapterIdentifiers?: TAdapterIdentifiers[];
+  readonly reconfigure?: TReconfigureAdapter;
+  readonly status?: TAdaptersStatus;
 };
 
 const defaultProps: Pick<
@@ -25,8 +25,10 @@ const defaultProps: Pick<
 > = {
   adapterIdentifiers: ['test'],
   status: {
-    subscriptionStatus: AdapterSubscriptionStatus.Subscribed,
-    configurationStatus: AdapterConfigurationStatus.Configured,
+    memory: {
+      subscriptionStatus: AdapterSubscriptionStatus.Subscribed,
+      configurationStatus: AdapterConfigurationStatus.Configured,
+    },
   },
 };
 

--- a/packages/react-broadcast/src/hooks/use-adapter-status/use-adapter-status.ts
+++ b/packages/react-broadcast/src/hooks/use-adapter-status/use-adapter-status.ts
@@ -7,9 +7,7 @@ import { useDebugValue } from 'react';
 export default function useAdapterStatus() {
   const { status } = useAdapterContext();
 
-  const adapterStatus = selectAdapterConfigurationStatus(
-    status.configurationStatus
-  );
+  const adapterStatus = selectAdapterConfigurationStatus(status);
 
   useDebugValue({ adapterStatus });
 

--- a/packages/react-redux/src/components/configure/configure.tsx
+++ b/packages/react-redux/src/components/configure/configure.tsx
@@ -10,9 +10,9 @@ import React from 'react';
 import { useUpdateFlags, useUpdateStatus } from '../../hooks';
 
 type BaseProps = {
-  children?: TConfigureAdapterChildren;
-  shouldDeferAdapterConfiguration?: boolean;
-  defaultFlags?: TFlags;
+  readonly children?: TConfigureAdapterChildren;
+  readonly shouldDeferAdapterConfiguration?: boolean;
+  readonly defaultFlags?: TFlags;
 };
 type Props<AdapterInstance extends TAdapter> = BaseProps &
   TConfigureAdapterProps<AdapterInstance>;
@@ -25,7 +25,9 @@ const defaultProps: Pick<
   shouldDeferAdapterConfiguration: false,
 };
 
-function Configure<AdapterInstance extends TAdapter>(props: Props<AdapterInstance>) {
+function Configure<AdapterInstance extends TAdapter>(
+  props: Props<AdapterInstance>
+) {
   const adapterIdentifiers = [props.adapter.id];
   const handleUpdateFlags = useUpdateFlags({ adapterIdentifiers });
   const handleUpdateStatus = useUpdateStatus();

--- a/packages/react-redux/src/ducks/status/status.spec.js
+++ b/packages/react-redux/src/ducks/status/status.spec.js
@@ -1,4 +1,7 @@
-import { AdapterConfigurationStatus } from '@flopflip/types';
+import {
+  AdapterConfigurationStatus,
+  adapterIdentifiers as allAdapterIdentifiers,
+} from '@flopflip/types';
 
 import { STATE_SLICE } from '../../store/constants';
 import reducer, { selectStatus, UPDATE_STATUS, updateStatus } from './status';
@@ -18,20 +21,47 @@ describe('action creators', () => {
       });
     });
 
-    it('should return passed configuration status', () => {
-      expect(
-        updateStatus({
-          status: {
-            configurationStatus: AdapterConfigurationStatus.Configured,
+    describe('with id in payload', () => {
+      it('should return passed configuration status', () => {
+        expect(
+          updateStatus({
+            id: 'memory',
+            status: {
+              configurationStatus: AdapterConfigurationStatus.Configured,
+            },
+          })
+        ).toEqual({
+          type: expect.any(String),
+          payload: {
+            id: 'memory',
+            status: {
+              configurationStatus: AdapterConfigurationStatus.Configured,
+            },
           },
-        })
-      ).toEqual({
-        type: expect.any(String),
-        payload: {
-          status: {
-            configurationStatus: AdapterConfigurationStatus.Configured,
+        });
+      });
+    });
+
+    describe('without id in payload', () => {
+      it('should return passed configuration status for all adapters', () => {
+        expect(
+          updateStatus(
+            {
+              status: {
+                configurationStatus: AdapterConfigurationStatus.Configured,
+              },
+            },
+            allAdapterIdentifiers
+          )
+        ).toEqual({
+          type: expect.any(String),
+          payload: {
+            adapterIdentifiers: allAdapterIdentifiers,
+            status: {
+              configurationStatus: AdapterConfigurationStatus.Configured,
+            },
           },
-        },
+        });
       });
     });
   });
@@ -43,6 +73,7 @@ describe('reducers', () => {
       let payload;
       beforeEach(() => {
         payload = {
+          id: 'memory',
           status: {
             configurationStatus: AdapterConfigurationStatus.Configuring,
           },
@@ -52,7 +83,9 @@ describe('reducers', () => {
       it('should set the new status', () => {
         expect(reducer(undefined, { type: UPDATE_STATUS, payload })).toEqual(
           expect.objectContaining({
-            configurationStatus: AdapterConfigurationStatus.Configuring,
+            memory: {
+              configurationStatus: AdapterConfigurationStatus.Configuring,
+            },
           })
         );
       });
@@ -62,6 +95,7 @@ describe('reducers', () => {
       let payload;
       beforeEach(() => {
         payload = {
+          id: 'memory',
           status: {
             configurationStatus: AdapterConfigurationStatus.Configuring,
           },
@@ -71,11 +105,17 @@ describe('reducers', () => {
       it('should set the new status', () => {
         expect(
           reducer(
-            { configurationStatus: AdapterConfigurationStatus.Configured },
+            {
+              memory: {
+                configurationStatus: AdapterConfigurationStatus.Configured,
+              },
+            },
             { type: UPDATE_STATUS, payload }
           )
         ).toEqual({
-          configurationStatus: AdapterConfigurationStatus.Configuring,
+          memory: {
+            configurationStatus: AdapterConfigurationStatus.Configuring,
+          },
         });
       });
     });
@@ -88,8 +128,10 @@ describe('selectors', () => {
 
   beforeEach(() => {
     status = {
-      configurationStatus: AdapterConfigurationStatus.Configuring,
-      subscriptionStatus: {},
+      memory: {
+        configurationStatus: AdapterConfigurationStatus.Configuring,
+        subscriptionStatus: {},
+      },
     };
     state = {
       [STATE_SLICE]: {

--- a/packages/react-redux/src/ducks/status/types.ts
+++ b/packages/react-redux/src/ducks/status/types.ts
@@ -1,6 +1,11 @@
-import { type TAdapterStatusChange } from '@flopflip/types';
+import {
+  type TAdapterIdentifiers,
+  type TAdapterStatusChange,
+} from '@flopflip/types';
 
 export type TUpdateStatusAction = {
   type: string;
-  payload: TAdapterStatusChange;
+  payload: TAdapterStatusChange & {
+    adapterIdentifiers: TAdapterIdentifiers[];
+  };
 };

--- a/packages/react-redux/src/hooks/use-update-status/use-update-status.ts
+++ b/packages/react-redux/src/hooks/use-update-status/use-update-status.ts
@@ -1,4 +1,5 @@
 import {
+  adapterIdentifiers as allAdapterIdentifiers,
   type TAdapterEventHandlers,
   type TAdapterStatusChange,
 } from '@flopflip/types';
@@ -9,9 +10,10 @@ import { updateStatus } from '../../ducks';
 
 const useUpdateStatus = (): TAdapterEventHandlers['onStatusStateChange'] => {
   const dispatch = useDispatch();
+
   return useCallback(
     (statusChange: TAdapterStatusChange) =>
-      dispatch(updateStatus(statusChange)),
+      dispatch(updateStatus(statusChange, Object.keys(allAdapterIdentifiers))),
     [dispatch]
   );
 };

--- a/packages/react-redux/src/store/enhancer/enhancer.spec.js
+++ b/packages/react-redux/src/store/enhancer/enhancer.spec.js
@@ -1,4 +1,7 @@
-import { AdapterConfigurationStatus } from '@flopflip/types';
+import {
+  AdapterConfigurationStatus,
+  adapterIdentifiers as allAdapterIdentifiers,
+} from '@flopflip/types';
 
 import { updateFlags, updateStatus } from '../../ducks';
 import createFlopFlipEnhancer from './enhancer';
@@ -94,7 +97,9 @@ describe('when creating enhancer', () => {
       });
 
       it('should invoke `dispatch` with `updateStatus`', () => {
-        expect(dispatch).toHaveBeenCalledWith(updateStatus(nextStatus));
+        expect(dispatch).toHaveBeenCalledWith(
+          updateStatus(nextStatus, Object.keys(allAdapterIdentifiers))
+        );
       });
     });
   });

--- a/packages/react-redux/src/store/enhancer/enhancer.ts
+++ b/packages/react-redux/src/store/enhancer/enhancer.ts
@@ -1,4 +1,5 @@
 import {
+  adapterIdentifiers as allAdapterIdentifiers,
   type TAdapter,
   type TAdapterArgs,
   type TAdapterInterface,
@@ -36,7 +37,9 @@ export default function createFlopFlipEnhancer(
           store.dispatch(updateFlags(flagsChange, [adapter.id]));
         },
         onStatusStateChange(statusChange: TAdapterStatusChange) {
-          store.dispatch(updateStatus(statusChange));
+          store.dispatch(
+            updateStatus(statusChange, Object.keys(allAdapterIdentifiers))
+          );
         },
       });
 

--- a/packages/react-redux/src/types.ts
+++ b/packages/react-redux/src/types.ts
@@ -1,4 +1,4 @@
-import { type TAdapterStatus, type TFlagsContext } from '@flopflip/types';
+import { type TAdaptersStatus, type TFlagsContext } from '@flopflip/types';
 
 import { type TUpdateFlagsAction } from './ducks/flags/types';
 import { type TUpdateStatusAction } from './ducks/status/types';
@@ -7,7 +7,7 @@ import type { STATE_SLICE } from './store/constants';
 export type TState = {
   [STATE_SLICE]: {
     flags?: TFlagsContext;
-    status?: TAdapterStatus;
+    status?: TAdaptersStatus;
   };
 };
 

--- a/packages/react/src/components/adapter-context/adapter-context.spec.js
+++ b/packages/react/src/components/adapter-context/adapter-context.spec.js
@@ -6,7 +6,11 @@ describe('selectAdapterConfigurationStatus', () => {
   describe('when configured', () => {
     it('should indicate ready state', () => {
       expect(
-        selectAdapterConfigurationStatus(AdapterConfigurationStatus.Configured)
+        selectAdapterConfigurationStatus({
+          memory: {
+            configurationStatus: AdapterConfigurationStatus.Configured,
+          },
+        })
       ).toEqual(
         expect.objectContaining({
           isReady: true,
@@ -15,7 +19,11 @@ describe('selectAdapterConfigurationStatus', () => {
     });
     it('should indicate configured state', () => {
       expect(
-        selectAdapterConfigurationStatus(AdapterConfigurationStatus.Configured)
+        selectAdapterConfigurationStatus({
+          memory: {
+            configurationStatus: AdapterConfigurationStatus.Configured,
+          },
+        })
       ).toEqual(
         expect.objectContaining({
           isConfigured: true,
@@ -26,7 +34,11 @@ describe('selectAdapterConfigurationStatus', () => {
   describe('when configuring', () => {
     it('should indicate configuring state', () => {
       expect(
-        selectAdapterConfigurationStatus(AdapterConfigurationStatus.Configuring)
+        selectAdapterConfigurationStatus({
+          memory: {
+            configurationStatus: AdapterConfigurationStatus.Configuring,
+          },
+        })
       ).toEqual(
         expect.objectContaining({
           isConfiguring: true,
@@ -35,7 +47,11 @@ describe('selectAdapterConfigurationStatus', () => {
     });
     it('should not indicate configured state', () => {
       expect(
-        selectAdapterConfigurationStatus(AdapterConfigurationStatus.Configuring)
+        selectAdapterConfigurationStatus({
+          memory: {
+            configurationStatus: AdapterConfigurationStatus.Configuring,
+          },
+        })
       ).toEqual(
         expect.objectContaining({
           isConfigured: false,
@@ -46,9 +62,11 @@ describe('selectAdapterConfigurationStatus', () => {
   describe('when unconfigured', () => {
     it('should indicate unconfigured', () => {
       expect(
-        selectAdapterConfigurationStatus(
-          AdapterConfigurationStatus.Unconfigured
-        )
+        selectAdapterConfigurationStatus({
+          memory: {
+            configurationStatus: AdapterConfigurationStatus.Unconfigured,
+          },
+        })
       ).toEqual(
         expect.objectContaining({
           isUnconfigured: true,

--- a/packages/react/src/components/adapter-context/adapter-context.ts
+++ b/packages/react/src/components/adapter-context/adapter-context.ts
@@ -1,43 +1,60 @@
 import {
   AdapterConfigurationStatus,
-  AdapterSubscriptionStatus,
   type TAdapterContext,
   type TAdapterIdentifiers,
-  type TAdapterStatus,
+  type TAdaptersStatus,
   type TReconfigureAdapter,
 } from '@flopflip/types';
 import { createContext } from 'react';
 
 const initialReconfigureAdapter: TReconfigureAdapter = () => undefined;
-const initialAdapterStatus: TAdapterStatus = {
-  subscriptionStatus: AdapterSubscriptionStatus.Subscribed,
-  configurationStatus: AdapterConfigurationStatus.Unconfigured,
-};
+
 const createAdapterContext = (
   adapterIdentifiers?: TAdapterIdentifiers[],
   reconfigure?: TReconfigureAdapter,
-  status?: TAdapterStatus
+  status?: TAdaptersStatus
 ): TAdapterContext => ({
   adapterEffectIdentifiers: adapterIdentifiers ?? [],
   reconfigure: reconfigure ?? initialReconfigureAdapter,
-  status: status ?? initialAdapterStatus,
+  status,
 });
 
 const initialAdapterContext = createAdapterContext();
 const AdapterContext = createContext(initialAdapterContext);
 
-const selectAdapterConfigurationStatus = (
-  configurationStatus?: AdapterConfigurationStatus
-) => {
-  const isReady = configurationStatus === AdapterConfigurationStatus.Configured;
-  const isUnconfigured =
-    configurationStatus === AdapterConfigurationStatus.Unconfigured;
-  const isConfiguring =
-    configurationStatus === AdapterConfigurationStatus.Configuring;
-  const isConfigured =
-    configurationStatus === AdapterConfigurationStatus.Configured;
+function hasEveryAdapterStatus(
+  adapterConfigurationStatus: AdapterConfigurationStatus,
+  adaptersStatus?: TAdaptersStatus
+) {
+  if (Object.keys(adaptersStatus ?? {}).length === 0) return false;
 
-  return { isReady, isUnconfigured, isConfiguring, isConfigured };
+  return Object.values(adaptersStatus ?? {}).every(
+    (adapterStatus) =>
+      adapterStatus.configurationStatus === adapterConfigurationStatus
+  );
+}
+
+const selectAdapterConfigurationStatus = (adaptersStatus?: TAdaptersStatus) => {
+  const isReady = hasEveryAdapterStatus(
+    AdapterConfigurationStatus.Configured,
+    adaptersStatus
+  );
+  const isUnconfigured = hasEveryAdapterStatus(
+    AdapterConfigurationStatus.Unconfigured,
+    adaptersStatus
+  );
+  const isConfiguring = hasEveryAdapterStatus(
+    AdapterConfigurationStatus.Configuring,
+    adaptersStatus
+  );
+  const isConfigured = hasEveryAdapterStatus(
+    AdapterConfigurationStatus.Configured,
+    adaptersStatus
+  );
+
+  const status = { isReady, isUnconfigured, isConfiguring, isConfigured };
+
+  return status;
 };
 
 export default AdapterContext;

--- a/packages/react/src/components/configure-adapter/configure-adapter.tsx
+++ b/packages/react/src/components/configure-adapter/configure-adapter.tsx
@@ -8,7 +8,7 @@ import {
   type TAdapterInterface,
   type TAdapterReconfiguration,
   type TAdapterReconfigurationOptions,
-  type TAdapterStatus,
+  type TAdaptersStatus,
   type TConfigureAdapterChildren,
   type TFlags,
 } from '@flopflip/types';
@@ -33,15 +33,15 @@ export type TAdapterStates = ValueOf<typeof AdapterStates>;
 
 type TProps = {
   // eslint-disable-next-line react/boolean-prop-naming
-  shouldDeferAdapterConfiguration?: boolean;
-  adapter: TAdapter;
-  adapterArgs: TAdapterArgs;
-  adapterStatus?: TAdapterStatus;
-  defaultFlags?: TFlags;
-  onFlagsStateChange: TAdapterEventHandlers['onFlagsStateChange'];
-  onStatusStateChange: TAdapterEventHandlers['onStatusStateChange'];
-  render?: () => React.ReactNode;
-  children?: TConfigureAdapterChildren;
+  readonly shouldDeferAdapterConfiguration?: boolean;
+  readonly adapter: TAdapter;
+  readonly adapterArgs: TAdapterArgs;
+  readonly adapterStatus?: TAdaptersStatus;
+  readonly defaultFlags?: TFlags;
+  readonly onFlagsStateChange: TAdapterEventHandlers['onFlagsStateChange'];
+  readonly onStatusStateChange: TAdapterEventHandlers['onStatusStateChange'];
+  readonly render?: () => React.ReactNode;
+  readonly children?: TConfigureAdapterChildren;
 };
 
 type TUseAppliedAdapterArgsStateOptions = {
@@ -49,7 +49,7 @@ type TUseAppliedAdapterArgsStateOptions = {
 };
 type TUseAppliedAdapterArgsStateReturn = [
   TAdapterArgs,
-  (nextAdapterArgs: TAdapterArgs) => void
+  (nextAdapterArgs: TAdapterArgs) => void,
 ];
 const useAppliedAdapterArgsState = ({
   initialAdapterArgs,
@@ -77,7 +77,7 @@ type TUseAdapterStateRefReturn = [
   React.MutableRefObject<TAdapterStates>,
   (nextAdapterState: TAdapterStates) => void,
   () => boolean,
-  () => boolean
+  () => boolean,
 ];
 const useAdapterStateRef = (): TUseAdapterStateRefReturn => {
   const adapterStateRef = useRef<TAdapterStates>(AdapterStates.UNCONFIGURED);
@@ -112,7 +112,7 @@ const useAdapterStateRef = (): TUseAdapterStateRefReturn => {
 type TUsePendingAdapterArgsRefReturn = [
   React.MutableRefObject<TAdapterArgs | undefined>,
   (nextReconfiguration: TAdapterReconfiguration) => void,
-  () => TAdapterArgs
+  () => TAdapterArgs,
 ];
 const usePendingAdapterArgsRef = (
   appliedAdapterArgs: TAdapterArgs

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -37,6 +37,7 @@ export type TAdapterStatus = {
   configurationStatus: AdapterConfigurationStatus;
   subscriptionStatus: AdapterSubscriptionStatus;
 };
+export type TAdaptersStatus = Record<TAdapterIdentifiers, TAdapterStatus>;
 export type TAdapterStatusChange = {
   id?: TAdapterIdentifiers;
   status: Partial<TAdapterStatus>;
@@ -400,7 +401,7 @@ export type TReconfigureAdapter = (
 export type TAdapterContext = {
   adapterEffectIdentifiers: TAdapterIdentifiers[];
   reconfigure: TReconfigureAdapter;
-  status: TAdapterStatus;
+  status?: TAdaptersStatus;
 };
 
 type TLaunchDarklyFlopflipGlobal = {


### PR DESCRIPTION
#### Summary

The adapter status is not kept correctly if multiple adapters are used. Essentially we need to kept the adapter state one per adapter.