### PR TITLE
fix: start LaunchDarkly client before waiting for initialization

### DIFF
--- a/.changeset/bright-flags-start.md
+++ b/.changeset/bright-flags-start.md
@@ -1,0 +1,5 @@
+---
+"@flopflip/launchdarkly-adapter": patch
+---
+
+fix: start the LaunchDarkly client before waiting for initialization

--- a/packages/launchdarkly-adapter/src/adapter.ts
+++ b/packages/launchdarkly-adapter/src/adapter.ts
@@ -425,6 +425,7 @@ class LaunchDarklyAdapter implements TLaunchDarklyAdapterInterface {
       this.#adapterState.context!,
       sdk.clientOptions ?? {},
     );
+    this.#adapterState.client.start();
 
     return this.#getInitialFlags({
       flags,

--- a/packages/launchdarkly-adapter/test/adapter.spec.js
+++ b/packages/launchdarkly-adapter/test/adapter.spec.js
@@ -23,6 +23,7 @@ const userWithoutKey = {
 };
 const flags = { 'some-flag-1': true, 'some-flag-2': false };
 const createClient = vi.fn((apiOverwrites) => ({
+  start: vi.fn(() => Promise.resolve({ status: 'complete' })),
   waitForInitialization: vi.fn(() => Promise.resolve({ status: 'complete' })),
   on: vi.fn(),
   allFlags: vi.fn(() => ({})),
@@ -205,6 +206,13 @@ describe('when configuring', () => {
                 variation: expect.any(Function),
                 waitForInitialization: expect.any(Function),
               }),
+            );
+          });
+
+          it('should start the client before waiting for initialization', () => {
+            expect(client.start).toHaveBeenCalledOnce();
+            expect(client.start.mock.invocationCallOrder[0]).toBeLessThan(
+              client.waitForInitialization.mock.invocationCallOrder[0],
             );
           });
         });


### PR DESCRIPTION
#### Summary

<!-- provide a short summary of your changes -->
Start the LaunchDarkly client before waiting for initialization.

#### Description

<!-- provide some context -->
LaunchDarkly JavaScript SDK v4 separates client creation from startup. createClient() no longer starts initialization automatically, so the adapter timed out while waiting and continued with default flag values.

This change calls client.start() before waitForInitialization() and adds regression coverage for the required call order.

#### Technical debt & future

<!--
  Which technical debt does this PR introduce?
  How do we plan to resolve it?
  What is the next step after this PR?
-->
