### PR TITLE
fix(launchdarkly-adapter): Make flags arg optional in TLaunchDarklyAdapterArgs type definition

### DIFF
--- a/.changeset/sweet-flies-smoke.md
+++ b/.changeset/sweet-flies-smoke.md
@@ -1,0 +1,5 @@
+---
+"@flopflip/types": patch
+---
+
+Fix to make flags arg optional in TLaunchDarklyAdapterArgs type definition.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -59,7 +59,7 @@ export type TLaunchDarklyAdapterArgs = TLaunchDarklyContextArgs & {
     clientSideId: string;
     clientOptions?: TLDOptions;
   };
-  flags: TFlags;
+  flags?: TFlags;
   subscribeToFlagChanges?: boolean;
   throwOnInitializationFailure?: boolean;
   flagsUpdateDelayMs?: number;


### PR DESCRIPTION
#### Summary

This PR makes the `flags` arg of `TLaunchDarklyAdapterArgs` optional.

#### Description

When configuring `<ConfigureFlopFlip />` with the launchdarkly adapter, you are unable to configure the adapter without the `flags` arg. Making the `flags` arg optional allows you to configure the adapter without explicitly providing flags.

This seems like the intended behavior, because there is a conditional check [here](https://github.com/tdeekens/flopflip/blob/d194e41c68e9c29b85c11c8682eb45ff9b8711d7/packages/launchdarkly-adapter/src/adapter/adapter.ts#L161-L162) that gets all flags if the `flags` arg is not provided.

