### PR TITLE
refactor: cache keys to be bound to adapter context

### DIFF
--- a/.changeset/modern-fireants-reflect.md
+++ b/.changeset/modern-fireants-reflect.md
@@ -1,0 +1,8 @@
+---
+"@flopflip/cache": patch
+"@flopflip/graphql-adapter": patch
+"@flopflip/http-adapter": patch
+"@flopflip/launchdarkly-adapter": patch
+---
+
+Refactor cache keys to be bound to adapter context.

--- a/packages/cache/src/cache/cache.spec.js
+++ b/packages/cache/src/cache/cache.spec.js
@@ -1,13 +1,14 @@
 import { adapterIdentifiers, cacheIdentifiers } from '@flopflip/types';
 
 import {
+  encodeCacheContext,
   getAllCachedFlags,
   getCache,
   getCachedFlags,
   getCachePrefix,
 } from './cache';
 
-const cacheKey = 'test';
+const cacheContext = { key: 'some-user-key', value: 'some-other-value' };
 
 describe('general caching', () => {
   it('should allow writing values to the cache', async () => {
@@ -17,7 +18,7 @@ describe('general caching', () => {
     const cache = await getCache(
       cacheIdentifiers.session,
       adapterIdentifiers.memory,
-      cacheKey
+      cacheContext
     );
 
     cache.set(flags);
@@ -32,7 +33,7 @@ describe('general caching', () => {
     const cache = await getCache(
       cacheIdentifiers.session,
       adapterIdentifiers.memory,
-      cacheKey
+      cacheContext
     );
 
     cache.set(flags);
@@ -48,13 +49,15 @@ describe('general caching', () => {
     const cache = await getCache(
       cacheIdentifiers.session,
       adapterIdentifiers.memory,
-      cacheKey
+      cacheContext
     );
 
     cache.set(flags);
 
     expect(sessionStorage.getItem).toHaveBeenLastCalledWith(
-      `${getCachePrefix(adapterIdentifiers.memory)}/${cacheKey}/flags`
+      expect.stringContaining(
+        `${getCachePrefix(adapterIdentifiers.memory)}/${encodeCacheContext(cacheContext)}/flags`
+      )
     );
   });
 });
@@ -68,7 +71,7 @@ describe('flag caching', () => {
       const cache = await getCache(
         cacheIdentifiers.session,
         adapterIdentifiers.memory,
-        cacheKey
+        cacheContext
       );
 
       cache.set(flags);
@@ -78,7 +81,7 @@ describe('flag caching', () => {
       ).toStrictEqual(flags);
 
       expect(sessionStorage.getItem).toHaveBeenLastCalledWith(
-        `${getCachePrefix(adapterIdentifiers.memory)}/${cacheKey}/flags`
+        `${getCachePrefix(adapterIdentifiers.memory)}/${encodeCacheContext(cacheContext)}/flags`
       );
     });
   });
@@ -94,12 +97,12 @@ describe('flag caching', () => {
       const memoryAdapterCache = await getCache(
         cacheIdentifiers.session,
         adapterIdentifiers.memory,
-        cacheKey
+        cacheContext
       );
       const localstorageAdapterCache = await getCache(
         cacheIdentifiers.session,
         adapterIdentifiers.localstorage,
-        cacheKey
+        cacheContext
       );
 
       localstorageAdapterCache.set(localstorageAdapterFlags);

--- a/packages/cache/src/cache/index.ts
+++ b/packages/cache/src/cache/index.ts
@@ -1,4 +1,9 @@
 const version = '__@FLOPFLIP/VERSION_OF_RELEASE__';
 
 export { version };
-export { getAllCachedFlags, getCache, getCachedFlags } from './cache';
+export {
+  encodeCacheContext,
+  getAllCachedFlags,
+  getCache,
+  getCachedFlags,
+} from './cache';

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -1,4 +1,9 @@
 const version = '__@FLOPFLIP/VERSION_OF_RELEASE__';
 
-export { getAllCachedFlags, getCache, getCachedFlags } from './cache';
+export {
+  encodeCacheContext,
+  getAllCachedFlags,
+  getCache,
+  getCachedFlags,
+} from './cache';
 export { version };

--- a/packages/graphql-adapter/src/adapter/adapter.spec.js
+++ b/packages/graphql-adapter/src/adapter/adapter.spec.js
@@ -1,3 +1,4 @@
+import { encodeCacheContext } from '@flopflip/cache';
 import { AdapterConfigurationStatus } from '@flopflip/types';
 import getGlobalThis from 'globalthis';
 import warning from 'tiny-warning';
@@ -35,6 +36,7 @@ describe('when configuring', () => {
 describe('when configured', () => {
   const adapterArgs = {
     url: `https://localhost:8080/graphql`,
+    user: { key: 'initial-user' },
     query: 'query AllFeatures { flags: allFeatures { name \n value} }',
     getQueryVariables: jest.fn(() => ({ userId: '123' })),
     getRequestHeaders: jest.fn(() => ({})),
@@ -142,6 +144,7 @@ describe('when configured', () => {
     const adapterArgs = {
       cacheIdentifier: 'session',
       url: `https://localhost:8080/graphql`,
+      user: { key: 'initial-user' },
       query: 'query AllFeatures { flags: allFeatures { name \n value} }',
       getQueryVariables: jest.fn(() => ({ userId: '123' })),
       getRequestHeaders: jest.fn(() => ({})),
@@ -180,7 +183,7 @@ describe('when configured', () => {
 
     it('should restore cached flags', () => {
       expect(sessionStorage.getItem).toHaveBeenCalledWith(
-        '@flopflip/graphql-adapter/flags'
+        `@flopflip/graphql-adapter/${encodeCacheContext(adapterArgs.user)}/flags`
       );
 
       expect(adapterEventHandlers.onFlagsStateChange).toHaveBeenCalledWith({
@@ -193,7 +196,11 @@ describe('when configured', () => {
 
     it('should cache newly fetched flags', () => {
       expect(
-        JSON.parse(sessionStorage.getItem('@flopflip/graphql-adapter/flags'))
+        JSON.parse(
+          sessionStorage.getItem(
+            `@flopflip/graphql-adapter/${encodeCacheContext(adapterArgs.user)}/flags`
+          )
+        )
       ).toStrictEqual({ disabled: false, enabled: true });
     });
 
@@ -343,7 +350,7 @@ describe('when configured', () => {
 
     it('should reset cache', () => {
       expect(sessionStorage.removeItem).toHaveBeenCalledWith(
-        '@flopflip/graphql-adapter/flags'
+        `@flopflip/graphql-adapter/${encodeCacheContext(adapterArgs.user)}/flags`
       );
     });
   });

--- a/packages/graphql-adapter/src/adapter/adapter.ts
+++ b/packages/graphql-adapter/src/adapter/adapter.ts
@@ -124,7 +124,7 @@ class GraphQlAdapter implements TGraphQlAdapterInterface {
             const cache = await getCache(
               adapterArgs.cacheIdentifier,
               adapterIdentifiers.graphql,
-              this.#adapterState.user?.key
+              { key: this.#adapterState.user?.key }
             );
 
             cache.set(nextFlags);
@@ -226,7 +226,7 @@ class GraphQlAdapter implements TGraphQlAdapterInterface {
         const cache = await getCache(
           adapterArgs.cacheIdentifier,
           adapterIdentifiers.graphql,
-          this.#adapterState.user?.key
+          { key: this.#adapterState.user?.key }
         );
 
         cachedFlags = cache.get();
@@ -250,7 +250,7 @@ class GraphQlAdapter implements TGraphQlAdapterInterface {
         const cache = await getCache(
           adapterArgs.cacheIdentifier,
           adapterIdentifiers.graphql,
-          this.#adapterState.user?.key
+          { key: this.#adapterState.user?.key }
         );
 
         cache.set(flags);
@@ -287,7 +287,7 @@ class GraphQlAdapter implements TGraphQlAdapterInterface {
       const cache = await getCache(
         adapterArgs.cacheIdentifier,
         adapterIdentifiers.graphql,
-        this.#adapterState.user?.key
+        { key: this.#adapterState.user?.key }
       );
 
       cache.unset();

--- a/packages/http-adapter/src/adapter/adapter.spec.js
+++ b/packages/http-adapter/src/adapter/adapter.spec.js
@@ -1,3 +1,4 @@
+import { encodeCacheContext } from '@flopflip/cache';
 import { AdapterConfigurationStatus } from '@flopflip/types';
 import getGlobalThis from 'globalthis';
 import warning from 'tiny-warning';
@@ -35,6 +36,7 @@ describe('when configuring', () => {
 describe('when configured', () => {
   const adapterArgs = {
     execute: jest.fn().mockResolvedValue({ enabled: true, disabled: false }),
+    user: { key: 'initial-user' },
   };
   let configurationResult;
   let adapterEventHandlers;
@@ -108,7 +110,7 @@ describe('when configured', () => {
     const adapterArgs = {
       cacheIdentifier: 'session',
       execute: jest.fn().mockResolvedValue({ enabled: true, disabled: false }),
-      user: 'initial-user',
+      user: { key: 'initial-user' },
     };
     let configurationResult;
     let adapterEventHandlers;
@@ -139,7 +141,7 @@ describe('when configured', () => {
 
     it('should restore cached flags', () => {
       expect(sessionStorage.getItem).toHaveBeenCalledWith(
-        '@flopflip/http-adapter/flags'
+        `@flopflip/http-adapter/${encodeCacheContext(adapterArgs.user)}/flags`
       );
 
       expect(adapterEventHandlers.onFlagsStateChange).toHaveBeenCalledWith({
@@ -152,7 +154,11 @@ describe('when configured', () => {
 
     it('should cache newly fetched flags', () => {
       expect(
-        JSON.parse(sessionStorage.getItem('@flopflip/http-adapter/flags'))
+        JSON.parse(
+          sessionStorage.getItem(
+            `@flopflip/http-adapter/${encodeCacheContext(adapterArgs.user)}/flags`
+          )
+        )
       ).toStrictEqual({ disabled: false, enabled: true });
     });
 
@@ -261,7 +267,7 @@ describe('when configured', () => {
 
   describe('when reconfiguring', () => {
     describe('when the user changed', () => {
-      const user = { id: 'changed-user' };
+      const user = { key: 'changed-user' };
 
       beforeEach(async () => {
         configurationResult = await adapter.reconfigure({
@@ -303,7 +309,7 @@ describe('when configured', () => {
 
       it('should reset cache', () => {
         expect(sessionStorage.removeItem).toHaveBeenCalledWith(
-          '@flopflip/http-adapter/flags'
+          `@flopflip/http-adapter/${encodeCacheContext(adapterArgs.user)}/flags`
         );
       });
     });

--- a/packages/http-adapter/src/adapter/adapter.ts
+++ b/packages/http-adapter/src/adapter/adapter.ts
@@ -107,7 +107,7 @@ class HttpAdapter implements THttpAdapterInterface {
             const cache = await getCache(
               adapterArgs.cacheIdentifier,
               adapterIdentifiers.http,
-              this.#adapterState.user?.key
+              { key: this.#adapterState.user?.key }
             );
 
             cache.set(nextFlags);
@@ -209,7 +209,7 @@ class HttpAdapter implements THttpAdapterInterface {
         const cache = await getCache(
           adapterArgs.cacheIdentifier,
           adapterIdentifiers.http,
-          this.#adapterState.user?.key
+          { key: this.#adapterState.user?.key }
         );
 
         cachedFlags = cache.get();
@@ -233,7 +233,7 @@ class HttpAdapter implements THttpAdapterInterface {
         const cache = await getCache(
           adapterArgs.cacheIdentifier,
           adapterIdentifiers.http,
-          this.#adapterState.user?.key
+          { key: this.#adapterState.user?.key }
         );
 
         cache.set(flags);
@@ -273,7 +273,7 @@ class HttpAdapter implements THttpAdapterInterface {
         const cache = await getCache(
           adapterArgs.cacheIdentifier,
           adapterIdentifiers.http,
-          this.#adapterState.user?.key
+          { key: this.#adapterState.user?.key }
         );
 
         cache.unset();

--- a/packages/launchdarkly-adapter/src/adapter/adapter.spec.js
+++ b/packages/launchdarkly-adapter/src/adapter/adapter.spec.js
@@ -1,3 +1,4 @@
+import { encodeCacheContext } from '@flopflip/cache';
 import { AdapterConfigurationStatus } from '@flopflip/types';
 import getGlobalThis from 'globalthis';
 import ldClient from 'launchdarkly-js-client-sdk';
@@ -10,7 +11,7 @@ jest.mock('launchdarkly-js-client-sdk', () => ({
 jest.mock('tiny-warning');
 
 const clientSideId = '123-abc';
-const userWithKey = { kind: 'user', key: 'foo-user' };
+const userWithKey = { kind: 'user', key: 'foo-user', anonymous: false };
 const userWithoutKey = {
   kind: 'user',
   group: 'foo-group',
@@ -488,7 +489,7 @@ describe('when configuring', () => {
 
         it('should restore cached flags', () => {
           expect(sessionStorage.getItem).toHaveBeenCalledWith(
-            '@flopflip/launchdarkly-adapter/foo-user/flags'
+            `@flopflip/launchdarkly-adapter/${encodeCacheContext(userWithKey)}/flags`
           );
 
           expect(onFlagsStateChange).toHaveBeenCalledWith({
@@ -503,7 +504,7 @@ describe('when configuring', () => {
           expect(
             JSON.parse(
               sessionStorage.getItem(
-                '@flopflip/launchdarkly-adapter/foo-user/flags'
+                `@flopflip/launchdarkly-adapter/${encodeCacheContext(userWithKey)}/flags`
               )
             )
           ).toStrictEqual({

--- a/packages/launchdarkly-adapter/src/adapter/adapter.ts
+++ b/packages/launchdarkly-adapter/src/adapter/adapter.ts
@@ -155,7 +155,7 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
         cacheIdentifier,
         adapterIdentifiers.launchdarkly,
         // NOTE: LDContextCommon is part of the type which we never use.
-        this.#adapterState.context?.key as string
+        this.#adapterState.context
       );
 
       const cachedFlags: TFlags = cache.get();
@@ -391,7 +391,7 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
       const cache = await getCache(
         adapterArgs.cacheIdentifier,
         adapterIdentifiers.launchdarkly,
-        context.key as string
+        this.#adapterState.context
       );
 
       cachedFlags = cache.get();
@@ -446,7 +446,7 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
         const cache = await getCache(
           adapterArgs.cacheIdentifier,
           adapterIdentifiers.launchdarkly,
-          this.#adapterState.context?.key as string
+          this.#adapterState.context
         );
 
         cache.unset();


### PR DESCRIPTION
#### Summary

This refactors the cache's key for flags to be a hashed version of the adapter's context.

#### Description

When caching lazily it is important to fall back to a hot cache as often as possible. Otherwise a user would be served a stale cache for flags.

Taking for example the flow of:

1. User logs in
2. Views project A
3. In project A feature is enabled
4. User navigates to project B
5. In project B feature is disabled

With a lazy acting cache, in the above flow the user at 5. would still see an enabled feature. This is rooted in the fact that the cache does not synchronize its state until another hard reload (or unmounting of flopflip). 

The reason for this behaviour is that at any point flopflip's cache is bound - without this change - to a user's key. Any user can only have one set of cached flags. 

This change proposes to take the entire context of the adapter into account for the cache key. This allows a user to have n caches depending on the number of contexts the user is in. This allows a "hot cache" to be restored more likely and flopflip not falling back onto a cold cache often.