### PR TITLE
feat(http-adapter): to fetch adapterArgs to execute

### DIFF
--- a/.changeset/sweet-lemons-fold.md
+++ b/.changeset/sweet-lemons-fold.md
@@ -1,0 +1,6 @@
+---
+"@flopflip/http-adapter": minor
+"@flopflip/types": minor
+---
+
+Add `adapterArgs` being passed to `execute` on the `http-adapter`.

--- a/packages/http-adapter/src/adapter/adapter.ts
+++ b/packages/http-adapter/src/adapter/adapter.ts
@@ -118,7 +118,7 @@ class HttpAdapter implements THttpAdapterInterface {
   readonly #fetchFlags = async (
     adapterArgs: THttpAdapterArgs
   ): Promise<TFlags> => {
-    const flags = await adapterArgs.execute();
+    const flags = await adapterArgs.execute(adapterArgs);
 
     return flags;
   };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -85,7 +85,11 @@ export type TGraphQlAdapterArgs<
 export type THttpAdapterArgs<
   TAdditionalUserProperties = TDefaultAdditionalUserProperties,
 > = TBaseAdapterArgs<TAdditionalUserProperties> & {
-  execute: () => Promise<any>;
+  execute: <
+    TPassedAdapterArgs extends TBaseAdapterArgs<TAdditionalUserProperties>,
+  >(
+    adapterArgs: TPassedAdapterArgs
+  ) => Promise<any>;
   pollingIntervalMs?: number;
   cacheIdentifier?: TCacheIdentifiers;
 };


### PR DESCRIPTION
#### Summary

When reconfiguring the adapterArgs can be passed into execute again. This helps passing new values to the underlying fetch.