### PR TITLE
fix(http-adapter): to not empty flags with unchanged reconfiguration

### DIFF
--- a/.changeset/twenty-cherries-call.md
+++ b/.changeset/twenty-cherries-call.md
@@ -1,0 +1,6 @@
+---
+"@flopflip/http-adapter": patch
+"@flopflip/launchdarkly-adapter": patch
+---
+
+Fix the `http-adapter` to not flush empty flags with unchanged reconfiguration of the same user.

--- a/packages/http-adapter/src/adapter/adapter.ts
+++ b/packages/http-adapter/src/adapter/adapter.ts
@@ -264,31 +264,33 @@ class HttpAdapter implements THttpAdapterInterface {
         )
       );
 
-    this.#adapterState.flags = {};
-
-    if (adapterArgs.cacheIdentifier) {
-      const cache = await getCache(
-        adapterArgs.cacheIdentifier,
-        adapterIdentifiers.http,
-        this.#adapterState.user?.key
-      );
-
-      cache.unset();
-    }
-
     const nextUser = adapterArgs.user;
 
-    this.#adapterState.user = nextUser;
+    if (!isEqual(this.#adapterState.user, nextUser)) {
+      this.#adapterState.flags = {};
 
-    const flags = normalizeFlags(await this.#fetchFlags(adapterArgs));
+      if (adapterArgs.cacheIdentifier) {
+        const cache = await getCache(
+          adapterArgs.cacheIdentifier,
+          adapterIdentifiers.http,
+          this.#adapterState.user?.key
+        );
 
-    this.#adapterState.flags = flags;
+        cache.unset();
+      }
 
-    this.#adapterState.emitter.emit('flagsStateChange', flags);
+      this.#adapterState.user = nextUser;
 
-    this.#adapterState.emitter.emit(this.#__internalConfiguredStatusChange__);
+      const flags = normalizeFlags(await this.#fetchFlags(adapterArgs));
 
-    this.#subscribeToFlagsChanges(adapterArgs);
+      this.#adapterState.flags = flags;
+
+      this.#adapterState.emitter.emit('flagsStateChange', flags);
+
+      this.#adapterState.emitter.emit(this.#__internalConfiguredStatusChange__);
+
+      this.#subscribeToFlagsChanges(adapterArgs);
+    }
 
     return Promise.resolve({
       initializationStatus: AdapterInitializationStatus.Succeeded,

--- a/packages/launchdarkly-adapter/src/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/src/adapter/adapter.ts
@@ -455,10 +455,6 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
       this.#adapterState.context = nextContext;
 
       await this.#changeClientContext(this.#adapterState.context);
-
-      return Promise.resolve({
-        initializationStatus: AdapterInitializationStatus.Succeeded,
-      });
     }
 
     return Promise.resolve({


### PR DESCRIPTION
#### Summary

The `launchdarkly-adapter` does not perform any action with reconfiguring on an unchanged user context.

The `http-adapter` should perform similar. We do not need to empty the cache and refetch. We can just perform no action in this case.