### PR TITLE
Fix reversing adapter identifiers in place

### DIFF
--- a/.changeset/weak-pots-melt.md
+++ b/.changeset/weak-pots-melt.md
@@ -1,0 +1,9 @@
+---
+"@flopflip/combine-adapters": patch
+"@flopflip/react-broadcast": patch
+"@flopflip/react-redux": patch
+"@flopflip/react": patch
+"@flopflip/test-utils": patch
+---
+
+Fix reversing adapter identifiers in place

--- a/packages/combine-adapters/src/adapter/adapter.spec.js
+++ b/packages/combine-adapters/src/adapter/adapter.spec.js
@@ -5,7 +5,6 @@ import {
   AdapterInitializationStatus,
 } from '@flopflip/types';
 import getGlobalThis from 'globalthis';
-import { beforeAll } from 'globalthis/implementation';
 import warning from 'tiny-warning';
 
 import adapter from './adapter';
@@ -269,6 +268,38 @@ describe('when combining', () => {
         expect(adapterEventHandlers.onFlagsStateChange).toHaveBeenCalledWith({
           id: localstorageAdapter.id,
           flags: expect.objectContaining(updatedFlags),
+        });
+      });
+    });
+
+    describe('when updating flags existing in both adapters', () => {
+      const similarFlags = updatedFlags;
+      beforeEach(() => {
+        adapterEventHandlers.onFlagsStateChange.mockClear();
+
+        memoryAdapter.updateFlags({ ...similarFlags, duplicateFlag: true });
+        localstorageAdapter.updateFlags({
+          ...similarFlags,
+          duplicateFlag: false,
+        });
+      });
+
+      it('should invoke `onFlagsStateChange` with `updatedFlags` for all combined adapters', () => {
+        expect(adapterEventHandlers.onFlagsStateChange).toHaveBeenCalledWith({
+          id: memoryAdapter.id,
+          flags: expect.objectContaining(similarFlags),
+        });
+        expect(adapterEventHandlers.onFlagsStateChange).toHaveBeenCalledWith({
+          id: localstorageAdapter.id,
+          flags: expect.objectContaining(similarFlags),
+        });
+        expect(adapterEventHandlers.onFlagsStateChange).toHaveBeenCalledWith({
+          id: memoryAdapter.id,
+          flags: expect.objectContaining({ duplicateFlag: true }),
+        });
+        expect(adapterEventHandlers.onFlagsStateChange).toHaveBeenCalledWith({
+          id: localstorageAdapter.id,
+          flags: expect.objectContaining({ duplicateFlag: false }),
         });
       });
     });

--- a/packages/react-broadcast/package.json
+++ b/packages/react-broadcast/package.json
@@ -27,6 +27,8 @@
   },
   "homepage": "https://github.com/tdeekens/flopflip#readme",
   "devDependencies": {
+    "@flopflip/combine-adapters": "13.4.0",
+    "@flopflip/localstorage-adapter": "13.4.0",
     "@flopflip/memory-adapter": "13.4.0",
     "@flopflip/test-utils": "*",
     "@types/react": "18.2.64",

--- a/packages/react-broadcast/src/hooks/use-all-feature-toggles/use-all-feature-toggles.spec.js
+++ b/packages/react-broadcast/src/hooks/use-all-feature-toggles/use-all-feature-toggles.spec.js
@@ -75,7 +75,7 @@ describe('with one adapter', () => {
   });
 });
 
-describe.only('when combining adapters', () => {
+describe('when combining adapters', () => {
   let adapterArgs;
 
   const createAdapterArgs = (customArgs = {}) => ({

--- a/packages/react-broadcast/src/hooks/use-all-feature-toggles/use-all-feature-toggles.spec.js
+++ b/packages/react-broadcast/src/hooks/use-all-feature-toggles/use-all-feature-toggles.spec.js
@@ -1,4 +1,13 @@
-import { defaultFlags, renderWithAdapter, screen } from '@flopflip/test-utils';
+import { adapterIdentifiers } from '@flopflip/combine-adapters';
+import combineAdapters from '@flopflip/combine-adapters';
+import localstorageAdapter from '@flopflip/localstorage-adapter';
+import memoryAdapter from '@flopflip/memory-adapter';
+import {
+  act,
+  defaultFlags,
+  renderWithAdapter,
+  screen,
+} from '@flopflip/test-utils';
 import React from 'react';
 
 import Configure from '../../components/configure';
@@ -11,15 +20,17 @@ const enabledDefaultFlags = Object.fromEntries(
   Object.entries(defaultFlags).filter(([, isEnabled]) => isEnabled)
 );
 
-const render = (TestComponent) =>
+const render = (TestComponent, { adapter, adapterArgs } = {}) =>
   renderWithAdapter(TestComponent, {
     components: {
       ConfigureFlopFlip: Configure,
     },
+    adapter,
+    adapterArgs,
   });
 
 function TestComponent() {
-  const allFlags = useAllFeatureToggles(['memory']);
+  const allFlags = useAllFeatureToggles();
 
   return (
     <ul>
@@ -32,30 +43,176 @@ function TestComponent() {
   );
 }
 
-describe('disabled features', () => {
-  it.each(Object.keys(disabledDefaultFlags))(
-    'should list disabled feature "%s"',
-    async (featureName) => {
-      const { waitUntilConfigured } = render(<TestComponent />);
+describe('with one adapter', () => {
+  describe('disabled features', () => {
+    it.each(Object.keys(disabledDefaultFlags))(
+      'should list disabled feature "%s"',
+      async (featureName) => {
+        const { waitUntilConfigured } = render(<TestComponent />);
 
-      await waitUntilConfigured();
+        await waitUntilConfigured();
 
-      expect(
-        screen.getByText(`${featureName} is disabled`)
-      ).toBeInTheDocument();
-    }
-  );
+        expect(
+          screen.getByText(`${featureName} is disabled`)
+        ).toBeInTheDocument();
+      }
+    );
+  });
+
+  describe('enabled features', () => {
+    it.each(Object.keys(enabledDefaultFlags))(
+      'should list enabled feature "%s"',
+      async (featureName) => {
+        const { waitUntilConfigured } = render(<TestComponent />);
+
+        await waitUntilConfigured();
+
+        expect(
+          screen.getByText(`${featureName} is enabled`)
+        ).toBeInTheDocument();
+      }
+    );
+  });
 });
 
-describe('enabled features', () => {
-  it.each(Object.keys(enabledDefaultFlags))(
-    'should list enabled feature "%s"',
-    async (featureName) => {
-      const { waitUntilConfigured } = render(<TestComponent />);
+describe.only('when combining adapters', () => {
+  let adapterArgs;
 
-      await waitUntilConfigured();
+  const createAdapterArgs = (customArgs = {}) => ({
+    user: { id: 'foo' },
+    [memoryAdapter.id]: {
+      user: {
+        id: 'memory-adapter-user-id',
+      },
+    },
+    [localstorageAdapter.id]: {
+      user: {
+        id: 'localstorage-adapter-user-id',
+      },
+    },
+    ...customArgs,
+  });
 
-      expect(screen.getByText(`${featureName} is enabled`)).toBeInTheDocument();
-    }
-  );
+  beforeAll(async () => {
+    combineAdapters.combine([memoryAdapter, localstorageAdapter]);
+
+    adapterArgs = createAdapterArgs();
+  });
+
+  describe('without flag updating', () => {
+    it.each(Object.keys(disabledDefaultFlags))(
+      'should list disabled feature "%s"',
+      async (featureName) => {
+        const { waitUntilConfigured } = render(<TestComponent />, {
+          adapter: combineAdapters,
+          adapterArgs,
+        });
+
+        await waitUntilConfigured();
+
+        expect(
+          screen.getByText(`${featureName} is disabled`)
+        ).toBeInTheDocument();
+      }
+    );
+
+    it.each(Object.keys(enabledDefaultFlags))(
+      'should list enabled feature "%s"',
+      async (featureName) => {
+        const { waitUntilConfigured } = render(<TestComponent />, {
+          adapter: combineAdapters,
+          adapterArgs,
+        });
+
+        await waitUntilConfigured();
+
+        expect(
+          screen.getByText(`${featureName} is enabled`)
+        ).toBeInTheDocument();
+      }
+    );
+  });
+
+  describe('with flag updating', () => {
+    describe('with no duplicate flags', () => {
+      it('should allow updating the flag of the memory adapter', async () => {
+        const { waitUntilConfigured: waitUntilConfiguredFirstRender } = render(
+          <TestComponent adapterIdentifiers={[memoryAdapter.id]} />,
+          {
+            adapter: combineAdapters,
+            adapterArgs,
+          }
+        );
+
+        await waitUntilConfiguredFirstRender();
+
+        expect(
+          screen.queryByText(`updatedFlag is enabled`)
+        ).not.toBeInTheDocument();
+
+        act(() => {
+          memoryAdapter.updateFlags({
+            updatedMemoryAdapterFlag: true,
+          });
+        });
+
+        expect(
+          screen.getByText(`updatedMemoryAdapterFlag is enabled`)
+        ).toBeInTheDocument();
+
+        act(() => {
+          localstorageAdapter.updateFlags({
+            updatedLocalstorageAdapterFlag: true,
+          });
+        });
+
+        expect(
+          screen.getByText(`updatedLocalstorageAdapterFlag is enabled`)
+        ).toBeInTheDocument();
+      });
+    });
+    describe('with duplicate flags', () => {
+      it('should resolve flag in the order of adapter identifiers', async () => {
+        const { waitUntilConfigured: waitUntilConfiguredFirstRender } = render(
+          <TestComponent adapterIdentifiers={[memoryAdapter.id]} />,
+          {
+            adapter: combineAdapters,
+            adapterArgs,
+          }
+        );
+
+        await waitUntilConfiguredFirstRender();
+
+        expect(
+          screen.queryByText(`updatedFlag is enabled`)
+        ).not.toBeInTheDocument();
+
+        act(() => {
+          memoryAdapter.updateFlags({
+            updatedShared: true,
+          });
+          localstorageAdapter.updateFlags({
+            updatedShared: false,
+          });
+        });
+
+        expect(
+          screen.getByText(`updatedShared is enabled`)
+        ).toBeInTheDocument();
+
+        act(() => {
+          memoryAdapter.updateFlags({
+            updatedShared: false,
+          });
+          localstorageAdapter.updateFlags({
+            updatedShared: true,
+          });
+        });
+
+        expect(
+          screen.getByText(`updatedShared is disabled`)
+        ).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/packages/react-broadcast/src/hooks/use-all-feature-toggles/use-all-feature-toggles.ts
+++ b/packages/react-broadcast/src/hooks/use-all-feature-toggles/use-all-feature-toggles.ts
@@ -6,8 +6,11 @@ import useFlagsContext from '../use-flags-context';
 export default function useAllFeatureToggles(): TFlags {
   const adapterContext = useAdapterContext();
   const flagsContext = useFlagsContext();
+  const reversedAdapterEffectIdentifiers = [
+    ...adapterContext.adapterEffectIdentifiers,
+  ].reverse();
 
-  return adapterContext.adapterEffectIdentifiers.reverse().reduce<TFlags>(
+  return reversedAdapterEffectIdentifiers.reduce<TFlags>(
     (_allFlags, adapterIdentifier) => ({
       ..._allFlags,
       ...flagsContext[adapterIdentifier],

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -27,6 +27,8 @@
   },
   "homepage": "https://github.com/tdeekens/flopflip#readme",
   "devDependencies": {
+    "@flopflip/combine-adapters": "13.4.0",
+    "@flopflip/localstorage-adapter": "13.4.0",
     "@flopflip/memory-adapter": "13.4.0",
     "@flopflip/test-utils": "*",
     "react": "18.2.0",

--- a/packages/react-redux/src/hooks/use-all-feature-toggles/use-all-feature-toggles.spec.js
+++ b/packages/react-redux/src/hooks/use-all-feature-toggles/use-all-feature-toggles.spec.js
@@ -1,4 +1,13 @@
-import { defaultFlags, renderWithAdapter, screen } from '@flopflip/test-utils';
+import { adapterIdentifiers } from '@flopflip/combine-adapters';
+import combineAdapters from '@flopflip/combine-adapters';
+import localstorageAdapter from '@flopflip/localstorage-adapter';
+import memoryAdapter from '@flopflip/memory-adapter';
+import {
+  act,
+  defaultFlags,
+  renderWithAdapter,
+  screen,
+} from '@flopflip/test-utils';
 import React from 'react';
 import { Provider } from 'react-redux';
 
@@ -16,12 +25,14 @@ const enabledDefaultFlags = Object.fromEntries(
   Object.entries(defaultFlags).filter(([, isEnabled]) => isEnabled)
 );
 
-const render = (store, TestComponent) =>
+const render = (store, TestComponent, { adapter, adapterArgs } = {}) =>
   renderWithAdapter(TestComponent, {
     components: {
       ConfigureFlopFlip: Configure,
       Wrapper: <Provider store={store} />,
     },
+    adapter,
+    adapterArgs,
   });
 
 function TestComponent() {
@@ -38,36 +49,204 @@ function TestComponent() {
   );
 }
 
-describe('disabled features', () => {
-  it.each(Object.keys(disabledDefaultFlags))(
-    'should list disabled feature "%s"',
-    async (featureName) => {
-      const store = createStore({
-        [STATE_SLICE]: { flags: { memory: defaultFlags } },
-      });
-      const { waitUntilConfigured } = render(store, <TestComponent />);
+describe('with one adapter', () => {
+  describe('disabled features', () => {
+    it.each(Object.keys(disabledDefaultFlags))(
+      'should list disabled feature "%s"',
+      async (featureName) => {
+        const store = createStore({
+          [STATE_SLICE]: { flags: { memory: defaultFlags } },
+        });
+        const { waitUntilConfigured } = render(store, <TestComponent />);
 
-      await waitUntilConfigured();
+        await waitUntilConfigured();
 
-      expect(
-        screen.getByText(`${featureName} is disabled`)
-      ).toBeInTheDocument();
-    }
-  );
+        expect(
+          screen.getByText(`${featureName} is disabled`)
+        ).toBeInTheDocument();
+      }
+    );
+  });
+  describe('enabled features', () => {
+    it.each(Object.keys(enabledDefaultFlags))(
+      'should list enabled feature "%s"',
+      async (featureName) => {
+        const store = createStore({
+          [STATE_SLICE]: { flags: { memory: defaultFlags } },
+        });
+        const { waitUntilConfigured } = render(store, <TestComponent />);
+
+        await waitUntilConfigured();
+
+        expect(
+          screen.getByText(`${featureName} is enabled`)
+        ).toBeInTheDocument();
+      }
+    );
+  });
 });
 
-describe('enabled features', () => {
-  it.each(Object.keys(enabledDefaultFlags))(
-    'should list enabled feature "%s"',
-    async (featureName) => {
-      const store = createStore({
-        [STATE_SLICE]: { flags: { memory: defaultFlags } },
+describe('when combining adapters', () => {
+  let adapterArgs;
+
+  const createAdapterArgs = (customArgs = {}) => ({
+    user: { id: 'foo' },
+    [memoryAdapter.id]: {
+      user: {
+        id: 'memory-adapter-user-id',
+      },
+    },
+    [localstorageAdapter.id]: {
+      user: {
+        id: 'localstorage-adapter-user-id',
+      },
+    },
+    ...customArgs,
+  });
+
+  beforeAll(async () => {
+    combineAdapters.combine([memoryAdapter, localstorageAdapter]);
+
+    adapterArgs = createAdapterArgs();
+  });
+
+  describe('without flag updating', () => {
+    it.each(Object.keys(disabledDefaultFlags))(
+      'should list disabled feature "%s"',
+      async (featureName) => {
+        const store = createStore({
+          [STATE_SLICE]: {
+            flags: { memory: defaultFlags, localstorage: defaultFlags },
+          },
+        });
+        const { waitUntilConfigured } = render(store, <TestComponent />, {
+          adapter: combineAdapters,
+          adapterArgs,
+        });
+
+        await waitUntilConfigured();
+
+        expect(
+          screen.getByText(`${featureName} is disabled`)
+        ).toBeInTheDocument();
+      }
+    );
+
+    it.each(Object.keys(enabledDefaultFlags))(
+      'should list enabled feature "%s"',
+      async (featureName) => {
+        const store = createStore({
+          [STATE_SLICE]: {
+            flags: { memory: defaultFlags, localstorage: defaultFlags },
+          },
+        });
+
+        const { waitUntilConfigured } = render(store, <TestComponent />, {
+          adapter: combineAdapters,
+          adapterArgs,
+        });
+
+        await waitUntilConfigured();
+
+        expect(
+          screen.getByText(`${featureName} is enabled`)
+        ).toBeInTheDocument();
+      }
+    );
+  });
+
+  describe('with flag updating', () => {
+    describe('with no duplicate flags', () => {
+      it('should allow updating the flag of the memory adapter', async () => {
+        const store = createStore({
+          [STATE_SLICE]: {
+            flags: { memory: defaultFlags, localstorage: defaultFlags },
+          },
+        });
+        const { waitUntilConfigured: waitUntilConfiguredFirstRender } = render(
+          store,
+          <TestComponent adapterIdentifiers={[memoryAdapter.id]} />,
+          {
+            adapter: combineAdapters,
+            adapterArgs,
+          }
+        );
+
+        await waitUntilConfiguredFirstRender();
+
+        expect(
+          screen.queryByText(`updatedFlag is enabled`)
+        ).not.toBeInTheDocument();
+
+        act(() => {
+          memoryAdapter.updateFlags({
+            updatedMemoryAdapterFlag: true,
+          });
+        });
+
+        expect(
+          screen.getByText(`updatedMemoryAdapterFlag is enabled`)
+        ).toBeInTheDocument();
+
+        act(() => {
+          localstorageAdapter.updateFlags({
+            updatedLocalstorageAdapterFlag: true,
+          });
+        });
+
+        expect(
+          screen.getByText(`updatedLocalstorageAdapterFlag is enabled`)
+        ).toBeInTheDocument();
       });
-      const { waitUntilConfigured } = render(store, <TestComponent />);
+    });
+    describe('with duplicate flags', () => {
+      it('should resolve flag in the order of adapter identifiers', async () => {
+        const store = createStore({
+          [STATE_SLICE]: {
+            flags: { memory: defaultFlags, localstorage: defaultFlags },
+          },
+        });
+        const { waitUntilConfigured: waitUntilConfiguredFirstRender } = render(
+          store,
+          <TestComponent adapterIdentifiers={[memoryAdapter.id]} />,
+          {
+            adapter: combineAdapters,
+            adapterArgs,
+          }
+        );
 
-      await waitUntilConfigured();
+        await waitUntilConfiguredFirstRender();
 
-      expect(screen.getByText(`${featureName} is enabled`)).toBeInTheDocument();
-    }
-  );
+        expect(
+          screen.queryByText(`updatedFlag is enabled`)
+        ).not.toBeInTheDocument();
+
+        act(() => {
+          memoryAdapter.updateFlags({
+            updatedShared: true,
+          });
+          localstorageAdapter.updateFlags({
+            updatedShared: false,
+          });
+        });
+
+        expect(
+          screen.getByText(`updatedShared is enabled`)
+        ).toBeInTheDocument();
+
+        act(() => {
+          memoryAdapter.updateFlags({
+            updatedShared: false,
+          });
+          localstorageAdapter.updateFlags({
+            updatedShared: true,
+          });
+        });
+
+        expect(
+          screen.getByText(`updatedShared is disabled`)
+        ).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/packages/react-redux/src/hooks/use-all-feature-toggles/use-all-feature-toggles.ts
+++ b/packages/react-redux/src/hooks/use-all-feature-toggles/use-all-feature-toggles.ts
@@ -7,8 +7,11 @@ import { selectFlags } from '../../ducks/flags';
 export default function useAllFeatureToggles(): TFlags {
   const adapterContext = useAdapterContext();
   const allFlags = useSelector(selectFlags());
+  const reversedAdapterEffectIdentifiers = [
+    ...adapterContext.adapterEffectIdentifiers,
+  ].reverse();
 
-  return adapterContext.adapterEffectIdentifiers.reverse().reduce<TFlags>(
+  return reversedAdapterEffectIdentifiers.reduce<TFlags>(
     (_allFlags, adapterIdentifier) => ({
       ..._allFlags,
       ...allFlags[adapterIdentifier],

--- a/packages/test-utils/src/index.js
+++ b/packages/test-utils/src/index.js
@@ -1,4 +1,4 @@
-import adapter from '@flopflip/memory-adapter';
+import memoryAdapter from '@flopflip/memory-adapter';
 import {
   act,
   buildQueries,
@@ -10,7 +10,7 @@ import {
 } from '@testing-library/react';
 import React, { cloneElement } from 'react';
 
-afterEach(adapter.reset);
+afterEach(memoryAdapter.reset);
 
 const mergeOptional = (defaultValue, value) =>
   value === null ? undefined : { ...defaultValue, ...value };
@@ -86,7 +86,9 @@ function FlagChangeField() {
         onChange={(event) => {
           const { flagName, flagVariation } = JSON.parse(event.target.value);
 
-          adapter.updateFlags({ [flagName]: fromEventString(flagVariation) });
+          memoryAdapter.updateFlags({
+            [flagName]: fromEventString(flagVariation),
+          });
         }}
       />
     </>
@@ -136,6 +138,7 @@ const renderWithAdapter = (
   ui,
   {
     components: { ConfigureFlopFlip, Wrapper = null },
+    adapter,
     adapterArgs,
     flags,
     ...rtlOptions
@@ -143,6 +146,7 @@ const renderWithAdapter = (
 ) => {
   const defaultedAdapterArgs = mergeOptional(defaultAdapterArgs, adapterArgs);
   const defaultedFlags = mergeOptional(defaultFlags, flags);
+  const defaultedAdapter = adapter || memoryAdapter;
 
   const wrapUiIfNeeded = (innerElement) =>
     Wrapper ? cloneElement(Wrapper, null, innerElement) : innerElement;
@@ -151,7 +155,7 @@ const renderWithAdapter = (
   const rendered = render(
     wrapUiIfNeeded(
       <ConfigureFlopFlip
-        adapter={adapter}
+        adapter={defaultedAdapter}
         adapterArgs={defaultedAdapterArgs}
         defaultFlags={defaultedFlags}
       >
@@ -192,7 +196,7 @@ const components = {
 export * from '@testing-library/react';
 export {
   act,
-  adapter,
+  memoryAdapter as adapter,
   components,
   defaultFlags,
   defaultRender as render,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,6 +489,12 @@ importers:
         specifier: 1.2.0
         version: 1.2.0(react@18.2.0)
     devDependencies:
+      '@flopflip/combine-adapters':
+        specifier: 13.4.0
+        version: link:../combine-adapters
+      '@flopflip/localstorage-adapter':
+        specifier: 13.4.0
+        version: link:../localstorage-adapter
       '@flopflip/memory-adapter':
         specifier: 13.4.0
         version: link:../memory-adapter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,12 @@ importers:
         specifier: 7.1.33
         version: 7.1.33
     devDependencies:
+      '@flopflip/combine-adapters':
+        specifier: 13.4.0
+        version: link:../combine-adapters
+      '@flopflip/localstorage-adapter':
+        specifier: 13.4.0
+        version: link:../localstorage-adapter
       '@flopflip/memory-adapter':
         specifier: 13.4.0
         version: link:../memory-adapter


### PR DESCRIPTION
#### Summary

Kudos to @CarlosCortizasCT for finding this bug.

We reversed the React context in place. Turns out you can do that 😓.

The commits for each package contain a broken test suite and then the fix. Sort of Uni-style TDD to prove the point.

The setup of how we test had to be adjusted as we want to test this with combined adapters.