### PR TITLE
Include new hook to read all enabled feature toggles

### DIFF
--- a/packages/react-broadcast/src/hooks/use-all-feature-toggles/index.ts
+++ b/packages/react-broadcast/src/hooks/use-all-feature-toggles/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-all-feature-toggles';

--- a/packages/react-broadcast/src/hooks/use-all-feature-toggles/use-all-feature-toggles.spec.js
+++ b/packages/react-broadcast/src/hooks/use-all-feature-toggles/use-all-feature-toggles.spec.js
@@ -1,0 +1,50 @@
+import { renderWithAdapter, screen } from '@flopflip/test-utils';
+import React from 'react';
+
+import Configure from '../../components/configure';
+import useAllFeatureToggles from './use-all-feature-toggles';
+
+const testFeatures = {
+  featureA: true,
+  featureB: false,
+  featureC: true,
+};
+
+const render = (TestComponent) =>
+  renderWithAdapter(TestComponent, {
+    components: {
+      ConfigureFlopFlip: Configure,
+    },
+    flags: testFeatures,
+  });
+
+function TestComponent() {
+  const allFlags = useAllFeatureToggles();
+
+  return (
+    <div>
+      <h1>Enabled features</h1>
+      <ul>
+        {Object.keys(allFlags).map((flagName) => (
+          <li key={flagName}>{flagName}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+it('should list all enabled features', async () => {
+  const { waitUntilConfigured } = render(<TestComponent />);
+
+  await waitUntilConfigured();
+
+  Object.entries(testFeatures).forEach(([featureName, isEnabled]) => {
+    if (isEnabled) {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(screen.getByText(featureName)).toBeInTheDocument();
+    } else {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(screen.queryByText(featureName)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/packages/react-broadcast/src/hooks/use-all-feature-toggles/use-all-feature-toggles.ts
+++ b/packages/react-broadcast/src/hooks/use-all-feature-toggles/use-all-feature-toggles.ts
@@ -1,0 +1,28 @@
+import { getIsFeatureEnabled, useAdapterContext } from '@flopflip/react';
+import { type TFlags } from '@flopflip/types';
+
+import useFlagsContext from '../use-flags-context';
+
+export default function useAllFeatureToggles(): TFlags {
+  const adapterContext = useAdapterContext();
+  const flagsContext = useFlagsContext();
+  const enabledFlags: TFlags = Object.values(flagsContext).reduce<TFlags>(
+    (_enabledFlags, flags) => {
+      Object.keys(flags).forEach((featureName) => {
+        if (
+          getIsFeatureEnabled(
+            flagsContext,
+            adapterContext.adapterEffectIdentifiers,
+            featureName
+          )
+        ) {
+          _enabledFlags[featureName] = true;
+        }
+      });
+      return _enabledFlags;
+    },
+    {}
+  );
+
+  return enabledFlags;
+}

--- a/packages/react-redux/src/hooks/use-all-feature-toggles/index.ts
+++ b/packages/react-redux/src/hooks/use-all-feature-toggles/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-all-feature-toggles';

--- a/packages/react-redux/src/hooks/use-all-feature-toggles/use-all-feature-toggles.spec.js
+++ b/packages/react-redux/src/hooks/use-all-feature-toggles/use-all-feature-toggles.spec.js
@@ -1,0 +1,61 @@
+import { renderWithAdapter, screen } from '@flopflip/test-utils';
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { createStore } from '../../../test-utils';
+import Configure from '../../components/configure';
+import { STATE_SLICE } from '../../store/constants';
+import useAllFeatureToggles from './use-all-feature-toggles';
+
+jest.mock('tiny-warning');
+
+const testFeatures = {
+  featureA: true,
+  featureB: false,
+  featureC: true,
+};
+
+const render = (store, TestComponent) =>
+  renderWithAdapter(TestComponent, {
+    components: {
+      ConfigureFlopFlip: Configure,
+      Wrapper: <Provider store={store} />,
+    },
+    flags: testFeatures,
+  });
+
+function TestComponent() {
+  const allFlags = useAllFeatureToggles();
+
+  return (
+    <div>
+      <h1>Enabled features</h1>
+      <ul>
+        {Object.keys(allFlags).map((flagName) => (
+          <li key={flagName}>{flagName}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+describe('when adapter is configured', () => {
+  it('should list all enabled features', async () => {
+    const store = createStore({
+      [STATE_SLICE]: { flags: { memory: { disabledFeature: false } } },
+    });
+    const { waitUntilConfigured } = render(store, <TestComponent />);
+
+    await waitUntilConfigured();
+
+    Object.entries(testFeatures).forEach(([featureName, isEnabled]) => {
+      if (isEnabled) {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(screen.getByText(featureName)).toBeInTheDocument();
+      } else {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(screen.queryByText(featureName)).not.toBeInTheDocument();
+      }
+    });
+  });
+});

--- a/packages/react-redux/src/hooks/use-all-feature-toggles/use-all-feature-toggles.ts
+++ b/packages/react-redux/src/hooks/use-all-feature-toggles/use-all-feature-toggles.ts
@@ -1,0 +1,30 @@
+import { getIsFeatureEnabled, useAdapterContext } from '@flopflip/react';
+import { type TFlags } from '@flopflip/types';
+import { useSelector } from 'react-redux';
+
+import { selectFlags } from '../../ducks/flags';
+
+export default function useAllFeatureToggles(): TFlags {
+  const allFlags = useSelector(selectFlags());
+  const adapterContext = useAdapterContext();
+
+  const enabledFlags: TFlags = Object.values(allFlags).reduce<TFlags>(
+    (_enabledFlags, flags) => {
+      Object.keys(flags).forEach((featureName) => {
+        if (
+          getIsFeatureEnabled(
+            allFlags,
+            adapterContext.adapterEffectIdentifiers,
+            featureName
+          )
+        ) {
+          _enabledFlags[featureName] = true;
+        }
+      });
+      return _enabledFlags;
+    },
+    {}
+  );
+
+  return enabledFlags;
+}


### PR DESCRIPTION
#### Summary

Include new hook to read all enabled feature toggles

#### Description

The idea is that there might be use cases where a consumer would like to read all configured feature toggles that are enabled.

In this PR I propose to include a new hook that achieves this feature.

It is not clear to me yet what to hook should return: it currently returns an object of type `TFlags` the same way it's used internally but maybe it would make more sense to just return an array of strings with the names of the enabled feature toggles.

Also, it's not clear to me how internal flags are supposed to use, as there' one configured in the test context and I don't know how the code is supposed to handle those king of toggles.
Are they something actually used? Do they have any specific context to know they should not be exposed?