### PR TITLE
fix(combine-adapters): status to connect underlying adapters

### DIFF
--- a/.changeset/moody-beds-rhyme.md
+++ b/.changeset/moody-beds-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@flopflip/combine-adapters": patch
+---
+
+fix(combine-adapters): status to connect underlying adapters

--- a/packages/combine-adapters/src/adapter/adapter.spec.js
+++ b/packages/combine-adapters/src/adapter/adapter.spec.js
@@ -178,18 +178,48 @@ describe('when combining', () => {
     });
 
     it('should resolve `waitUntilConfigured`', async () => {
-      await expect(adapter.waitUntilConfigured()).resolves.not.toBeDefined();
+      await expect(adapter.waitUntilConfigured()).resolves.toBeDefined();
     });
 
-    it('should invoke `onStatusStateChange` with configured', () => {
-      expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: adapter.id,
-          status: {
-            configurationStatus: AdapterConfigurationStatus.Configured,
-          },
-        })
-      );
+    describe('invokcation of `onStatusStateChange`', () => {
+      describe('of `combine-adapters`', () => {
+        it('should invoke `onStatusStateChange` with configured', () => {
+          expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: adapter.id,
+              status: {
+                configurationStatus: AdapterConfigurationStatus.Configured,
+              },
+            })
+          );
+        });
+      });
+
+      describe('of `memory-adapter`', () => {
+        it('should invoke `onStatusStateChange` with configured', () => {
+          expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: memoryAdapter.id,
+              status: {
+                configurationStatus: AdapterConfigurationStatus.Configured,
+              },
+            })
+          );
+        });
+      });
+
+      describe('of `localstorage-adapter`', () => {
+        it('should invoke `onStatusStateChange` with configured', () => {
+          expect(adapterEventHandlers.onStatusStateChange).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: localstorageAdapter.id,
+              status: {
+                configurationStatus: AdapterConfigurationStatus.Configured,
+              },
+            })
+          );
+        });
+      });
     });
 
     it('should invoke `onFlagsStateChange`', () => {

--- a/packages/combine-adapters/src/adapter/adapter.ts
+++ b/packages/combine-adapters/src/adapter/adapter.ts
@@ -129,7 +129,7 @@ class CombineAdapters implements TCombinedAdapterInterface {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         return adapter.configure(adapterArgsForAdapter, {
           onFlagsStateChange: adapterEventHandlers.onFlagsStateChange,
-          onStatusStateChange: () => undefined,
+          onStatusStateChange: adapterEventHandlers.onStatusStateChange,
         });
       })
     ).then((allInitializationStatus) => {
@@ -192,7 +192,7 @@ class CombineAdapters implements TCombinedAdapterInterface {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         return adapter.reconfigure(adapterArgsForAdapter, {
           onFlagsStateChange: adapterEventHandlers.onFlagsStateChange,
-          onStatusStateChange: () => undefined,
+          onStatusStateChange: adapterEventHandlers.onStatusStateChange,
         });
       })
     ).then((allInitializationStatus) => {
@@ -229,17 +229,9 @@ class CombineAdapters implements TCombinedAdapterInterface {
   };
 
   async waitUntilConfigured() {
-    return new Promise<void>((resolve) => {
-      if (
-        this.getIsConfigurationStatus(AdapterConfigurationStatus.Configured)
-      ) {
-        resolve();
-      } else
-        this.#adapterState.emitter.on(
-          this.#__internalConfiguredStatusChange__,
-          resolve
-        );
-    });
+    return Promise.all(
+      this.#adapters.map(async (adapter) => adapter?.waitUntilConfigured?.())
+    );
   }
 
   unsubscribe = () => {


### PR DESCRIPTION
#### Summary

This wires up the underlying adapters now that the state above can handle keeping track of all adapters.