### PR TITLE
fix(combine-adapters): to be configured earlier

### DIFF
--- a/.changeset/sweet-mirrors-punch.md
+++ b/.changeset/sweet-mirrors-punch.md
@@ -1,0 +1,5 @@
+---
+"@flopflip/combine-adapters": patch
+---
+
+fix(combine-adapters): to be configured earlier

--- a/packages/combine-adapters/src/adapter/adapter.ts
+++ b/packages/combine-adapters/src/adapter/adapter.ts
@@ -139,18 +139,20 @@ class CombineAdapters implements TCombinedAdapterInterface {
             initializationStatus === AdapterInitializationStatus.Succeeded
         );
 
+      // NOTE: We consider this adapter configured if all adapters have been asked to do so
+      // and have reported to be initialized successfully.
+      this.setConfigurationStatus(AdapterConfigurationStatus.Configured);
+
+      this.#adapterState.emitter.emit(this.#__internalConfiguredStatusChange__);
+
       if (haveAllAdaptersInitializedSuccessfully) {
-        this.setConfigurationStatus(AdapterConfigurationStatus.Configured);
-
-        this.#adapterState.emitter.emit(
-          this.#__internalConfiguredStatusChange__
-        );
-
         return {
           initializationStatus: AdapterInitializationStatus.Succeeded,
         };
       }
 
+      // NOTE: If not all adapters have initialized successfully we can not consider
+      // this adapter being configured fully.
       this.setConfigurationStatus(AdapterConfigurationStatus.Unconfigured);
 
       this.#adapterState.emitter.emit(this.#__internalConfiguredStatusChange__);


### PR DESCRIPTION
#### Summary

Otherwise this adapter often hands in state 1 instead of moving to 2.