### PR TITLE
Refactor to use redux-toolkit

### DIFF
--- a/.changeset/dull-turtles-thank.md
+++ b/.changeset/dull-turtles-thank.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": major
+---
+
+Migrates to use Redux Toolkit v2 internally. This changes the usage of `redux` to `v9` and `react-redux` to `v5`. This in turn means that with [v9](https://github.com/reduxjs/react-redux/releases/tag/v9.0.0) of `react-redux` that React 18 is required. This breaking change will be made in another changeset.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,10 +17,6 @@
       "matchUpdateTypes": ["digest", "patch", "minor", "major"]
     },
     {
-      "matchPackageNames": ["react-redux"],
-      "allowedVersions": "<=8.0.5"
-    },
-    {
       "matchPackageNames": ["cypress"],
       "allowedVersions": "<=13.6.4"
     }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://github.com/tdeekens/flopflip#readme",
   "keywords": [
     "react",
+    "@reduxjs/toolkit",
     "redux",
     "feature-flags",
     "feature-toggles",

--- a/packages/cypress-plugin/package.json
+++ b/packages/cypress-plugin/package.json
@@ -51,7 +51,7 @@
     "tsup": "8.3.6"
   },
   "peerDependencies": {
-    "cypress": "4.x || 5.x || 6.x || 7.x || 8.x || 9.x || 10.x || 11.x || 12.x || 13.x"
+    "cypress": "13.x || 14.x"
   },
   "dependencies": {
     "@flopflip/types": "workspace:*"

--- a/packages/react-broadcast/package.json
+++ b/packages/react-broadcast/package.json
@@ -58,8 +58,8 @@
     "tsup": "8.3.6"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0.0",
-    "react-dom": "^16.8 || ^17.0 || ^18.0.0"
+    "react": "18.x || 19.x",
+    "react-dom": "18.x || 19.x"
   },
   "dependencies": {
     "@babel/runtime": "7.26.9",

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -51,24 +51,22 @@
     "@flopflip/memory-adapter": "workspace:*",
     "@flopflip/test-utils": "workspace:*",
     "@flopflip/tsconfig": "workspace:*",
+    "@reduxjs/toolkit": "2.5.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-redux": "8.0.5",
-    "redux": "4.2.1",
+    "react-redux": "9.2.0",
+    "redux": "5.0.1",
     "tsup": "8.3.6"
   },
   "dependencies": {
     "@babel/runtime": "7.26.9",
     "@flopflip/react": "workspace:*",
     "@flopflip/types": "workspace:*",
-    "@types/react": "18.3.18",
-    "@types/react-redux": "7.1.34"
+    "@types/react": "18.3.18"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0.0",
-    "react-dom": "^16.8 || ^17.0 || ^18.0.0",
-    "react-redux": "^7.0.0 || ^8.0.0",
-    "redux": "^4.0"
+    "react": "18.x || 19.x",
+    "react-dom": "18.x || 19.x"
   },
   "keywords": [
     "feature-flags",

--- a/packages/react-redux/src/ducks/flags.ts
+++ b/packages/react-redux/src/ducks/flags.ts
@@ -6,11 +6,7 @@ import type {
   TFlagsChange,
   TFlagsContext,
 } from '@flopflip/types';
-import {
-  type PayloadAction,
-  createSelector,
-  createSlice,
-} from '@reduxjs/toolkit';
+import { type PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { STATE_SLICE } from '../constants';
 import type { TState } from '../types';

--- a/packages/react-redux/src/ducks/index.ts
+++ b/packages/react-redux/src/ducks/index.ts
@@ -1,26 +1,23 @@
 import type { TFlagsContext } from '@flopflip/types';
-import { combineReducers } from 'redux';
+import { combineReducers } from '@reduxjs/toolkit';
 
 import {
   createReducer as createFlagsReducer,
   reducer as flagsReducer,
 } from './flags';
 import { reducer as statusReducer } from './status';
-import type { TUpdateFlagsAction, TUpdateStatusAction } from './types';
 
-type Actions = TUpdateFlagsAction & TUpdateStatusAction;
+export { selectFlag, selectFlags, updateFlags } from './flags';
+export { updateStatus } from './status';
 
-export { selectFlag, selectFlags, UPDATE_FLAGS, updateFlags } from './flags';
-export { UPDATE_STATUS, updateStatus } from './status';
-
-export const flopflipReducer = combineReducers<any, Actions>({
+export const flopflipReducer = combineReducers({
   flags: flagsReducer,
   status: statusReducer,
 });
 export const createFlopflipReducer = (
   preloadedState: TFlagsContext = { memory: {} }
 ) =>
-  combineReducers<any, Actions>({
+  combineReducers({
     flags: createFlagsReducer(preloadedState),
     status: statusReducer,
   });

--- a/packages/react-redux/src/ducks/status.ts
+++ b/packages/react-redux/src/ducks/status.ts
@@ -4,72 +4,67 @@ import type {
   TAdapterStatusChange,
   TAdaptersStatus,
 } from '@flopflip/types';
+import {
+  type PayloadAction,
+  createSelector,
+  createSlice,
+} from '@reduxjs/toolkit';
 
 import { STATE_SLICE } from '../constants';
 import type { TState } from '../types';
-import type { TUpdateStatusAction } from './types';
 
-// Actions
-export const UPDATE_STATUS = '@flopflip/status/update';
+const initialState: TAdaptersStatus = {};
 
-const initialState = {};
-
-// Reducer
-const reducer = (
-  // biome-ignore lint/style/useDefaultParameterLast: <explanation>
-  state: TAdaptersStatus = initialState,
-  action: TUpdateStatusAction
-): TAdaptersStatus => {
-  switch (action.type) {
-    case UPDATE_STATUS:
-      if (action.payload.id) {
-        return {
-          ...state,
-          [action.payload.id]: {
-            ...state?.[action.payload.id],
+const statusSlice = createSlice({
+  name: 'status',
+  initialState,
+  reducers: {
+    updateStatus: {
+      reducer(
+        state,
+        action: PayloadAction<
+          TAdapterStatusChange & { adapterIdentifiers: TAdapterIdentifiers[] }
+        >
+      ) {
+        if (action.payload.id) {
+          state[action.payload.id] = {
+            ...state[action.payload.id],
             ...action.payload.status,
-          },
+          };
+          return;
+        }
+
+        for (const adapterInterfaceIdentifier of action.payload
+          .adapterIdentifiers) {
+          state[adapterInterfaceIdentifier] = {
+            ...state[adapterInterfaceIdentifier],
+            ...action.payload.status,
+          };
+        }
+      },
+      prepare(
+        statusChange: TAdapterStatusChange,
+        adapterIdentifiers: TAdapterIdentifiers[]
+      ) {
+        return {
+          payload: { ...statusChange, adapterIdentifiers },
         };
-      }
-
-      return {
-        ...state,
-        ...Object.fromEntries(
-          action.payload.adapterIdentifiers.map(
-            (adapterInterfaceIdentifier) => [
-              adapterInterfaceIdentifier,
-              {
-                ...state?.[adapterInterfaceIdentifier],
-                ...action.payload.status,
-              },
-            ]
-          )
-        ),
-      };
-
-    default:
-      return state;
-  }
-};
-
-export { reducer };
-
-// Action Creators
-export const updateStatus = (
-  statusChange: TAdapterStatusChange,
-  adapterIdentifiers: TAdapterIdentifiers[]
-): TUpdateStatusAction => ({
-  type: UPDATE_STATUS,
-  payload: { ...statusChange, adapterIdentifiers },
+      },
+    },
+  },
 });
+
+export const { updateStatus } = statusSlice.actions;
+export const reducer = statusSlice.reducer;
+
 // Selectors
 type TSelectStatusArgs = {
   adapterIdentifiers?: TAdapterIdentifiers[];
 };
+
 export const selectStatus =
   ({ adapterIdentifiers }: TSelectStatusArgs = {}) =>
   (state: TState) => {
     const { status } = state[STATE_SLICE];
-
     return selectAdapterConfigurationStatus(status, adapterIdentifiers);
   };

--- a/packages/react-redux/src/ducks/status.ts
+++ b/packages/react-redux/src/ducks/status.ts
@@ -4,11 +4,7 @@ import type {
   TAdapterStatusChange,
   TAdaptersStatus,
 } from '@flopflip/types';
-import {
-  type PayloadAction,
-  createSelector,
-  createSlice,
-} from '@reduxjs/toolkit';
+import { type PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { STATE_SLICE } from '../constants';
 import type { TState } from '../types';

--- a/packages/react-redux/src/enhancer.ts
+++ b/packages/react-redux/src/enhancer.ts
@@ -6,36 +6,37 @@ import {
   type TFlagsChange,
   adapterIdentifiers as allAdapterIdentifiers,
 } from '@flopflip/types';
-import type {
-  PreloadedState,
-  Reducer,
-  Store,
-  StoreEnhancerStoreCreator,
-} from 'redux';
+import { createAction } from '@reduxjs/toolkit';
+import type { Reducer, Store, StoreEnhancerStoreCreator } from 'redux';
 
 import { updateFlags, updateStatus } from './ducks';
 import type { TState } from './types';
+
+// Create typed actions
+const configureAdapter = createAction<{
+  adapter: TAdapter;
+  adapterArgs: TAdapterArgs;
+}>('flopflip/configureAdapter');
 
 function createFlopFlipEnhancer(
   adapter: TAdapter,
   adapterArgs: TAdapterArgs
 ): <StoreState extends TState>(
   next: StoreEnhancerStoreCreator<StoreState>
-) => (
-  reducer: Reducer<StoreState>,
-  preloadedState?: PreloadedState<StoreState>
-) => Store {
+) => (reducer: Reducer<StoreState>, preloadedState?: StoreState) => Store {
   return (next) =>
     (...args) => {
       const store: Store = next(...args);
 
+      // Dispatch configuration action
+      store.dispatch(configureAdapter({ adapter, adapterArgs }));
+
+      // Configure adapter with bound action creators
       (adapter as TAdapterInterface<TAdapterArgs>).configure(adapterArgs, {
-        // NOTE: This is like `bindActionCreators` but the bound action
-        // creators are renamed to fit the adapter API and conventions.
-        onFlagsStateChange(flagsChange: TFlagsChange) {
+        onFlagsStateChange: (flagsChange: TFlagsChange) => {
           store.dispatch(updateFlags(flagsChange, [adapter.id]));
         },
-        onStatusStateChange(statusChange: TAdapterStatusChange) {
+        onStatusStateChange: (statusChange: TAdapterStatusChange) => {
           store.dispatch(
             updateStatus(statusChange, Object.keys(allAdapterIdentifiers))
           );

--- a/packages/react-redux/src/index.ts
+++ b/packages/react-redux/src/index.ts
@@ -8,8 +8,6 @@ export { ToggleFeature } from './toggle-feature';
 export {
   createFlopflipReducer,
   flopflipReducer,
-  UPDATE_FLAGS,
-  UPDATE_STATUS,
 } from './ducks';
 export {
   selectFlag as selectFeatureFlag,

--- a/packages/react-redux/test/ducks/flags.spec.js
+++ b/packages/react-redux/test/ducks/flags.spec.js
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import { STATE_SLICE } from '../../src/constants';
 
 import {
-  UPDATE_FLAGS,
   reducer,
   selectFlag,
   selectFlags,
@@ -11,19 +10,13 @@ import {
 
 const adapterIdentifiers = ['memory'];
 
-describe('constants', () => {
-  it('should contain `flags/updateFlags`', () => {
-    expect(UPDATE_FLAGS).toEqual('@flopflip/flags/update');
-  });
-});
-
 describe('action creators', () => {
   describe('when updating flags', () => {
     const flags = { a: 'b' };
 
     it('should return `flags/updateFlags` type', () => {
       expect(updateFlags({ flags }, adapterIdentifiers)).toEqual({
-        type: UPDATE_FLAGS,
+        type: 'flags/updateFlags',
         payload: expect.any(Object),
       });
     });
@@ -56,7 +49,10 @@ describe('reducers', () => {
           },
         };
         it('should set the new flags', () => {
-          const reduced = reducer(undefined, { type: UPDATE_FLAGS, payload });
+          const reduced = reducer(undefined, {
+            type: 'flags/updateFlags',
+            payload,
+          });
           expect(reduced).toHaveProperty('memory.a', payload.flags.a);
           expect(reduced).toHaveProperty('memory.b', payload.flags.b);
         });
@@ -72,7 +68,10 @@ describe('reducers', () => {
         };
 
         it('should set the new flags for all adapter interfaces', () => {
-          const reduced = reducer(undefined, { type: UPDATE_FLAGS, payload });
+          const reduced = reducer(undefined, {
+            type: 'flags/updateFlags',
+            payload,
+          });
           expect(reduced).toHaveProperty('memory.a', payload.flags.a);
           expect(reduced).toHaveProperty('memory.b', payload.flags.b);
 
@@ -98,7 +97,10 @@ describe('reducers', () => {
         };
 
         it('should merge with new flags', () => {
-          const reduced = reducer(state, { type: UPDATE_FLAGS, payload });
+          const reduced = reducer(state, {
+            type: 'flags/updateFlags',
+            payload,
+          });
 
           expect(reduced).toHaveProperty('memory.a', payload.flags.a);
           expect(reduced).toHaveProperty('memory.b', payload.flags.b);
@@ -121,7 +123,10 @@ describe('reducers', () => {
         };
 
         it('should merge with new flags', () => {
-          const reduced = reducer(state, { type: UPDATE_FLAGS, payload });
+          const reduced = reducer(state, {
+            type: 'flags/updateFlags',
+            payload,
+          });
 
           expect(reduced).toHaveProperty('memory.a', payload.flags.a);
           expect(reduced).toHaveProperty('memory.b', payload.flags.b);

--- a/packages/react-redux/test/ducks/status.spec.js
+++ b/packages/react-redux/test/ducks/status.spec.js
@@ -5,24 +5,13 @@ import {
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { STATE_SLICE } from '../../src/constants';
-import {
-  UPDATE_STATUS,
-  reducer,
-  selectStatus,
-  updateStatus,
-} from '../../src/ducks/status';
-
-describe('constants', () => {
-  it('should contain `UPDATE_STATUS`', () => {
-    expect(UPDATE_STATUS).toEqual('@flopflip/status/update');
-  });
-});
+import { reducer, selectStatus, updateStatus } from '../../src/ducks/status';
 
 describe('action creators', () => {
   describe('when updating status', () => {
     it('should return `UPDATE_STATUS` type', () => {
       expect(updateStatus({ isReady: false })).toEqual({
-        type: UPDATE_STATUS,
+        type: 'status/updateStatus',
         payload: expect.any(Object),
       });
     });
@@ -87,7 +76,9 @@ describe('reducers', () => {
       });
 
       it('should set the new status', () => {
-        expect(reducer(undefined, { type: UPDATE_STATUS, payload })).toEqual(
+        expect(
+          reducer(undefined, { type: 'status/updateStatus', payload })
+        ).toEqual(
           expect.objectContaining({
             memory: {
               configurationStatus: AdapterConfigurationStatus.Configuring,
@@ -116,7 +107,7 @@ describe('reducers', () => {
                 configurationStatus: AdapterConfigurationStatus.Configured,
               },
             },
-            { type: UPDATE_STATUS, payload }
+            { type: 'status/updateStatus', payload }
           )
         ).toEqual({
           memory: {

--- a/packages/react-redux/test/test-utils.js
+++ b/packages/react-redux/test/test-utils.js
@@ -1,4 +1,4 @@
-import { combineReducers, createStore as createReduxStore } from 'redux';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
 
 import { FLOPFLIP_STATE_SLICE, createFlopflipReducer } from '../src/';
 
@@ -8,6 +8,9 @@ const reducer = combineReducers({
   [FLOPFLIP_STATE_SLICE]: createFlopflipReducer(),
 });
 const createStore = (initialState = defaultInitialState) =>
-  createReduxStore(reducer, initialState);
+  configureStore({
+    reducer,
+    preloadedState: initialState,
+  });
 
 export { createStore };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,8 +55,8 @@
     "tsup": "8.3.6"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17.0 || ^18.0.0",
-    "react-dom": "^16.8 || ^17.0 || ^18.0.0"
+    "react": "18.x || 19.x",
+    "react-dom": "18.x || 19.x"
   },
   "dependencies": {
     "@babel/runtime": "7.26.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,9 +590,6 @@ importers:
       '@types/react':
         specifier: 18.3.18
         version: 18.3.18
-      '@types/react-redux':
-        specifier: 7.1.34
-        version: 7.1.34
     devDependencies:
       '@flopflip/combine-adapters':
         specifier: workspace:*
@@ -609,6 +606,9 @@ importers:
       '@flopflip/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@reduxjs/toolkit':
+        specifier: 2.5.1
+        version: 2.5.1(react-redux@9.2.0(@types/react@18.3.18)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -616,11 +616,11 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-redux:
-        specifier: 8.0.5
-        version: 8.0.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)
+        specifier: 9.2.0
+        version: 9.2.0(@types/react@18.3.18)(react@18.3.1)(redux@5.0.1)
       redux:
-        specifier: 4.2.1
-        version: 4.2.1
+        specifier: 5.0.1
+        version: 5.0.1
       tsup:
         specifier: 8.3.6
         version: 8.3.6(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0)
@@ -1827,6 +1827,17 @@ packages:
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
 
+  '@reduxjs/toolkit@2.5.1':
+    resolution: {integrity: sha512-UHhy3p0oUpdhnSxyDjaRDYaw8Xra75UiLbCiRozVPHjfDwNYkh0TsVm/1OmTW8Md+iDAJmYPWUKMvsMc2GtpNg==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.34.0':
     resolution: {integrity: sha512-Eeao7ewDq79jVEsrtWIj5RNqB8p2knlm9fhR6uJ2gqP7UfbLrTrxevudVrEPDM7Wkpn/HpRC2QfazH7MXLz3vQ==}
     cpu: [arm]
@@ -1996,9 +2007,6 @@ packages:
   '@types/google.analytics@0.0.40':
     resolution: {integrity: sha512-R3HpnLkqmKxhUAf8kIVvDVGJqPtaaZlW4yowNwjOZUTmYUQEgHh8Nh5wkSXKMroNAuQM8gbXJHmNbbgA8tdb7Q==}
 
-  '@types/hoist-non-react-statics@3.3.6':
-    resolution: {integrity: sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==}
-
   '@types/ioredis@4.28.10':
     resolution: {integrity: sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==}
 
@@ -2034,9 +2042,6 @@ packages:
   '@types/react-is@17.0.7':
     resolution: {integrity: sha512-WrTEiT+c6rgq36QApoy0063uAOdltCrhF0QMXLIgYPaTvIdQhAB8hPb5oGGqX18xToElNILS9UprwU6GyINcJg==}
 
-  '@types/react-redux@7.1.34':
-    resolution: {integrity: sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==}
-
   '@types/react@18.3.18':
     resolution: {integrity: sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==}
 
@@ -2052,8 +2057,8 @@ packages:
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
-  '@types/use-sync-external-store@0.0.3':
-    resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -2968,9 +2973,6 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hoist-non-react-statics@3.3.2:
-    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
-
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -3020,6 +3022,9 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  immer@10.1.1:
+    resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -3798,32 +3803,20 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-redux@8.0.5:
-    resolution: {integrity: sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==}
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
     peerDependencies:
       '@types/react': 18.3.18
-      '@types/react-dom': 18.3.5
-      react: ^16.8 || ^17.0 || ^18.0
-      react-dom: ^16.8 || ^17.0 || ^18.0
-      react-native: '>=0.59'
-      redux: ^4
+      react: ^18.0 || ^19
+      redux: ^5.0.0
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-      react-dom:
-        optional: true
-      react-native:
         optional: true
       redux:
         optional: true
@@ -3863,8 +3856,13 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
-  redux@4.2.1:
-    resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect-metadata@0.1.14:
     resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
@@ -3914,6 +3912,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -6005,6 +6006,16 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
+  '@reduxjs/toolkit@2.5.1(react-redux@9.2.0(@types/react@18.3.18)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+    dependencies:
+      immer: 10.1.1
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 18.3.1
+      react-redux: 9.2.0(@types/react@18.3.18)(react@18.3.1)(redux@5.0.1)
+
   '@rollup/rollup-android-arm-eabi@4.34.0':
     optional: true
 
@@ -6155,11 +6166,6 @@ snapshots:
 
   '@types/google.analytics@0.0.40': {}
 
-  '@types/hoist-non-react-statics@3.3.6':
-    dependencies:
-      '@types/react': 18.3.18
-      hoist-non-react-statics: 3.3.2
-
   '@types/ioredis@4.28.10':
     dependencies:
       '@types/node': 22.13.4
@@ -6197,13 +6203,6 @@ snapshots:
     dependencies:
       '@types/react': 18.3.18
 
-  '@types/react-redux@7.1.34':
-    dependencies:
-      '@types/hoist-non-react-statics': 3.3.6
-      '@types/react': 18.3.18
-      hoist-non-react-statics: 3.3.2
-      redux: 4.2.1
-
   '@types/react@18.3.18':
     dependencies:
       '@types/prop-types': 15.7.14
@@ -6217,7 +6216,7 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
-  '@types/use-sync-external-store@0.0.3': {}
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -7209,10 +7208,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hoist-non-react-statics@3.3.2:
-    dependencies:
-      react-is: 16.13.1
-
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -7258,6 +7253,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  immer@10.1.1: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -7961,26 +7958,18 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-is@16.13.1: {}
-
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
-  react-redux@8.0.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1):
+  react-redux@9.2.0(@types/react@18.3.18)(react@18.3.1)(redux@5.0.1):
     dependencies:
-      '@babel/runtime': 7.26.9
-      '@types/hoist-non-react-statics': 3.3.6
-      '@types/use-sync-external-store': 0.0.3
-      hoist-non-react-statics: 3.3.2
+      '@types/use-sync-external-store': 0.0.6
       react: 18.3.1
-      react-is: 18.3.1
       use-sync-external-store: 1.4.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.18
-      '@types/react-dom': 18.3.5(@types/react@18.3.18)
-      react-dom: 18.3.1(react@18.3.1)
-      redux: 4.2.1
+      redux: 5.0.1
 
   react-refresh@0.14.2: {}
 
@@ -8015,9 +8004,11 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
-  redux@4.2.1:
+  redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
-      '@babel/runtime': 7.26.9
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect-metadata@0.1.14: {}
 
@@ -8065,6 +8056,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 


### PR DESCRIPTION
#### Summary

Migrates to RTK to support redux v5 and react-redux v9 with standard patterns. 