### PR TITLE
fix: to rename pollingInteralMs to pollingIntervalMs

### DIFF
--- a/.changeset/lucky-bears-hunt.md
+++ b/.changeset/lucky-bears-hunt.md
@@ -1,0 +1,11 @@
+---
+"@flopflip/graphql-adapter": patch
+"@flopflip/http-adapter": patch
+"@flopflip/launchdarkly-adapter": patch
+"@flopflip/localstorage-adapter": patch
+"@flopflip/splitio-adapter": patch
+"@flopflip/types": patch
+---
+
+Rename pollingInteralMs to pollingIntervalMs.
+

--- a/packages/graphql-adapter/CHANGELOG.md
+++ b/packages/graphql-adapter/CHANGELOG.md
@@ -550,7 +550,7 @@
 
   **localstorage-adapter**
 
-  All fields are now top-level not under `adapterConfiguration` while it is now `pollingInteralMs` not `pollingInteral`.
+  All fields are now top-level not under `adapterConfiguration` while it is now `pollingIntervalMs` not `pollingInteral`.
 
 ### Patch Changes
 

--- a/packages/graphql-adapter/src/adapter/adapter.ts
+++ b/packages/graphql-adapter/src/adapter/adapter.ts
@@ -58,7 +58,7 @@ class GraphQlAdapter implements TGraphQlAdapterInterface {
     '__internalConfiguredStatusChange__';
 
   #adapterState: TAdapterStatus & TGraphQlAdapterState;
-  #defaultPollingInteralMs = 1000 * 60;
+  #defaultpollingIntervalMs = 1000 * 60;
 
   constructor() {
     this.id = adapterIdentifiers.graphql;
@@ -140,8 +140,8 @@ class GraphQlAdapter implements TGraphQlAdapterInterface {
   };
 
   #subscribeToFlagsChanges = (adapterArgs: TGraphQlAdapterArgs) => {
-    const pollingInteralMs =
-      adapterArgs.pollingInteralMs ?? this.#defaultPollingInteralMs;
+    const pollingIntervalMs =
+      adapterArgs.pollingIntervalMs ?? this.#defaultpollingIntervalMs;
 
     setInterval(async () => {
       if (!this.#getIsAdapterUnsubscribed()) {
@@ -158,7 +158,7 @@ class GraphQlAdapter implements TGraphQlAdapterInterface {
           this.#adapterState.emitter.emit('flagsStateChange', nextFlags);
         }
       }
-    }, pollingInteralMs);
+    }, pollingIntervalMs);
   };
 
   getUser = () => this.#adapterState.user;

--- a/packages/http-adapter/src/adapter/adapter.ts
+++ b/packages/http-adapter/src/adapter/adapter.ts
@@ -57,7 +57,7 @@ class HttpAdapter implements THttpAdapterInterface {
     '__internalConfiguredStatusChange__';
 
   #adapterState: TAdapterStatus & THttpAdapterState;
-  #defaultPollingInteralMs = 1000 * 60;
+  #defaultpollingIntervalMs = 1000 * 60;
 
   constructor() {
     this.id = adapterIdentifiers.http;
@@ -123,8 +123,8 @@ class HttpAdapter implements THttpAdapterInterface {
   };
 
   #subscribeToFlagsChanges = (adapterArgs: THttpAdapterArgs) => {
-    const pollingInteralMs =
-      adapterArgs.pollingInteralMs ?? this.#defaultPollingInteralMs;
+    const pollingIntervalMs =
+      adapterArgs.pollingIntervalMs ?? this.#defaultpollingIntervalMs;
 
     setInterval(async () => {
       if (!this.#getIsAdapterUnsubscribed()) {
@@ -141,7 +141,7 @@ class HttpAdapter implements THttpAdapterInterface {
           this.#adapterState.emitter.emit('flagsStateChange', nextFlags);
         }
       }
-    }, pollingInteralMs);
+    }, pollingIntervalMs);
   };
 
   getUser = () => this.#adapterState.user;

--- a/packages/launchdarkly-adapter/CHANGELOG.md
+++ b/packages/launchdarkly-adapter/CHANGELOG.md
@@ -555,7 +555,7 @@
 
   **localstorage-adapter**
 
-  All fields are now top-level not under `adapterConfiguration` while it is now `pollingInteralMs` not `pollingInteral`.
+  All fields are now top-level not under `adapterConfiguration` while it is now `pollingIntervalMs` not `pollingInteral`.
 
 ### Patch Changes
 

--- a/packages/localstorage-adapter/CHANGELOG.md
+++ b/packages/localstorage-adapter/CHANGELOG.md
@@ -507,7 +507,7 @@
 
   **localstorage-adapter**
 
-  All fields are now top-level not under `adapterConfiguration` while it is now `pollingInteralMs` not `pollingInteral`.
+  All fields are now top-level not under `adapterConfiguration` while it is now `pollingIntervalMs` not `pollingInteral`.
 
 ### Patch Changes
 

--- a/packages/localstorage-adapter/src/adapter/adapter.ts
+++ b/packages/localstorage-adapter/src/adapter/adapter.ts
@@ -84,10 +84,10 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
     [user.key, 'flags'].filter(Boolean).join('/');
 
   #subscribeToFlagsChanges = ({
-    pollingInteralMs = 1000 * 60,
+    pollingIntervalMs = 1000 * 60,
     user,
   }: {
-    pollingInteralMs?: TLocalStorageAdapterArgs['pollingInteralMs'];
+    pollingIntervalMs?: TLocalStorageAdapterArgs['pollingIntervalMs'];
     user: TUser;
   }) => {
     setInterval(() => {
@@ -101,7 +101,7 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
           this.#adapterState.emitter.emit('flagsStateChange', nextFlags);
         }
       }
-    }, pollingInteralMs);
+    }, pollingIntervalMs);
   };
 
   updateFlags = (flags: TFlags, options?: TUpdateFlagsOptions) => {
@@ -183,7 +183,7 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
 
     this.setConfigurationStatus(AdapterConfigurationStatus.Configuring);
 
-    const { user, pollingInteralMs } = adapterArgs;
+    const { user, pollingIntervalMs } = adapterArgs;
 
     this.#adapterState.user = user;
 
@@ -199,7 +199,7 @@ class LocalStorageAdapter implements TLocalStorageAdapterInterface {
       this.#adapterState.emitter.emit(this.#__internalConfiguredStatusChange__);
 
       this.#subscribeToFlagsChanges({
-        pollingInteralMs,
+        pollingIntervalMs,
         user,
       });
 

--- a/packages/splitio-adapter/CHANGELOG.md
+++ b/packages/splitio-adapter/CHANGELOG.md
@@ -470,7 +470,7 @@
 
   **localstorage-adapter**
 
-  All fields are now top-level not under `adapterConfiguration` while it is now `pollingInteralMs` not `pollingInteral`.
+  All fields are now top-level not under `adapterConfiguration` while it is now `pollingIntervalMs` not `pollingInteral`.
 
 ### Patch Changes
 

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -340,7 +340,7 @@
 
   **localstorage-adapter**
 
-  All fields are now top-level not under `adapterConfiguration` while it is now `pollingInteralMs` not `pollingInteral`.
+  All fields are now top-level not under `adapterConfiguration` while it is now `pollingIntervalMs` not `pollingInteral`.
 
 ## 4.1.1
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -70,7 +70,7 @@ export type TGraphQlAdapterArgs<
   fetcher?: typeof fetch;
   uri: string;
   query: string;
-  pollingInteralMs?: number;
+  pollingIntervalMs?: number;
   getQueryVariables?: (adapterArgs: TGraphQlAdapterArgs) => unknown;
   getRequestHeaders?: (
     adapterArgs: TGraphQlAdapterArgs
@@ -84,13 +84,13 @@ export type THttpAdapterArgs<
   TAdditionalUserProperties = TDefaultAdditionalUserProperties,
 > = TBaseAdapterArgs<TAdditionalUserProperties> & {
   execute: () => Promise<any>;
-  pollingInteralMs?: number;
+  pollingIntervalMs?: number;
   cacheIdentifier?: TCacheIdentifiers;
 };
 export type TLocalStorageAdapterArgs<
   TAdditionalUserProperties = TDefaultAdditionalUserProperties,
 > = TBaseAdapterArgs<TAdditionalUserProperties> & {
-  pollingInteralMs?: number;
+  pollingIntervalMs?: number;
 };
 export type TMemoryAdapterArgs<
   TAdditionalUserProperties = TDefaultAdditionalUserProperties,

--- a/readme.md
+++ b/readme.md
@@ -323,11 +323,11 @@ _3. The `@flopflip/graphql-adapter` accepts_
 - `getRequestHeaders`: a function called with `adapterArgs` being headers to your GraphQL request
 - `parseFlags`: a function called with the `data` of fetched flags to parse the result before being exposed to your application. This function should be used to parse a query response into the `TFlags` type.
 - `fetcher`: a fetch implemtation if you prefer to not rely on the global `fetch`
-- `pollingInteralMs`: the polling interval to check for updated flag values
+- `pollingIntervalMs`: the polling interval to check for updated flag values
 
 _4. The `@flopflip/localstorage-adapter` accepts_
 
-- `pollingInteralMs`: an interval at which the adapter polls for new flags from localstorage in milliseconds
+- `pollingIntervalMs`: an interval at which the adapter polls for new flags from localstorage in milliseconds
 
 _5. The `@flopflip/memory-adapter` accepts_
 


### PR DESCRIPTION
Closes https://github.com/tdeekens/flopflip/issues/1746

#### Summary

If used this is a breaking change. However, we're quite sure this argument is not set by anybody. Otherwise TypeScript should also help. 