### PR TITLE
fix(ci): prevent oxlint from failing on non-lintable staged files

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,6 +1,3 @@
 export default {
-  '*': [
-    'oxlint --fix', // Lint and apply safe fixes
-    'oxfmt --write', // Format and sort imports
-  ],
+  '*': ['oxlint --fix --no-error-on-unmatched-pattern', 'oxfmt --write'],
 };

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,3 +1,6 @@
 export default {
-  '*': ['oxlint --fix --no-error-on-unmatched-pattern', 'oxfmt --write'],
+  '*': [
+    'oxlint --fix --no-error-on-unmatched-pattern', // Lint and apply safe fixes; allow non-lintable files (e.g. .md, .json)
+    'oxfmt --write', // Format and sort imports
+  ],
 };


### PR DESCRIPTION
## Summary
- Adds `--no-error-on-unmatched-pattern` to the `oxlint --fix` command in `lint-staged.config.mjs`

## Motivation

The changeset release workflow runs `changeset version`, which updates `package.json` and `CHANGELOG.md` files, then commits them. That commit goes through lint-staged via the husky pre-commit hook, but the staged files are all `.json` and `.md` — no JS/TS files for oxlint to lint. `oxlint` exits with code 1 when it finds zero lintable files, failing the pre-commit hook and blocking the release workflow.

This affects any PR that triggers the changeset release workflow, not just a specific PR.

## Test plan
- [x] Verified `oxlint --fix --no-error-on-unmatched-pattern` exits 0 on non-lintable files
- [x] Pre-commit hook passes on the commit itself (only `.mjs` file staged)