### PR TITLE
feat: allow use-adapter-status to fetch status of one adapter

### DIFF
--- a/.changeset/fair-knives-fetch.md
+++ b/.changeset/fair-knives-fetch.md
@@ -1,0 +1,15 @@
+---
+"@flopflip/react-broadcast": minor
+"@flopflip/react-redux": minor
+"@flopflip/react": minor
+---
+
+The `useAdapterStatus` hooks now allow to fetch status of one or more adapters instead of always all.
+
+You can pass the `adapterIdentifiers` argument which is of type `TAdapterIdentifiers[]`. This means you can:
+
+```js
+const status = useAdapterStatus({ adapterIdentifiers: ['http', 'memory] });
+```
+
+This returns `isConfigured` once both adapters have reached the configurd state.

--- a/packages/react-broadcast/src/hooks/use-adapter-status/use-adapter-status.ts
+++ b/packages/react-broadcast/src/hooks/use-adapter-status/use-adapter-status.ts
@@ -2,12 +2,19 @@ import {
   selectAdapterConfigurationStatus,
   useAdapterContext,
 } from '@flopflip/react';
+import { type TAdapterIdentifiers } from '@flopflip/types';
 import { useDebugValue } from 'react';
 
-export default function useAdapterStatus() {
+type TUseAdapterStatusArgs = { adapterIdentifiers?: TAdapterIdentifiers[] };
+export default function useAdapterStatus({
+  adapterIdentifiers,
+}: TUseAdapterStatusArgs = {}) {
   const { status } = useAdapterContext();
 
-  const adapterStatus = selectAdapterConfigurationStatus(status);
+  const adapterStatus = selectAdapterConfigurationStatus(
+    status,
+    adapterIdentifiers
+  );
 
   useDebugValue({ adapterStatus });
 

--- a/packages/react-redux/src/ducks/status/status.spec.js
+++ b/packages/react-redux/src/ducks/status/status.spec.js
@@ -132,6 +132,10 @@ describe('selectors', () => {
         configurationStatus: AdapterConfigurationStatus.Configuring,
         subscriptionStatus: {},
       },
+      http: {
+        configurationStatus: AdapterConfigurationStatus.Unconfigured,
+        subscriptionStatus: {},
+      },
     };
     state = {
       [STATE_SLICE]: {
@@ -140,12 +144,29 @@ describe('selectors', () => {
     };
   });
 
-  describe('selecting status', () => {
+  describe('selecting status for all', () => {
     it('should return configuration and ready status', () => {
-      expect(selectStatus(state)).toEqual(
+      expect(selectStatus()(state)).toEqual(
+        expect.objectContaining({
+          isConfiguring: false,
+          isReady: false,
+          isUnconfigured: false,
+        })
+      );
+    });
+  });
+  describe('selecting status for one', () => {
+    it('should return unconfigured status', () => {
+      expect(selectStatus({ adapterIdentifiers: ['http'] })(state)).toEqual(
+        expect.objectContaining({
+          isUnconfigured: true,
+        })
+      );
+    });
+    it('should return configuring status', () => {
+      expect(selectStatus({ adapterIdentifiers: ['memory'] })(state)).toEqual(
         expect.objectContaining({
           isConfiguring: true,
-          isConfigured: false,
         })
       );
     });

--- a/packages/react-redux/src/ducks/status/status.ts
+++ b/packages/react-redux/src/ducks/status/status.ts
@@ -63,8 +63,13 @@ export const updateStatus = (
   payload: { ...statusChange, adapterIdentifiers },
 });
 // Selectors
-export const selectStatus = (state: TState) => {
-  const { status } = state[STATE_SLICE];
-
-  return selectAdapterConfigurationStatus(status);
+type TSelectStatusArgs = {
+  adapterIdentifiers?: TAdapterIdentifiers[];
 };
+export const selectStatus =
+  ({ adapterIdentifiers }: TSelectStatusArgs = {}) =>
+  (state: TState) => {
+    const { status } = state[STATE_SLICE];
+
+    return selectAdapterConfigurationStatus(status, adapterIdentifiers);
+  };

--- a/packages/react-redux/src/hooks/use-adapter-status/use-adapter-status.ts
+++ b/packages/react-redux/src/hooks/use-adapter-status/use-adapter-status.ts
@@ -1,10 +1,14 @@
+import { type TAdapterIdentifiers } from '@flopflip/types';
 import { useDebugValue } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectStatus } from '../../ducks/status';
 
-export default function useAdapterStatus() {
-  const adapterStatus = useSelector(selectStatus);
+type TUseAdapterStatusArgs = { adapterIdentifiers?: TAdapterIdentifiers[] };
+export default function useAdapterStatus({
+  adapterIdentifiers,
+}: TUseAdapterStatusArgs = {}) {
+  const adapterStatus = useSelector(selectStatus({ adapterIdentifiers }));
 
   useDebugValue({ adapterStatus });
 

--- a/packages/react/src/components/adapter-context/adapter-context.spec.js
+++ b/packages/react/src/components/adapter-context/adapter-context.spec.js
@@ -74,4 +74,44 @@ describe('selectAdapterConfigurationStatus', () => {
       );
     });
   });
+  describe('with multiple adapters and one of interest', () => {
+    it('should indicate ready state for one', () => {
+      expect(
+        selectAdapterConfigurationStatus(
+          {
+            memory: {
+              configurationStatus: AdapterConfigurationStatus.Configured,
+            },
+            http: {
+              configurationStatus: AdapterConfigurationStatus.Unconfigured,
+            },
+          },
+          ['memory']
+        )
+      ).toEqual(
+        expect.objectContaining({
+          isReady: true,
+        })
+      );
+    });
+    it('should indicate unconfigured state for another', () => {
+      expect(
+        selectAdapterConfigurationStatus(
+          {
+            memory: {
+              configurationStatus: AdapterConfigurationStatus.Configured,
+            },
+            http: {
+              configurationStatus: AdapterConfigurationStatus.Unconfigured,
+            },
+          },
+          ['http']
+        )
+      ).toEqual(
+        expect.objectContaining({
+          isUnconfigured: true,
+        })
+      );
+    });
+  });
 });

--- a/packages/react/src/components/adapter-context/adapter-context.ts
+++ b/packages/react/src/components/adapter-context/adapter-context.ts
@@ -24,9 +24,18 @@ const AdapterContext = createContext(initialAdapterContext);
 
 function hasEveryAdapterStatus(
   adapterConfigurationStatus: AdapterConfigurationStatus,
-  adaptersStatus?: TAdaptersStatus
+  adaptersStatus?: TAdaptersStatus,
+  adapterIdentifiers?: TAdapterIdentifiers[]
 ) {
   if (Object.keys(adaptersStatus ?? {}).length === 0) return false;
+
+  if (Array.isArray(adapterIdentifiers)) {
+    return adapterIdentifiers.every(
+      (adapterIdentifier) =>
+        adaptersStatus?.[adapterIdentifier].configurationStatus ===
+        adapterConfigurationStatus
+    );
+  }
 
   return Object.values(adaptersStatus ?? {}).every(
     (adapterStatus) =>
@@ -34,22 +43,29 @@ function hasEveryAdapterStatus(
   );
 }
 
-const selectAdapterConfigurationStatus = (adaptersStatus?: TAdaptersStatus) => {
+const selectAdapterConfigurationStatus = (
+  adaptersStatus?: TAdaptersStatus,
+  adapterIdentifiers?: TAdapterIdentifiers[]
+) => {
   const isReady = hasEveryAdapterStatus(
     AdapterConfigurationStatus.Configured,
-    adaptersStatus
+    adaptersStatus,
+    adapterIdentifiers
   );
   const isUnconfigured = hasEveryAdapterStatus(
     AdapterConfigurationStatus.Unconfigured,
-    adaptersStatus
+    adaptersStatus,
+    adapterIdentifiers
   );
   const isConfiguring = hasEveryAdapterStatus(
     AdapterConfigurationStatus.Configuring,
-    adaptersStatus
+    adaptersStatus,
+    adapterIdentifiers
   );
   const isConfigured = hasEveryAdapterStatus(
     AdapterConfigurationStatus.Configured,
-    adaptersStatus
+    adaptersStatus,
+    adapterIdentifiers
   );
 
   const status = { isReady, isUnconfigured, isConfiguring, isConfigured };


### PR DESCRIPTION
#### Summary

Allows fetching the status of one adapter from the system.