### PR TITLE
fix: drop npm from engines (pnpm manages runtime)

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
   },
   "engines": {
     "node": ">=24",
-    "npm": ">=11",
     "pnpm": ">=11"
   },
   "packageManager": "pnpm@11.9.0",


### PR DESCRIPTION
## Problem

`main` went red the moment the pnpm/setup migration (#2166) merged.
Every workflow fails in the shared `Setup` step during `pnpm install`:

```
postinstall$ husky install && manypkg check && check-node-version --package --print
node: 24.17.0
npm: 10.9.8
Wanted npm version >=11 (>=11.0.0)   ← fails
pnpm: 11.9.0
[ELIFECYCLE] Command failed with exit code 1.
```

## Root cause

`actions/setup-node` used to install the official Node 24.17 build,
which bundles **npm 11.x**. `pnpm/setup` instead provisions Node via
`pnpm runtime`, and pnpm's Node distribution **does not ship npm**, so
`npm` falls through to the runner's ambient **npm 10.9.8** — which
violates `engines.npm: ">=11"` and fails `check-node-version`.

## Fix

Drop `npm` from `engines`. The project installs exclusively with pnpm
(`preinstall` runs `only-allow pnpm`), so the npm version is outside the
project's control and the constraint is unenforceable and vestigial.
`node` and `pnpm` are still validated.

## Scope

- Restores green CI on `main` and unblocks all open PRs (including the
  Renovate PR #2167).
- Also unblocks `release.yml`, which runs the same `pnpm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
